### PR TITLE
Fix win32 display.

### DIFF
--- a/tgfx/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/tgfx/src/gpu/opengl/egl/EGLDevice.cpp
@@ -84,8 +84,9 @@ std::shared_ptr<EGLDevice> EGLDevice::MakeAdopted(EGLDisplay eglDisplay, EGLSurf
 std::shared_ptr<EGLDevice> EGLDevice::MakeFrom(EGLNativeWindowType nativeWindow,
                                                EGLContext sharedContext) {
   static auto eglGlobals = EGLGlobals::Get();
+  EGLint surfaceAttributes[] = {EGL_DIRECT_COMPOSITION_ANGLE, EGL_TRUE, EGL_NONE};
   auto eglSurface =
-      eglCreateWindowSurface(eglGlobals->display, eglGlobals->windowConfig, nativeWindow, nullptr);
+      eglCreateWindowSurface(eglGlobals->display, eglGlobals->windowConfig, nativeWindow, surfaceAttributes);
   if (eglSurface == nullptr) {
     LOGE("EGLDevice::MakeFrom() eglCreateWindowSurface error=%d", eglGetError());
     return nullptr;

--- a/tgfx/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/tgfx/src/gpu/opengl/egl/EGLDevice.cpp
@@ -86,8 +86,8 @@ std::shared_ptr<EGLDevice> EGLDevice::MakeFrom(EGLNativeWindowType nativeWindow,
   static auto eglGlobals = EGLGlobals::Get();
 #if defined(_WIN32)
   EGLint surfaceAttributes[] = {EGL_DIRECT_COMPOSITION_ANGLE, EGL_TRUE, EGL_NONE};
-  auto eglSurface =
-      eglCreateWindowSurface(eglGlobals->display, eglGlobals->windowConfig, nativeWindow, surfaceAttributes);
+  auto eglSurface = eglCreateWindowSurface(eglGlobals->display, eglGlobals->windowConfig,
+                                           nativeWindow, surfaceAttributes);
 #else
   auto eglSurface =
       eglCreateWindowSurface(eglGlobals->display, eglGlobals->windowConfig, nativeWindow, nullptr);

--- a/tgfx/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/tgfx/src/gpu/opengl/egl/EGLDevice.cpp
@@ -84,7 +84,10 @@ std::shared_ptr<EGLDevice> EGLDevice::MakeAdopted(EGLDisplay eglDisplay, EGLSurf
 std::shared_ptr<EGLDevice> EGLDevice::MakeFrom(EGLNativeWindowType nativeWindow,
                                                EGLContext sharedContext) {
   static auto eglGlobals = EGLGlobals::Get();
-  EGLint surfaceAttributes[] = {EGL_DIRECT_COMPOSITION_ANGLE, EGL_TRUE, EGL_NONE};
+  EGLint surfaceAttributes[] = nullptr;
+#if defined(_WIN32)
+  surfaceAttributes = {EGL_DIRECT_COMPOSITION_ANGLE, EGL_TRUE, EGL_NONE};
+#endif
   auto eglSurface =
       eglCreateWindowSurface(eglGlobals->display, eglGlobals->windowConfig, nativeWindow, surfaceAttributes);
   if (eglSurface == nullptr) {

--- a/tgfx/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/tgfx/src/gpu/opengl/egl/EGLDevice.cpp
@@ -84,12 +84,14 @@ std::shared_ptr<EGLDevice> EGLDevice::MakeAdopted(EGLDisplay eglDisplay, EGLSurf
 std::shared_ptr<EGLDevice> EGLDevice::MakeFrom(EGLNativeWindowType nativeWindow,
                                                EGLContext sharedContext) {
   static auto eglGlobals = EGLGlobals::Get();
-  EGLint surfaceAttributes[] = {};
 #if defined(_WIN32)
-  surfaceAttributes = {EGL_DIRECT_COMPOSITION_ANGLE, EGL_TRUE, EGL_NONE};
-#endif
+  EGLint surfaceAttributes[] = {EGL_DIRECT_COMPOSITION_ANGLE, EGL_TRUE, EGL_NONE};
   auto eglSurface =
       eglCreateWindowSurface(eglGlobals->display, eglGlobals->windowConfig, nativeWindow, surfaceAttributes);
+#else
+  auto eglSurface =
+      eglCreateWindowSurface(eglGlobals->display, eglGlobals->windowConfig, nativeWindow, nullptr);
+#endif
   if (eglSurface == nullptr) {
     LOGE("EGLDevice::MakeFrom() eglCreateWindowSurface error=%d", eglGetError());
     return nullptr;

--- a/tgfx/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/tgfx/src/gpu/opengl/egl/EGLDevice.cpp
@@ -84,7 +84,7 @@ std::shared_ptr<EGLDevice> EGLDevice::MakeAdopted(EGLDisplay eglDisplay, EGLSurf
 std::shared_ptr<EGLDevice> EGLDevice::MakeFrom(EGLNativeWindowType nativeWindow,
                                                EGLContext sharedContext) {
   static auto eglGlobals = EGLGlobals::Get();
-  EGLint surfaceAttributes[] = nullptr;
+  EGLint surfaceAttributes[] = {};
 #if defined(_WIN32)
   surfaceAttributes = {EGL_DIRECT_COMPOSITION_ANGLE, EGL_TRUE, EGL_NONE};
 #endif

--- a/tgfx/src/gpu/opengl/egl/EGLDisplayWrapper.cpp
+++ b/tgfx/src/gpu/opengl/egl/EGLDisplayWrapper.cpp
@@ -22,7 +22,7 @@
 #include <EGL/eglext.h>
 #include "WinUser.h"
 
-namespace pag {
+namespace tgfx {
 enum {
   D3D11,
   D3D11_FL_9_3,

--- a/tgfx/src/gpu/opengl/egl/EGLDisplayWrapper.cpp
+++ b/tgfx/src/gpu/opengl/egl/EGLDisplayWrapper.cpp
@@ -1,0 +1,101 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#if defined(_WIN32)
+
+#include "EGLDisplayWrapper.h"
+#include <EGL/eglext.h>
+#include "WinUser.h"
+
+namespace pag {
+enum {
+  D3D11_Level10_0,
+  D3D11_Level9_3,
+  D3D11_Level11_0,
+  PLAN_END
+};
+static const EGLint D3D11_Level10_0_display_attributes[] = {
+    EGL_PLATFORM_ANGLE_TYPE_ANGLE,
+    EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
+    EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
+    EGL_TRUE,
+    EGL_NONE,
+};
+static const EGLint D3D11_Level9_3_display_attributes[] = {
+    EGL_PLATFORM_ANGLE_TYPE_ANGLE,
+    EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
+    EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE, 9,
+    EGL_PLATFORM_ANGLE_MAX_VERSION_MINOR_ANGLE, 3,
+    EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
+    EGL_TRUE,
+    EGL_NONE,
+};
+static const EGLint D3D11_Level11_0_display_attributes[] = {
+    // These attributes request D3D11 WARP (software rendering fallback) as a
+    // last resort.
+    EGL_PLATFORM_ANGLE_TYPE_ANGLE,
+    EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
+    EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
+    EGL_TRUE,
+    EGL_NONE,
+};
+
+static int Win32EGLDisplayPlan = D3D11_Level10_0;
+
+EGLDisplay EGLDisplayWrapper::EGLGetPlatformDisplay() {
+  EGLDisplay display;
+
+  auto hdc = GetDC(nullptr);
+
+  auto eglGetPlatformDisplayEXT =
+      reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
+          eglGetProcAddress("eglGetPlatformDisplayEXT"));
+  if (!eglGetPlatformDisplayEXT) {
+    return nullptr;
+  }
+
+  if (Win32EGLDisplayPlan == D3D11_Level10_0) {
+    display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
+                                       hdc,
+                                       D3D11_Level10_0_display_attributes);
+  } else if (Win32EGLDisplayPlan == D3D11_Level9_3) {
+    display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
+                                       hdc,
+                                       D3D11_Level9_3_display_attributes);
+  } else if (Win32EGLDisplayPlan == D3D11_Level11_0) {
+    display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
+                                       hdc,
+                                       D3D11_Level11_0_display_attributes);
+  } else {
+    return eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  }
+
+  if (display == EGL_NO_DISPLAY) {
+    Win32EGLDisplayPlan ++;
+    return EGLDisplayWrapper::EGLGetPlatformDisplay();
+  }
+
+  return display;
+}
+
+bool EGLDisplayWrapper::HasNext() {
+  Win32EGLDisplayPlan ++;
+  return Win32EGLDisplayPlan < PLAN_END;
+}
+}  // namespace tgfx
+#endif

--- a/tgfx/src/gpu/opengl/egl/EGLDisplayWrapper.cpp
+++ b/tgfx/src/gpu/opengl/egl/EGLDisplayWrapper.cpp
@@ -24,30 +24,50 @@
 
 namespace pag {
 enum {
-  D3D11_Level10_0,
-  D3D11_Level9_3,
-  D3D11_Level11_0,
+  D3D11,
+  D3D11_FL_9_3,
+  D3D11_WARP,
   PLAN_END
 };
-static const EGLint D3D11_Level10_0_display_attributes[] = {
+
+// These are preferred display attributes and request ANGLE's D3D11
+// renderer. eglInitialize will only succeed with these attributes if the
+// hardware supports D3D11 Feature Level 10_0+.
+const EGLint d3d11_display_attributes[] = {
     EGL_PLATFORM_ANGLE_TYPE_ANGLE,
     EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
+
+    // EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE is an option that will
+    // enable ANGLE to automatically call the IDXGIDevice3::Trim method on
+    // behalf of the application when it gets suspended.
+    EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
+    EGL_TRUE,
+
+    // This extension allows angle to render directly on a D3D swapchain
+    // in the correct orientation on D3D11.
+    EGL_EXPERIMENTAL_PRESENT_PATH_ANGLE,
+    EGL_EXPERIMENTAL_PRESENT_PATH_FAST_ANGLE,
+
+    EGL_NONE,
+};
+
+// These are used to request ANGLE's D3D11 renderer, with D3D11 Feature
+// Level 9_3.
+const EGLint d3d11_fl_9_3_display_attributes[] = {
+    EGL_PLATFORM_ANGLE_TYPE_ANGLE,
+    EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
+    EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE,
+    9,
+    EGL_PLATFORM_ANGLE_MAX_VERSION_MINOR_ANGLE,
+    3,
     EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
     EGL_TRUE,
     EGL_NONE,
 };
-static const EGLint D3D11_Level9_3_display_attributes[] = {
-    EGL_PLATFORM_ANGLE_TYPE_ANGLE,
-    EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
-    EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE, 9,
-    EGL_PLATFORM_ANGLE_MAX_VERSION_MINOR_ANGLE, 3,
-    EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
-    EGL_TRUE,
-    EGL_NONE,
-};
-static const EGLint D3D11_Level11_0_display_attributes[] = {
-    // These attributes request D3D11 WARP (software rendering fallback) as a
-    // last resort.
+
+// These attributes request D3D11 WARP (software rendering fallback) in case
+// hardware-backed D3D11 is unavailable.
+const EGLint d3d11_warp_display_attributes[] = {
     EGL_PLATFORM_ANGLE_TYPE_ANGLE,
     EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
     EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
@@ -55,7 +75,7 @@ static const EGLint D3D11_Level11_0_display_attributes[] = {
     EGL_NONE,
 };
 
-static int Win32EGLDisplayPlan = D3D11_Level10_0;
+static int Win32EGLDisplayPlan = D3D11;
 
 EGLDisplay EGLDisplayWrapper::EGLGetPlatformDisplay() {
   EGLDisplay display;
@@ -69,18 +89,18 @@ EGLDisplay EGLDisplayWrapper::EGLGetPlatformDisplay() {
     return nullptr;
   }
 
-  if (Win32EGLDisplayPlan == D3D11_Level10_0) {
+  if (Win32EGLDisplayPlan == D3D11) {
     display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
                                        hdc,
-                                       D3D11_Level10_0_display_attributes);
-  } else if (Win32EGLDisplayPlan == D3D11_Level9_3) {
+                                       d3d11_display_attributes);
+  } else if (Win32EGLDisplayPlan == D3D11_FL_9_3) {
     display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
                                        hdc,
-                                       D3D11_Level9_3_display_attributes);
-  } else if (Win32EGLDisplayPlan == D3D11_Level11_0) {
+                                       d3d11_fl_9_3_display_attributes);
+  } else if (Win32EGLDisplayPlan == D3D11_WARP) {
     display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
                                        hdc,
-                                       D3D11_Level11_0_display_attributes);
+                                       d3d11_warp_display_attributes);
   } else {
     return eglGetDisplay(EGL_DEFAULT_DISPLAY);
   }

--- a/tgfx/src/gpu/opengl/egl/EGLDisplayWrapper.cpp
+++ b/tgfx/src/gpu/opengl/egl/EGLDisplayWrapper.cpp
@@ -23,12 +23,7 @@
 #include "WinUser.h"
 
 namespace tgfx {
-enum {
-  D3D11,
-  D3D11_FL_9_3,
-  D3D11_WARP,
-  PLAN_END
-};
+enum { D3D11, D3D11_FL_9_3, D3D11_WARP, PLAN_END };
 
 // These are preferred display attributes and request ANGLE's D3D11
 // renderer. eglInitialize will only succeed with these attributes if the
@@ -82,31 +77,26 @@ EGLDisplay EGLDisplayWrapper::EGLGetPlatformDisplay() {
 
   auto hdc = GetDC(nullptr);
 
-  auto eglGetPlatformDisplayEXT =
-      reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
-          eglGetProcAddress("eglGetPlatformDisplayEXT"));
+  auto eglGetPlatformDisplayEXT = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
+      eglGetProcAddress("eglGetPlatformDisplayEXT"));
   if (!eglGetPlatformDisplayEXT) {
     return nullptr;
   }
 
   if (Win32EGLDisplayPlan == D3D11) {
-    display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                       hdc,
-                                       d3d11_display_attributes);
+    display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, hdc, d3d11_display_attributes);
   } else if (Win32EGLDisplayPlan == D3D11_FL_9_3) {
-    display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                       hdc,
-                                       d3d11_fl_9_3_display_attributes);
+    display =
+        eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, hdc, d3d11_fl_9_3_display_attributes);
   } else if (Win32EGLDisplayPlan == D3D11_WARP) {
-    display = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                       hdc,
-                                       d3d11_warp_display_attributes);
+    display =
+        eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, hdc, d3d11_warp_display_attributes);
   } else {
     return eglGetDisplay(EGL_DEFAULT_DISPLAY);
   }
 
   if (display == EGL_NO_DISPLAY) {
-    Win32EGLDisplayPlan ++;
+    Win32EGLDisplayPlan++;
     return EGLDisplayWrapper::EGLGetPlatformDisplay();
   }
 
@@ -114,7 +104,7 @@ EGLDisplay EGLDisplayWrapper::EGLGetPlatformDisplay() {
 }
 
 bool EGLDisplayWrapper::HasNext() {
-  Win32EGLDisplayPlan ++;
+  Win32EGLDisplayPlan++;
   return Win32EGLDisplayPlan < PLAN_END;
 }
 }  // namespace tgfx

--- a/tgfx/src/gpu/opengl/egl/EGLDisplayWrapper.h
+++ b/tgfx/src/gpu/opengl/egl/EGLDisplayWrapper.h
@@ -1,0 +1,31 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#if defined(_WIN32)
+#include <EGL/egl.h>
+
+namespace tgfx {
+class EGLDisplayWrapper {
+ public:
+  static EGLDisplay EGLGetPlatformDisplay();
+  static bool HasNext();
+};
+}  // namespace tgfx
+#endif

--- a/tgfx/src/gpu/opengl/egl/EGLGlobals.cpp
+++ b/tgfx/src/gpu/opengl/egl/EGLGlobals.cpp
@@ -18,14 +18,25 @@
 
 #include "EGLGlobals.h"
 #include <EGL/eglext.h>
+#if defined(_WIN32)
+#include "EGLDisplayWrapper.h"
+#endif
 
 namespace tgfx {
+
 EGLGlobals InitializeEGL() {
   EGLGlobals globals = {};
-  globals.display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
   EGLint majorVersion;
   EGLint minorVersion;
+#if defined(_WIN32)
+  do {
+    globals.display = EGLDisplayWrapper::EGLGetPlatformDisplay();
+  } while (eglInitialize(globals.display, &majorVersion, &minorVersion) == EGL_FALSE &&
+           EGLDisplayWrapper::HasNext());
+#else
+  globals.display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
   eglInitialize(globals.display, &majorVersion, &minorVersion);
+#endif
   eglBindAPI(EGL_OPENGL_ES_API);
   EGLint numConfigs = 0;
   const EGLint configAttribs[] = {EGL_SURFACE_TYPE,


### PR DESCRIPTION
1.Add the surface attributes EGL_DIRECT_COMPOSITION_ANGLE.
2.Attempt to initialize ANGLE's renderer in order of: D3D11, D3D11 Feature Level 9_3 and finally D3D11 WARP.