### PR TITLE
Modify the minimum cmake version of the harfbuzz repository to 3.5 to resolve the compilation error.

### DIFF
--- a/vendor.json
+++ b/vendor.json
@@ -26,7 +26,8 @@
         "arguments": [
           "-DHB_HAVE_FREETYPE=OFF",
           "-DHB_HAVE_CORETEXT=OFF",
-          "-DCMAKE_CXX_FLAGS=\"-DHB_LEAN -DHB_MINI -DHB_NO_UCD_UNASSIGNED -DNDEBUG -D__OPTIMIZE_SIZE__\""
+          "-DCMAKE_CXX_FLAGS=\"-DHB_LEAN -DHB_MINI -DHB_NO_UCD_UNASSIGNED -DNDEBUG -D__OPTIMIZE_SIZE__\"",
+          "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
         ]
       }
     },


### PR DESCRIPTION
将harfbuzz的最小CMake版本修改为3.5，修复编译错误。