### PR TITLE
fix: added missing exports

### DIFF
--- a/include/pag/file.h
+++ b/include/pag/file.h
@@ -812,7 +812,7 @@ class PAG_API MosaicEffect : public Effect {
   RTTR_ENABLE(Effect)
 };
 
-class BrightnessContrastEffect : public Effect {
+class PAG_API BrightnessContrastEffect : public Effect {
  public:
   ~BrightnessContrastEffect() override;
 
@@ -852,7 +852,7 @@ class PAG_API ChannelControlType {
   static const int Count = 7;
 };
 
-class HueSaturationEffect : public Effect {
+class PAG_API HueSaturationEffect : public Effect {
  public:
   ~HueSaturationEffect() override;
 

--- a/include/pag/types.h
+++ b/include/pag/types.h
@@ -1309,7 +1309,7 @@ class PAG_API Matrix {
    * of zero values are different. Returns false if either Matrix contains NaN, even if the other
    * Matrix also contains NaN.
    */
-  friend bool operator==(const Matrix& a, const Matrix& b);
+  friend PAG_API bool operator==(const Matrix& a, const Matrix& b);
 
   /**
    * Compares a and b; returns true if a and b are not numerically equal. Returns false even if


### PR DESCRIPTION
1, for `BrightnessContrastEffect` and `HueSaturationEffect` classess that should be an oversight i believe.
2, for a `friend` declaration, if its body is encapsulated into the cpp file, this declaration won't be exported to the `*.lib`, which means the build in the 3rd party develop will fail because of the linking error: `can't find the symbol`. in this PR the `operator !=` will be exported but it will cause error if you try to call it, because it calls `==` internally which is not exported.
