### PR TITLE
Upgraded ffmpeg to version 7.0.2 to address security vulnerabilities.

### DIFF
--- a/android/libpag/libs/arm64-v8a/libffavc.so
+++ b/android/libpag/libs/arm64-v8a/libffavc.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40ea21619762959aa3abbb1eea951e5f750323c8d0526a57aeae07daf9a7c492
-size 1134272
+oid sha256:1e214164a6c153f74f25018c1625f3e71d1d5ba601f6592c4dd89385dcc4b0bc
+size 1161456

--- a/android/libpag/libs/armeabi-v7a/libffavc.so
+++ b/android/libpag/libs/armeabi-v7a/libffavc.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38c7d801c91ccc4b32cc7b31e5e698a1d311e46fa2574904b0ca9dd59a67cd30
-size 963872
+oid sha256:1b846b1a3f836265b59c6b9728cd7ee9b36ed9f2333e53b9018c1102864cb127
+size 979696

--- a/android/libpag/libs/armeabi/libffavc.so
+++ b/android/libpag/libs/armeabi/libffavc.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38c7d801c91ccc4b32cc7b31e5e698a1d311e46fa2574904b0ca9dd59a67cd30
-size 963872
+oid sha256:1b846b1a3f836265b59c6b9728cd7ee9b36ed9f2333e53b9018c1102864cb127
+size 979696

--- a/android/libpag/libs/x86_64/libffavc.so
+++ b/android/libpag/libs/x86_64/libffavc.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:393609a8d1bfe1e86e1ce2f77b8dec00102e4a357ccc6af02db33fbb641f5473
-size 1435144
+oid sha256:5da4dea926ef43d7ac4535b5799afba00d9d0e0fd396e350486037de6843e7e2
+size 1403816

--- a/vendor/ffavc/mac/arm64/libffavc.dylib
+++ b/vendor/ffavc/mac/arm64/libffavc.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:953fd50fb98d44de54f13908e99df7145f5a4cecdf9f1b6b4689e69905b0bfc1
-size 1784635
+oid sha256:4658c347651a28c973f2767f2a864d423d09e1747e8f9f330adfb7c14e4015e4
+size 1787616

--- a/vendor/ffavc/mac/x64/libffavc.dylib
+++ b/vendor/ffavc/mac/x64/libffavc.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25384b6db1267671a4a3c2c90c2bf71deda1d002e77d44e9cbda7a57f052400c
-size 2159632
+oid sha256:c9da2b29909058511e98ac513fcd3d15aaca796e4dd284ced9909140ec40716e
+size 2158656


### PR DESCRIPTION
将ffmpeg升级到n7.0.2版本，编译好ffavc后，用其替换Android和Mac平台原本使用的低版本ffmpeg（n4.4）的ffavc动态库。