### PR TITLE
Add PAGSurface.updateSize()

### DIFF
--- a/ohos/libpag/src/main/cpp/types/libpag/Index.d.ts
+++ b/ohos/libpag/src/main/cpp/types/libpag/Index.d.ts
@@ -278,6 +278,8 @@ export declare class JPAGSurface {
 
   freeCache(): void;
 
+  updateSize(): void;
+
   makeSnapshot(): image.PixelMap | null;
 }
 

--- a/ohos/libpag/src/main/ets/PAGSurface.ets
+++ b/ohos/libpag/src/main/ets/PAGSurface.ets
@@ -73,6 +73,13 @@ export class PAGSurface {
   }
 
   /**
+   * Update the size of the surface. This method should be called when the size of the surface is changed.
+   */
+  updateSize(): void {
+    this.nativeSurface.updateSize();
+  }
+
+  /**
    * Returns a bitmap capturing the contents of the PAGSurface. Subsequent rendering of the
    * PAGSurface will not be captured.
    */


### PR DESCRIPTION
目前 C++ 层的 `GPUDrawable.updateSize` 只会在创建的时候调一次，后续给 NativeWindow 设置宽高后，没办法更新这里已经获取的宽高

`JPAGSurface` 的 napi 里面已经暴露了 `UpdateSize`，但是 ets 层没有写上，导致外部没办法调用，这里补充上 ets 侧的方法，让外部可以在设置宽高后调用 `PAGSurface.updateSize`