### PR TITLE
[Feature]Add Tint Color For PAGShapeLayer (Android API)

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGShapeLayer.java
+++ b/android/libpag/src/main/java/org/libpag/PAGShapeLayer.java
@@ -9,6 +9,10 @@ public class PAGShapeLayer extends PAGLayer {
 
     private static native void nativeInit();
 
+    public native void setShapeColor(int shapeColor);
+
+    public native int getShapeColor();
+
     static {
         LibraryLoadUtils.loadLibrary("pag");
         nativeInit();

--- a/include/pag/file.h
+++ b/include/pag/file.h
@@ -1937,7 +1937,16 @@ class PAG_API ShapeLayer : public Layer {
 
   Rect getBounds() const override;
 
+  std::shared_ptr<Color> getTintColor() const;
+
+  void setTintColor(pag::Color color);
+
+  void clearTintColor();
+
   RTTR_ENABLE(Layer)
+
+  private:
+    std::shared_ptr<pag::Color> _shapeColor = nullptr;
 };
 
 class PAG_API ImageFillRule {

--- a/include/pag/pag.h
+++ b/include/pag/pag.h
@@ -661,6 +661,12 @@ class ShapeLayer;
 class PAG_API PAGShapeLayer : public PAGLayer {
  public:
   PAGShapeLayer(std::shared_ptr<File> file, ShapeLayer* layer);
+
+  std::shared_ptr<Color> getTintColor() const;
+
+  void setTintColor(pag::Color value);
+
+  void clearTintColor();
 };
 
 /**

--- a/src/base/ShapeLayer.cpp
+++ b/src/base/ShapeLayer.cpp
@@ -51,4 +51,16 @@ bool ShapeLayer::verify() const {
 Rect ShapeLayer::getBounds() const {
   return Rect::MakeWH(containingComposition->width, containingComposition->height);
 }
+
+std::shared_ptr<Color> ShapeLayer::getTintColor() const {
+  return _shapeColor;
+}
+
+void ShapeLayer::setTintColor(Color color) {
+  _shapeColor = std::make_shared<pag::Color>(color);
+}
+
+void ShapeLayer::clearTintColor() {
+  _shapeColor = nullptr;
+}
 }  // namespace pag

--- a/src/platform/android/JPAGShapeLayer.cpp
+++ b/src/platform/android/JPAGShapeLayer.cpp
@@ -37,4 +37,35 @@ extern "C" {
 PAG_API void Java_org_libpag_PAGShapeLayer_nativeInit(JNIEnv* env, jclass clazz) {
   PAGShapeLayer_nativeContext = env->GetFieldID(clazz, "nativeContext", "J");
 }
+
+PAG_API jint Java_org_libpag_PAGShapeLayer_getTintColor(JNIEnv* env, jobject thiz) {
+  auto pagShapeLayer = GetPAGShapeLayer(env, thiz);
+  if (pagShapeLayer == nullptr) {
+      return 0;
+  }
+  auto color = pagShapeLayer->getTintColor();
+  if (color == nullptr) {
+    return 0;
+  } else {
+    return MakeColorInt(env, color->red, color->green, color->blue);
+  }
+}
+
+
+PAG_API void Java_org_libpag_PAGShapeLayer_setTintColor(JNIEnv* env, jobject thiz, jint color) {
+  auto pagShapeLayer = GetPAGShapeLayer(env, thiz);
+  if (pagShapeLayer == nullptr) {
+    return;
+  }
+  pag::Color pagColor = ToColor(env, color);
+  pagShapeLayer->setTintColor(pagColor);
+}
+
+PAG_API void Java_org_libpag_PAGShapeLayer_clearTintColor(JNIEnv* env, jobject thiz) {
+  auto pagShapeLayer = GetPAGShapeLayer(env, thiz);
+  if (pagShapeLayer == nullptr) {
+    return;
+  }
+  pagShapeLayer->clearTintColor();
+}
 }

--- a/src/rendering/caches/ShapeContentCache.cpp
+++ b/src/rendering/caches/ShapeContentCache.cpp
@@ -16,6 +16,8 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
+#include <rendering/graphics/Shape.h>
+#include <base/utils/TGFXCast.h>
 #include "ShapeContentCache.h"
 #include "rendering/renderers/ShapeRenderer.h"
 
@@ -30,8 +32,18 @@ void ShapeContentCache::excludeVaryingRanges(std::vector<TimeRange>* timeRanges)
 }
 
 GraphicContent* ShapeContentCache::createContent(Frame layerFrame) const {
-  auto graphic =
-      RenderShapes(layer->uniqueID, static_cast<ShapeLayer*>(layer)->contents, layerFrame);
+  auto shapeLayer = static_cast<ShapeLayer*>(layer);
+  auto pagColor = shapeLayer->getTintColor();
+
+  std::shared_ptr<Graphic> graphic;
+  if (pagColor == nullptr) {
+    graphic = RenderShapes(layer->uniqueID, static_cast<ShapeLayer *>(layer)->contents, layerFrame);
+  } else {
+    auto tgfxColor = ToTGFX(*shapeLayer->getTintColor());
+    graphic = RenderShapes(layer->uniqueID, static_cast<ShapeLayer *>(layer)->contents, layerFrame,
+                           &tgfxColor);
+  };
+
   return new GraphicContent(graphic);
 }
 }  // namespace pag

--- a/src/rendering/layers/PAGShapeLayer.cpp
+++ b/src/rendering/layers/PAGShapeLayer.cpp
@@ -16,6 +16,8 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
+#include <rendering/utils/LockGuard.h>
+#include <rendering/renderers/ShapeRenderer.h>
 #include "pag/pag.h"
 #include "rendering/caches/LayerCache.h"
 #include "rendering/layers/PAGStage.h"
@@ -24,4 +26,25 @@ namespace pag {
 PAGShapeLayer::PAGShapeLayer(std::shared_ptr<pag::File> file, ShapeLayer* layer)
     : PAGLayer(std::move(file), layer) {
 }
+
+std::shared_ptr<Color> PAGShapeLayer::getTintColor() const {
+    LockGuard autoLock(rootLocker);
+    auto shapeLayer = static_cast<ShapeLayer*>(layer);
+    return shapeLayer->getTintColor();
+}
+
+void PAGShapeLayer::setTintColor(pag::Color value) {
+    LockGuard autoLock(rootLocker);
+
+    auto shapeLayer = static_cast<ShapeLayer*>(layer);
+    shapeLayer->setTintColor(value);
+}
+
+void PAGShapeLayer::clearTintColor() {
+    LockGuard autoLock(rootLocker);
+
+    auto shapeLayer = static_cast<ShapeLayer*>(layer);
+    shapeLayer->clearTintColor();
+}
+
 }  // namespace pag

--- a/src/rendering/renderers/ShapeRenderer.cpp
+++ b/src/rendering/renderers/ShapeRenderer.cpp
@@ -880,7 +880,7 @@ std::shared_ptr<Graphic> RenderShape(ID assetID, PaintElement* paint, tgfx::Path
   return Graphic::MakeCompose(shape, modifier);
 }
 
-std::shared_ptr<Graphic> RenderShape(ID assetID, GroupElement* group, tgfx::Path* path) {
+std::shared_ptr<Graphic> RenderShape(ID assetID, GroupElement* group, tgfx::Path* path, tgfx::Color* color) {
   std::vector<std::shared_ptr<Graphic>> contents = {};
   for (auto& element : group->elements) {
     switch (element->type()) {
@@ -890,6 +890,9 @@ std::shared_ptr<Graphic> RenderShape(ID assetID, GroupElement* group, tgfx::Path
       } break;
       case ElementDataType::Paint: {
         auto paint = reinterpret_cast<PaintElement*>(element);
+        if (color != nullptr) {
+          paint->color = *color;
+        }
         auto shape = RenderShape(assetID, paint, path);
         if (shape) {
           if (paint->compositeOrder == CompositeOrder::AbovePreviousInSameGroup) {
@@ -901,7 +904,7 @@ std::shared_ptr<Graphic> RenderShape(ID assetID, GroupElement* group, tgfx::Path
       } break;
       case ElementDataType::Group: {
         tgfx::Path tempPath = {};
-        auto shape = RenderShape(assetID, static_cast<GroupElement*>(element), &tempPath);
+        auto shape = RenderShape(assetID, static_cast<GroupElement*>(element), &tempPath, color);
         path->addPath(tempPath);
         if (shape) {
           contents.insert(contents.begin(), shape);
@@ -914,12 +917,13 @@ std::shared_ptr<Graphic> RenderShape(ID assetID, GroupElement* group, tgfx::Path
   return Graphic::MakeCompose(shape, modifier);
 }
 
-std::shared_ptr<Graphic> RenderShapes(ID assetID, const std::vector<ShapeElement*>& contents,
-                                      Frame layerFrame) {
+std::shared_ptr<Graphic>
+RenderShapes(ID assetID, const std::vector<ShapeElement *> &contents,
+             Frame layerFrame, tgfx::Color* tgfxColor) {
   GroupElement rootGroup;
   auto matrix = tgfx::Matrix::I();
   RenderElements(contents, matrix, &rootGroup, layerFrame);
   tgfx::Path tempPath = {};
-  return RenderShape(assetID, &rootGroup, &tempPath);
+  return RenderShape(assetID, &rootGroup, &tempPath, tgfxColor);
 }
 }  // namespace pag

--- a/src/rendering/renderers/ShapeRenderer.h
+++ b/src/rendering/renderers/ShapeRenderer.h
@@ -23,6 +23,7 @@
 #include "rendering/utils/Transform.h"
 
 namespace pag {
-std::shared_ptr<Graphic> RenderShapes(ID assetID, const std::vector<ShapeElement*>& contents,
-                                      Frame layerFrame);
+std::shared_ptr<Graphic>
+RenderShapes(ID assetID, const std::vector<ShapeElement *> &contents, Frame layerFrame,
+             tgfx::Color* tgfxColor = nullptr);
 }


### PR DESCRIPTION
【Feature】为PAGShapeLayer添加着色功能，想法来源于https://github.com/Tencent/libpag/discussions/1932
对于一些简单的动画，lottie提供了着色的功能，但是pag只对solid图层有设置颜色功能
增加此功能，提升动画颜色的拓展性，避免同样的动画文件制作多个

纯ShapeLayer动画举例:
[纯shape动画.zip](https://github.com/Tencent/libpag/files/13612446/shape.zip)
望采纳