### PR TITLE
Fix TexDocument binding type error on Web env.

### DIFF
--- a/src/platform/web/PAGWasmBindings.cpp
+++ b/src/platform/web/PAGWasmBindings.cpp
@@ -369,8 +369,12 @@ EMSCRIPTEN_BINDINGS(pag) {
       .property("applyStroke", &TextDocument::applyStroke)
       .property("baselineShift", &TextDocument::baselineShift)
       .property("boxText", &TextDocument::boxText)
-      .property("boxTextPos", &TextDocument::boxTextPos)
-      .property("boxTextSize", &TextDocument::boxTextSize)
+      .property("boxTextPos", optional_override([](const TextDocument& textDocument) {
+                  return ToTGFX(textDocument.boxTextPos);
+                }))
+      .property("boxTextSize", optional_override([](const TextDocument& textDocument) {
+                  return ToTGFX(textDocument.boxTextSize);
+                }))
       .property("firstBaseLine", &TextDocument::firstBaseLine)
       .property("fauxBold", &TextDocument::fauxBold)
       .property("fauxItalic", &TextDocument::fauxItalic)

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 0.1.8
+
+### Feature
+
+- Support init `PAGView` from `offscreenCanvas`. 
+- Add `readPixels` function on `PAGSurface`.
+
+### BugFixes
+
+- Fix render cache validate fail.
+
 ## 0.1.7
 
 ### Feature

--- a/web/CHANGELOG.zh_CN.md
+++ b/web/CHANGELOG.zh_CN.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 0.1.8
+
+### Feature
+
+- 支持从 `offscreenCanvas` 创建 `PAGView`
+- `PAGSurface` 上增加 `readPixels` 接口
+
+### BugFixes
+
+- 修复缓存没有生效的问题
+
 ## 0.1.7
 
 ### Feature

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libpag",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Portable Animated Graphics",
   "main": "lib/libpag.cjs.js",
   "module": "lib/libpag.esm.js",


### PR DESCRIPTION
- [Fix TexDocument binding type error on Web env.](https://github.com/Tencent/libpag/commit/1ca2b21e8909734b105f5d12b2f93e5fb21ed668)
- [Release WebSDK version 0.1.8.](https://github.com/Tencent/libpag/commit/60d1ce15cab4b5d8c0a62296e4efd820a95d110a)