### PR TITLE
Fix StateChangeCallback Enum Value

### DIFF
--- a/src/platform/ohos/JPAGImageView.cpp
+++ b/src/platform/ohos/JPAGImageView.cpp
@@ -316,10 +316,10 @@ static napi_value NumFrame(napi_env env, napi_callback_info info) {
 }
 
 static void StateChangeCallback(napi_env env, napi_value callback, void*, void* data) {
-  int state = *static_cast<int*>(data);
+  Enum state = *static_cast<Enum*>(data);
   size_t argc = 1;
   napi_value argv[1] = {0};
-  napi_create_uint32(env, state, &argv[0]);
+  napi_create_uint32(env, static_cast<uint32_t>(state), &argv[0]);
   napi_value undefined;
   napi_get_undefined(env, &undefined);
   napi_call_function(env, undefined, callback, argc, argv, nullptr);

--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -252,11 +252,10 @@ static napi_value UniqueID(napi_env env, napi_callback_info info) {
 }
 
 static void StateChangeCallback(napi_env env, napi_value callback, void*, void* data) {
-  Enum enumValue = *static_cast<Enum*>(data);
-  int state = static_cast<int>(enumValue);
+  Enum state = *static_cast<Enum*>(data);
   size_t argc = 1;
   napi_value argv[1] = {0};
-  napi_create_uint32(env, state, &argv[0]);
+  napi_create_uint32(env, static_cast<uint32_t>(state), &argv[0]);
   napi_value undefined;
   napi_get_undefined(env, &undefined);
   napi_call_function(env, undefined, callback, argc, argv, nullptr);

--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -252,7 +252,8 @@ static napi_value UniqueID(napi_env env, napi_callback_info info) {
 }
 
 static void StateChangeCallback(napi_env env, napi_value callback, void*, void* data) {
-  int state = *static_cast<int*>(data);
+  Enum enumValue = *static_cast<Enum*>(data);
+  int state = static_cast<int>(enumValue);
   size_t argc = 1;
   napi_value argv[1] = {0};
   napi_create_uint32(env, state, &argv[0]);


### PR DESCRIPTION
Fix StateChangeCallback Enum Value

```
  static void StateChangeCallback(napi_env env, napi_value callback, void*, void* data) {
  Enum enumValue = *static_cast<Enum*>(data);
  int state = static_cast<int>(enumValue);
  size_t argc = 1;
  napi_value argv[1] = {0};
  napi_create_uint32(env, state, &argv[0]);
  napi_value undefined;
  napi_get_undefined(env, &undefined);
  napi_call_function(env, undefined, callback, argc, argv, nullptr);
}
```