### PR TITLE
Added description to the comment of PAGLayer::getTotalMatrix

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGLayer.java
+++ b/android/libpag/src/main/java/org/libpag/PAGLayer.java
@@ -61,9 +61,12 @@ public class PAGLayer {
      */
     public native void resetMatrix();
 
-    /**
-     * The final matrix for displaying, it is the combination of the matrix property and current matrix from animation.
-     */
+  /**
+   * The final matrix for displaying, it is the combination of the matrix property and current
+   * matrix from animation, This matrix does not include the matrix of the parent layer.
+   * If you need to calculate the final bounds size relative to the PAGSurface screen, you can
+   * directly use the PAGPlayer::getBounds(PAGLayer) method
+   */
     public Matrix getTotalMatrix() {
         float[] data = new float[9];
         getTotalMatrix(data);

--- a/android/libpag/src/main/java/org/libpag/PAGLayer.java
+++ b/android/libpag/src/main/java/org/libpag/PAGLayer.java
@@ -61,12 +61,12 @@ public class PAGLayer {
      */
     public native void resetMatrix();
 
-  /**
-   * The final matrix for displaying, it is the combination of the matrix property and current
-   * matrix from animation, This matrix does not include the matrix of the parent layer.
-   * If you need to calculate the final bounds size relative to the PAGSurface screen, you can
-   * directly use the PAGPlayer::getBounds(PAGLayer) method
-   */
+    /**
+     * The final matrix for displaying, it is the combination of the matrix property and current
+     * matrix from animation, This matrix does not include the matrix of the parent layer.
+     * If you need to calculate the final bounds size relative to the PAGSurface screen, you can
+     * directly use the PAGPlayer::getBounds(PAGLayer) method
+     */
     public Matrix getTotalMatrix() {
         float[] data = new float[9];
         getTotalMatrix(data);

--- a/include/pag/pag.h
+++ b/include/pag/pag.h
@@ -287,7 +287,9 @@ class PAG_API PAGLayer : public Content {
 
   /**
    * The final matrix for displaying, it is the combination of the matrix property and current
-   * matrix from animation.
+   * matrix from animation, This matrix does not include the matrix of the parent layer.
+   * If you need to calculate the final bounds size relative to the PAGSurface screen, you can
+   * directly use the PAGPlayer::getBounds(PAGLayer) method
    */
   Matrix getTotalMatrix();
 

--- a/ohos/libpag/src/main/ets/PAGLayer.ets
+++ b/ohos/libpag/src/main/ets/PAGLayer.ets
@@ -80,7 +80,10 @@ export class PAGLayer {
   }
 
   /**
-   * The final matrix for displaying, it is the combination of the matrix property and current matrix from animation.
+   * The final matrix for displaying, it is the combination of the matrix property and current
+   * matrix from animation, This matrix does not include the matrix of the parent layer.
+   * If you need to calculate the final bounds size relative to the PAGSurface screen, you can
+   * directly use the PAGPlayer::getBounds(PAGLayer) method
    */
   getTotalMatrix(): Matrix4 {
     return PAGUtils.ToTsMatrix(this.nativeLayer.getTotalMatrix());

--- a/src/platform/cocoa/PAGLayer.h
+++ b/src/platform/cocoa/PAGLayer.h
@@ -59,12 +59,12 @@ PAG_API @interface PAGLayer : NSObject
  */
 - (void)resetMatrix;
 
-  /**
-   * The final matrix for displaying, it is the combination of the matrix property and current
-   * matrix from animation, This matrix does not include the matrix of the parent layer.
-   * If you need to calculate the final bounds size relative to the PAGSurface screen, you can
-   * directly use the PAGPlayer::getBounds(PAGLayer) method
-   */
+/**
+ * The final matrix for displaying, it is the combination of the matrix property and current
+ * matrix from animation, This matrix does not include the matrix of the parent layer.
+ * If you need to calculate the final bounds size relative to the PAGSurface screen, you can
+ * directly use the PAGPlayer::getBounds(PAGLayer) method
+ */
 - (CGAffineTransform)getTotalMatrix;
 
 /**

--- a/src/platform/cocoa/PAGLayer.h
+++ b/src/platform/cocoa/PAGLayer.h
@@ -59,10 +59,12 @@ PAG_API @interface PAGLayer : NSObject
  */
 - (void)resetMatrix;
 
-/**
- * The final matrix for displaying, it is the combination of the matrix property and current matrix
- * from animation.
- */
+  /**
+   * The final matrix for displaying, it is the combination of the matrix property and current
+   * matrix from animation, This matrix does not include the matrix of the parent layer.
+   * If you need to calculate the final bounds size relative to the PAGSurface screen, you can
+   * directly use the PAGPlayer::getBounds(PAGLayer) method
+   */
 - (CGAffineTransform)getTotalMatrix;
 
 /**

--- a/web/src/pag-layer.ts
+++ b/web/src/pag-layer.ts
@@ -54,7 +54,9 @@ export class PAGLayer {
   }
   /**
    * The final matrix for displaying, it is the combination of the matrix property and current
-   * matrix from animation.
+   * matrix from animation, This matrix does not include the matrix of the parent layer.
+   * If you need to calculate the final bounds size relative to the PAGSurface screen, you can
+   * directly use the PAGPlayer::getBounds(PAGLayer) method
    */
   public getTotalMatrix(): Matrix {
     const wasmIns = this.wasmIns._getTotalMatrix();


### PR DESCRIPTION
PAGLayer::getTotalMatrix的注释增加描述，不包含父类的矩阵，并说明计算包围盒时应该采用的方法。