### PR TITLE
Fix #38, the text was not displayed when the text contained space

### DIFF
--- a/tgfx/src/raster/TextBlob.cpp
+++ b/tgfx/src/raster/TextBlob.cpp
@@ -55,11 +55,9 @@ bool TextBlob::getPath(Path* path, const Stroke* stroke) const {
       }
       glyphPath.transform(Matrix::MakeTrans(position.x, position.y));
       totalPath.addPath(glyphPath);
-    } else {
-      return false;
     }
   }
   *path = totalPath;
-  return true;
+  return !totalPath.isEmpty();
 }
 }  // namespace pag


### PR DESCRIPTION
当文本中包含空格时，`CTFontCreatePathForGlyph`会返回`NULL`，致使`CGTypeface::getGlyphPath `返回`false`。
原逻辑是字符串中某个字符`getGlyphPath`失败就会导致`TextBlob::getPath`返回`false`，改为只要有字符`getGlyphPath`成功`TextBlob::getPath`都返回`true`。