### PR TITLE
fix textShaper bug

### DIFF
--- a/src/rendering/utils/shaper/TextShaperPrimitive.cpp
+++ b/src/rendering/utils/shaper/TextShaperPrimitive.cpp
@@ -33,17 +33,22 @@ PositionedGlyphs TextShaperPrimitive::Shape(const std::string& text,
     auto length = textStart - oldPosition;
     auto str = std::string(oldPosition, length);
     auto glyphID = typeface->getGlyphID(str);
+    bool found = false;
     if (glyphID == 0) {
       for (const auto& faceHolder : fallbackTypefaces) {
         auto face = faceHolder->getTypeface();
         glyphID = face->getGlyphID(str);
         if (glyphID != 0) {
           glyphs.emplace_back(std::move(face), glyphID, oldPosition - &(text[0]));
+          found = true;
           break;
         }
       }
+      if (!found) {
+        glyphs.emplace_back(typeface, glyphID, oldPosition - &(text[0]));
+      }
     } else {
-      glyphs.emplace_back(typeface, typeface->getGlyphID(str), oldPosition - &(text[0]));
+      glyphs.emplace_back(typeface, glyphID, oldPosition - &(text[0]));
     }
   }
   return PositionedGlyphs(glyphs);


### PR DESCRIPTION
fix the bug that when the font does not have a lineBreak(U+000A) glyph, the line break does not take effect