### PR TITLE
Fix BitmapSequenceReader::decodeFrame

### DIFF
--- a/src/rendering/sequences/BitmapSequenceReader.cpp
+++ b/src/rendering/sequences/BitmapSequenceReader.cpp
@@ -43,8 +43,12 @@ bool BitmapSequenceReader::decodeFrame(Frame targetFrame) {
   if (pixelBuffer == nullptr) {
     return false;
   }
-  lastDecodeFrame = -1;
   auto startFrame = findStartFrame(targetFrame);
+  if (lastDecodeFrame > startFrame && lastDecodeFrame < targetFrame) {
+    startFrame = lastDecodeFrame;
+  } else {
+    lastDecodeFrame = -1;
+  }
   auto& bitmapFrames = static_cast<BitmapSequence*>(sequence)->frames;
   tgfx::Bitmap bitmap(pixelBuffer);
   for (Frame frame = startFrame; frame <= targetFrame; frame++) {

--- a/src/rendering/sequences/BitmapSequenceReader.cpp
+++ b/src/rendering/sequences/BitmapSequenceReader.cpp
@@ -44,11 +44,7 @@ bool BitmapSequenceReader::decodeFrame(Frame targetFrame) {
     return false;
   }
   auto startFrame = findStartFrame(targetFrame);
-  if (lastDecodeFrame > startFrame && lastDecodeFrame < targetFrame) {
-    startFrame = lastDecodeFrame;
-  } else {
-    lastDecodeFrame = -1;
-  }
+  lastDecodeFrame = -1;
   auto& bitmapFrames = static_cast<BitmapSequence*>(sequence)->frames;
   tgfx::Bitmap bitmap(pixelBuffer);
   for (Frame frame = startFrame; frame <= targetFrame; frame++) {


### PR DESCRIPTION
Issue: While decoding a target frame, BitmapSequenceReader always read from last key frame. It's slow when target frame is far from last keyframe.

Changes: Use lastDecodeFrame as the start frame if lastDecodeFrame is between last keyframe and target frame.