### PR TITLE
Fix PAGViewer rendering abnormal when using multiply blend mode on qt.

### DIFF
--- a/tgfx/include/tgfx/opengl/qt/QGLWindow.h
+++ b/tgfx/include/tgfx/opengl/qt/QGLWindow.h
@@ -64,7 +64,7 @@ class QGLWindow : public Window {
   bool textureInvalid = true;
   QQuickItem* quickItem = nullptr;
   QSGTexture* outTexture = nullptr;
-  std::shared_ptr<GLRenderTarget> renderTarget = nullptr;
+  std::shared_ptr<Surface> surface = nullptr;
   std::shared_ptr<Texture> frontTexture = nullptr;
   std::shared_ptr<Texture> backTexture = nullptr;
 


### PR DESCRIPTION
In QGLWindow, modify the texture property held by the surface when changing the texture bound to the frame buffer.