### PR TITLE
Remove `packageType` in `oh-package.json5`

### DIFF
--- a/ohos/libpag/oh-package.json5
+++ b/ohos/libpag/oh-package.json5
@@ -5,7 +5,6 @@
   "main": "Index.ets",
   "author": "libpag",
   "license": "Apache-2.0",
-  "packageType": "InterfaceHar",
   "dependencies": {
     "libpag.so": "file:./src/main/cpp/types/libpag"
   },


### PR DESCRIPTION
Fix #2492 
`"packageType": "InterfaceHar"` is for HSP module