### PR TITLE
Enable compatibility with the latest version of Emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,7 +509,7 @@ endif ()
 if (WEB)
     add_executable(pag ${PAG_FILES})
     list(APPEND PAG_LINK_OPTIONS --no-entry -lembind -sEXPORT_NAME='Hello2D' -sWASM=1 -sASYNCIFY
-            -sMAX_WEBGL_VERSION=2 -sEXPORTED_RUNTIME_METHODS=['GL','Asyncify'] -sALLOW_MEMORY_GROWTH=1
+            -sMAX_WEBGL_VERSION=2 -sEXPORTED_RUNTIME_METHODS=['GL','Asyncify','HEAPU8'] -sALLOW_MEMORY_GROWTH=1
             -sMODULARIZE=1 -sENVIRONMENT='web,worker' -sEXPORT_ES6=1)
     if (${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.4")
         list(APPEND PAG_LINK_OPTIONS -sUSE_ES6_IMPORT_META=0)


### PR DESCRIPTION
1、导出运行时方法HEAPU8以适配emsdk 4.0.7