### PR TITLE
Keep the same precision of encoding and decoding, remove the listener of ValueAnimator later.

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGView.java
@@ -405,7 +405,6 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
         if (pagSurface != null) {
             pagSurface.freeCache();
         }
-        animator.removeUpdateListener(mAnimatorUpdateListener);
 
         boolean surfaceDestroy = true;
         if (g_PAGViewHandler != null && surface != null) {
@@ -852,5 +851,11 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
         }
         _isAnimatorPreRunning = null;
         doPlay();
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
+        animator.removeUpdateListener(mAnimatorUpdateListener);
     }
 }

--- a/src/codec/tags/Images.cpp
+++ b/src/codec/tags/Images.cpp
@@ -52,8 +52,8 @@ void WriteImages(EncodeStream* stream, const std::vector<pag::ImageBytes*>* imag
       continue;
     }
 
-    int realWidth = static_cast<int>(ceil(imageBytes->width * imageBytes->scaleFactor));
-    int realHeight = static_cast<int>(ceil(imageBytes->height * imageBytes->scaleFactor));
+    int realWidth = static_cast<int>(round(imageBytes->width * imageBytes->scaleFactor));
+    int realHeight = static_cast<int>(round(imageBytes->height * imageBytes->scaleFactor));
 
     if (scaledWidth == realWidth && scaledHeight == realHeight) {
       if (imageBytes->scaleFactor == 1.0f) {


### PR DESCRIPTION
Keep the same precision of encoding and decoding,  remove the listener of ValueAnimator later.