### PR TITLE
Add editable text layer support with rich styling options in viewer

### DIFF
--- a/viewer/images/checked.png
+++ b/viewer/images/checked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7727c8cd8bea478c7cc749c6aa5675f03cd040c1103ee7f81985af4bdbf289a
+size 872

--- a/viewer/images/revert.png
+++ b/viewer/images/revert.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1497b694d479d3abf394c572c486815e4be2fd43b7bbf2995cd212f3188978dc
+size 1610

--- a/viewer/images/unchecked.png
+++ b/viewer/images/unchecked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ffae26acbbb5969b1f2020a3d3da3f43c60c27f71ab0062a91568b5d0695e7b
+size 336

--- a/viewer/qml/MainForm.qml
+++ b/viewer/qml/MainForm.qml
@@ -242,8 +242,8 @@ SplitView {
                                 Rectangle {
                                     id: textListContainer
                                     width: parent.width
-                                    height: isTextListOpen ? (pagView.textCount * 40 + 44) : 32
-                                    visible: pagView.textCount > 0
+                                    height: isTextListOpen ? (pagView.editableTextLayerCount * 40 + 44) : 32
+                                    visible: pagView.editableTextLayerCount > 0
                                     color: "#20202A"
                                     anchors.left: parent.left
                                     anchors.leftMargin: 0
@@ -309,7 +309,7 @@ SplitView {
 
                                     TextListView {
                                         id: textListView
-                                        height: pagView.textCount * 40
+                                        height: pagView.editableTextLayerCount * 40
                                         textHeight: 40
                                         textModel: textLayerModel
                                         visible: isTextListOpen && height > 0

--- a/viewer/qml/MainForm.qml
+++ b/viewer/qml/MainForm.qml
@@ -13,6 +13,8 @@ SplitView {
 
     property bool isEditPanelOpen: false
 
+    property bool isTextListOpen: true
+
     property int minPlayerWidth: 360
 
     property int minPanelWidth: 300
@@ -188,9 +190,142 @@ SplitView {
                     anchors.right: parent.right
                     anchors.rightMargin: 0
 
+                    /* Layer Editing Area */
                     Rectangle {
                         color: "#20202A"
                         anchors.fill: tabContents.alignment
+
+                        ScrollView {
+                            id: editArea
+                            anchors.fill: parent
+                            clip: true
+
+                            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+                            ScrollBar.vertical.policy: ScrollBar.AsNeeded
+                            ScrollBar.vertical.background: Rectangle {
+                                color: "#00000000"
+                            }
+                            ScrollBar.vertical.contentItem: Rectangle {
+                                implicitWidth: 9
+                                implicitHeight: 100
+                                color: "#00000000"
+
+                                Rectangle {
+                                    anchors.fill: parent
+                                    radius: 4
+                                    anchors.right: parent.right
+                                    anchors.rightMargin: 2
+                                    color: "#AA4B4B5A"
+                                    visible: editArea.ScrollBar.vertical.size < 1.0
+                                }
+                            }
+
+                            Column {
+                                spacing: 0
+                                width: parent.width
+
+                                Rectangle {
+                                    width: parent.width
+                                    height: editArea.height
+                                    visible: !textListContainer.visible
+                                    color: "#20202A"
+                                    Text {
+                                        color: "#80ffffff"
+                                        text: qsTr("No layer was editable")
+                                        font.pixelSize: 12
+                                        verticalAlignment: Text.AlignVCenter
+                                        horizontalAlignment: Text.AlignHCenter
+                                        anchors.fill: parent
+                                    }
+                                }
+
+                                Rectangle {
+                                    id: textListContainer
+                                    width: parent.width
+                                    height: isTextListOpen ? (pagView.textCount * 40 + 44) : 32
+                                    visible: pagView.textCount > 0
+                                    color: "#20202A"
+                                    anchors.left: parent.left
+                                    anchors.leftMargin: 0
+                                    anchors.right: parent.right
+                                    anchors.rightMargin: 0
+
+                                    Row {
+                                        id: textListTitle
+                                        spacing: 0
+                                        width: parent.width
+                                        height: 21
+                                        anchors.top: parent.top
+                                        anchors.topMargin: 5
+
+                                        Item {
+                                            width: 5
+                                            height: 1
+                                        }
+
+                                        CheckBox {
+                                            id: textListCheckBox
+                                            width: 20
+                                            height: 21
+                                            anchors.top: parent.top
+                                            checked: isTextListOpen
+                                            rotation: isTextListOpen ? 0 : -90
+
+                                            indicator: Image {
+                                                width: parent.width
+                                                height: parent.height
+                                                source: "qrc:/images/icon-collapse.png"
+                                                MouseArea {
+                                                    anchors.fill: parent
+                                                    hoverEnabled: true
+                                                    cursorShape: Qt.PointingHandCursor
+                                                    onPressed: function (mouse) {
+                                                        mouse.accepted = false;
+                                                    }
+                                                }
+                                            }
+
+                                            onClicked: {
+                                                splitView.isTextListOpen = !splitView.isTextListOpen;
+                                            }
+                                        }
+
+                                        Item {
+                                            width: 5
+                                            height: 1
+                                        }
+
+                                        Text {
+                                            id: textListTitleText
+                                            height: 20
+                                            anchors.top: parent.top
+                                            text: qsTr("Edit Text")
+                                            font.pixelSize: 12
+                                            renderType: Text.NativeRendering
+                                            color: "#9B9B9B"
+                                            verticalAlignment: Text.AlignVCenter
+                                        }
+                                    }
+
+                                    TextListView {
+                                        id: textListView
+                                        height: pagView.textCount * 40
+                                        textHeight: 40
+                                        textModel: textLayerModel
+                                        visible: isTextListOpen && height > 0
+                                        anchors.top: textListTitle.bottom
+                                        anchors.topMargin: 5
+                                        anchors.bottom: parent.bottom
+                                        anchors.bottomMargin: 10
+                                        anchors.left: parent.left
+                                        anchors.leftMargin: 15
+                                        anchors.right: parent.right
+                                        anchors.rightMargin: 15
+                                        clip: true
+                                    }
+                                }
+                            }
+                        }
                     }
 
                     /* File Structure Area */

--- a/viewer/qml/TextEditDialog.qml
+++ b/viewer/qml/TextEditDialog.qml
@@ -1,0 +1,774 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt.labs.platform
+
+Popup {
+    id: dialog
+
+    required property var textModel
+
+    property bool fauxBold: false
+    property bool fauxItalic: false
+    property int layerIndex: 0
+    property double fontSize: 120.0
+    property double strokeWidth: 1.0
+    property string fillColor: ""
+    property string fontFamily: ""
+    property string fontStyle: ""
+    property string strokeColor: ""
+    property string displatText: ""
+
+    z: 9999
+    width: 330
+    height: 270
+    modal: false
+    focus: true
+    closePolicy: Popup.CloseOnEscape
+
+    background: Rectangle {
+        anchors.fill: parent
+        border.width: 1
+        radius: 5
+        color: "#20202A"
+        opacity: 1
+
+        MouseArea {
+            property int mouseStartX: 0
+            property int mouseStartY: 0
+            property int windowX: 0
+            property int windowY: 0
+
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton
+            onPressed: function (mouse) {
+                mouseStartX = mouseX;
+                mouseStartY = mouseY;
+                windowX = dialog.x;
+                windowY = dialog.y;
+            }
+            onPositionChanged: function (mouse) {
+                let offsetX = mouseX - mouseStartX;
+                let offsetY = mouseY - mouseStartY;
+                if ((offsetX === (dialog.x - windowX)) && (offsetY === (dialog.y - windowY))) {
+                    return;
+                }
+                dialog.x = windowX + offsetX;
+                dialog.y = windowY + offsetY;
+            }
+        }
+
+        Column {
+            spacing: 0
+            anchors.left: parent.left
+            anchors.leftMargin: 20
+            anchors.right: parent.right
+            anchors.rightMargin: 20
+
+            Row {
+                width: parent.width
+                height: 40
+
+                Text {
+                    id: title
+                    width: parent.width - closeButton.width
+                    height: parent.height
+                    text: qsTr("Edit Text")
+                    font.pixelSize: 12
+                    horizontalAlignment: Text.AlignLeft
+                    verticalAlignment: Text.AlignVCenter
+                    color: "#FFFFFF"
+                }
+
+                Button {
+                    id: closeButton
+                    width: 12
+                    height: 12
+                    anchors.top: parent.top
+                    anchors.topMargin: (parent.height - height) / 2
+                    anchors.bottom: parent.bottom
+                    anchors.bottomMargin: (parent.height - height) / 2
+                    background: Image {
+                        width: parent.height
+                        height: parent.height
+                        source: "qrc:/images/icon-close.png"
+                    }
+
+                    onClicked: {
+                        dialog.close();
+                    }
+                }
+            }
+
+            Item {
+                width: 1
+                height: 4
+            }
+
+            Row {
+                height: 20
+
+                Item {
+                    width: 20
+                    height: 1
+                }
+
+                Label {
+                    id: fontFamilyLabel
+                    width: 28
+                    height: parent.height
+                    text: qsTr("Font")
+                    font.pixelSize: 12
+                    color: "#9B9B9B"
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                Item {
+                    width: 6
+                    height: 1
+                }
+
+                ComboBox {
+                    id: fontFamilyComboBox
+                    width: 220
+                    height: parent.height
+                    topInset: 0
+                    bottomInset: 0
+                    model: textModel ? textModel.getFontFamilies() : null
+                    currentIndex: textModel ? textModel.getFontFamilies().indexOf(currentValue) : -1
+
+                    background: Rectangle {
+                        color: "#16161D"
+                    }
+
+                    contentItem: Text {
+                        id: fontFamilyName
+                        text: fontFamily
+                        leftPadding: 5
+                        color: "#FFFFFF"
+                        verticalAlignment: Text.AlignVCenter
+                        elide: Text.ElideRight
+                        font.pixelSize: 12
+                    }
+
+                    indicator: Image {
+                        id: fontsDropdown
+                        width: 20
+                        anchors.top: parent.top
+                        anchors.topMargin: 0
+                        anchors.right: parent.right
+                        anchors.rightMargin: 4
+                        fillMode: Image.PreserveAspectFit
+                        source: "qrc:/images/icon-collapse.png"
+                    }
+
+                    delegate: Rectangle {
+                        required property string modelData
+                        width: fontFamilyComboBox.width
+                        height: 26
+                        border.width: 1
+                        border.color: "#504b4b"
+                        color: modelData === fontFamilyName.text ? "#333333" : "#16161D"
+                        Text {
+                            height: parent.height
+                            text: modelData + " 中文示例"
+                            color: "#DDDDDD"
+                            font.pixelSize: 12
+                            font.family: modelData
+                            elide: Text.ElideRight
+                            verticalAlignment: Text.AlignVCenter
+                            renderType: Text.QtRendering
+                            leftPadding: 5
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                fontFamilyName.text = modelData;
+                                fontStyleComboBox.currentFontFamily = modelData;
+                                let index = textModel.getFontStyles(modelData).indexOf(fontStyleName.text);
+                                if (index >= 0) {
+                                    cbFontStyle.currentIndex = index;
+                                } else {
+                                    cbFontStyle.currentIndex = 0;
+                                    fontStyleName.text = textModel.getFontStyles(modelData)[0];
+                                }
+                                fontFamilyComboBox.currentIndex = fontFamilyComboBox.model.indexOf(modelData);
+                                textModel.changeFontFamily(layerIndex, modelData);
+                                fontFamilyComboBox.popup.close();
+                            }
+                        }
+                    }
+                    popup: Popup {
+                        y: fontFamilyComboBox.height - 1
+                        width: fontFamilyComboBox.width
+                        implicitHeight: Math.min(contentItem.implicitHeight, 300)
+                        padding: 0
+
+                        contentItem: ListView {
+                            clip: true
+                            implicitHeight: contentHeight
+                            model: fontFamilyComboBox.popup.visible ? fontFamilyComboBox.delegateModel : null
+
+                            ScrollIndicator.vertical: ScrollIndicator {}
+                        }
+
+                        background: Rectangle {
+                            border.color: "#333333"
+                            color: "#16161D"
+                        }
+                    }
+                }
+            }
+
+            Item {
+                width: 1
+                height: 16
+            }
+
+            Row {
+                height: 20
+
+                Item {
+                    width: 20
+                    height: 1
+                }
+
+                Label {
+                    id: fontStyleLabel
+                    width: 28
+                    height: parent.height
+                    text: qsTr("Style")
+                    font.pixelSize: 12
+                    verticalAlignment: Text.AlignVCenter
+                    color: "#9B9B9B"
+                }
+
+                Item {
+                    width: 6
+                    height: 1
+                }
+
+                ComboBox {
+                    id: fontStyleComboBox
+
+                    property string currentFontFamily: fontFamilyName.text
+
+                    width: 220
+                    height: parent.height
+                    topInset: 0
+                    bottomInset: 0
+                    model: textModel ? textModel.getFontStyles(currentFontFamily) : null
+                    currentIndex: textModel ? textModel.getFontStyles(currentFontFamily).indexOf(currentValue) : -1
+
+                    background: Rectangle {
+                        color: "#16161D"
+                    }
+
+                    contentItem: Text {
+                        id: fontStyleName
+                        text: fontStyle
+                        leftPadding: 5
+                        color: "#FFFFFF"
+                        verticalAlignment: Text.AlignVCenter
+                        elide: Text.ElideRight
+                        font.pixelSize: 12
+                    }
+
+                    indicator: Image {
+                        id: fontStyleDropdown
+                        width: 20
+                        anchors.right: parent.right
+                        anchors.rightMargin: 4
+                        anchors.top: parent.top
+                        anchors.topMargin: 0
+                        fillMode: Image.PreserveAspectFit
+                        source: "qrc:/images/icon-collapse.png"
+                    }
+
+                    delegate: Rectangle {
+                        required property string modelData
+                        width: parent.width
+                        height: 26
+                        color: modelData === fontStyleName.text ? "#333333" : "#16161D"
+                        Text {
+                            height: parent.height
+                            text: modelData + " 中文示例"
+                            color: "#DDDDDD"
+                            font.pixelSize: 12
+                            font.family: fontStyleName.text
+                            font.styleName: modelData
+                            elide: Text.ElideRight
+                            verticalAlignment: Text.AlignVCenter
+                            renderType: Text.QtRendering
+                            leftPadding: 5
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                fontStyleName.text = modelData;
+                                fontStyleComboBox.currentIndex = fontStyleComboBox.model.indexOf(modelData);
+                                textModel.changeFontStyle(layerIndex, modelData);
+                                fontStyleComboBox.popup.close();
+                            }
+                        }
+                    }
+
+                    popup: Popup {
+                        y: fontStyleComboBox.height - 1
+                        width: fontStyleComboBox.width
+                        implicitHeight: Math.min(contentItem.implicitHeight, 300)
+                        padding: 1
+
+                        contentItem: ListView {
+                            clip: true
+                            implicitHeight: contentHeight
+                            model: fontStyleComboBox.popup.visible ? fontStyleComboBox.delegateModel : null
+                            ScrollIndicator.vertical: ScrollIndicator {
+                                implicitWidth: 7
+                                implicitHeight: 7
+
+                                background: Rectangle {
+                                    color: "#00000000"
+                                }
+                            }
+                        }
+
+                        background: Rectangle {
+                            border.color: "#333333"
+                            color: "#16161D"
+                        }
+                    }
+                }
+            }
+
+            Item {
+                width: 1
+                height: 16
+            }
+
+            Row {
+                height: 20
+
+                Item {
+                    width: 20
+                    height: 1
+                }
+
+                Label {
+                    id: fontSizeLabel
+                    width: 28
+                    height: parent.height
+                    text: qsTr("Size")
+                    font.pixelSize: 12
+                    verticalAlignment: Text.AlignVCenter
+                    color: "#9B9B9B"
+                }
+
+                Item {
+                    width: 6
+                    height: 1
+                }
+
+                Rectangle {
+                    width: 98
+                    height: parent.height
+                    color: "#16161D"
+
+                    Item {
+                        width: 6
+                        height: 1
+                    }
+
+                    TextInput {
+                        id: fontSizeTextInput
+                        text: fontSize
+                        font.pixelSize: 12
+                        anchors.fill: parent
+                        leftPadding: 5
+                        color: "#FFFFFF"
+                        verticalAlignment: Text.AlignVCenter
+                        clip: true
+                        selectByMouse: true
+                        validator: RegularExpressionValidator {
+                            regularExpression: /[0-9]+\.[0-9]+/
+                        }
+                        onTextChanged: {
+                            let fontSize = fontSizeTextInput.text;
+                            textModel.changeFontSize(layerIndex, fontSize);
+                        }
+                    }
+                }
+
+                Item {
+                    width: 20
+                    height: 1
+                }
+
+                CheckBox {
+                    id: boldCheckBox
+                    height: parent.height
+                    text: qsTr("Bold")
+                    font.pixelSize: 12
+                    spacing: 0
+                    checked: fauxBold
+                    topPadding: 0
+                    bottomPadding: 0
+                    enabled: true
+
+                    indicator: Image {
+                        id: boldImg
+                        height: 16
+                        width: 16
+                        anchors.verticalCenter: parent.verticalCenter
+                        source: boldCheckBox.checked ? "qrc:/images/checked.png" : "qrc:/images/unchecked.png"
+                    }
+
+                    contentItem: Text {
+                        text: boldCheckBox.text
+                        font: boldCheckBox.font
+                        opacity: enabled ? 1.0 : 0.3
+                        color: "#FFFFFF"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        leftPadding: 12
+                    }
+
+                    onCheckedChanged: {
+                        dialog.fauxBold = boldCheckBox.checked;
+                        textModel.changeFauxBold(layerIndex, dialog.fauxBold);
+                    }
+                }
+
+                Item {
+                    width: 10
+                    height: 1
+                }
+
+                CheckBox {
+                    id: italicCheckBox
+                    height: parent.height
+                    text: qsTr("Italic")
+                    font.pixelSize: 12
+                    spacing: 0
+                    checked: fauxItalic
+                    topPadding: 0
+                    bottomPadding: 0
+                    enabled: true
+
+                    indicator: Image {
+                        id: italicImg
+                        height: 16
+                        width: 16
+                        anchors.verticalCenter: parent.verticalCenter
+                        source: italicCheckBox.checked ? "qrc:/images/checked.png" : "qrc:/images/unchecked.png"
+                    }
+
+                    contentItem: Text {
+                        text: italicCheckBox.text
+                        font: italicCheckBox.font
+                        opacity: enabled ? 1.0 : 0.3
+                        color: "#FFFFFF"
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        leftPadding: 12
+                    }
+
+                    onCheckedChanged: {
+                        dialog.fauxItalic = italicCheckBox.checked;
+                        textModel.changeFauxItalic(layerIndex, dialog.fauxItalic);
+                    }
+                }
+            }
+
+            Item {
+                width: 1
+                height: 16
+            }
+
+            Row {
+                height: 20
+
+                Item {
+                    width: 20
+                    height: 1
+                }
+
+                Label {
+                    id: fontColorLabel
+                    width: 28
+                    height: parent.height
+                    text: qsTr("Color")
+                    font.pixelSize: 12
+                    verticalAlignment: Text.AlignVCenter
+                    color: "#9B9B9B"
+                }
+
+                Item {
+                    width: 6
+                    height: 1
+                }
+
+                Rectangle {
+                    width: 54
+                    height: 20
+                    color: "#16161D"
+
+                    Rectangle {
+                        id: currentFontColor
+                        width: 12
+                        height: 12
+                        anchors.top: parent.top
+                        anchors.topMargin: 4
+                        anchors.left: parent.left
+                        anchors.leftMargin: 4
+                        color: fillColor
+                    }
+
+                    Button {
+                        anchors.top: parent.top
+                        anchors.topMargin: -10
+                        anchors.left: parent.left
+                        anchors.leftMargin: 32
+
+                        background: Image {
+                            width: 20
+                            fillMode: Image.PreserveAspectFit
+                            source: "qrc:/images/icon-collapse.png"
+                        }
+
+                        onClicked: {
+                            selectColorDialog.close();
+                            if (selectColorDialog.currentAcceptHandler) {
+                                selectColorDialog.accepted.disconnect(selectColorDialog.currentAcceptHandler);
+                            }
+                            selectColorDialog.color = dialog.fillColor;
+                            selectColorDialog.currentAcceptHandler = function () {
+                                dialog.fillColor = selectColorDialog.color;
+                                textModel.changeFillColor(layerIndex, dialog.fillColor);
+                            };
+                            selectColorDialog.accepted.connect(selectColorDialog.currentAcceptHandler);
+                            selectColorDialog.open();
+                        }
+                    }
+                }
+
+                Item {
+                    width: 10
+                    height: 1
+                }
+
+                Label {
+                    id: strokeLbale
+                    width: 30
+                    height: parent.height
+                    text: qsTr("Stroke")
+                    font.pixelSize: 12
+                    verticalAlignment: Text.AlignVCenter
+                    color: "#9B9B9B"
+                }
+
+                Item {
+                    width: 6
+                    height: 1
+                }
+
+                Rectangle {
+                    width: 54
+                    height: 20
+                    color: "#16161D"
+
+                    Rectangle {
+                        id: currentStrokeColor
+                        width: 12
+                        height: 12
+                        anchors.top: parent.top
+                        anchors.topMargin: 4
+                        anchors.left: parent.left
+                        anchors.leftMargin: 4
+                        color: strokeColor
+                    }
+
+                    Button {
+                        anchors.top: parent.top
+                        anchors.topMargin: -10
+                        anchors.left: parent.left
+                        anchors.leftMargin: 32
+
+                        background: Image {
+                            width: 20
+                            fillMode: Image.PreserveAspectFit
+                            source: "qrc:/images/icon-collapse.png"
+                        }
+
+                        onClicked: {
+                            selectColorDialog.close();
+                            if (selectColorDialog.currentAcceptHandler) {
+                                selectColorDialog.accepted.disconnect(selectColorDialog.currentAcceptHandler);
+                            }
+                            selectColorDialog.color = dialog.strokeColor;
+                            selectColorDialog.currentAcceptHandler = function () {
+                                dialog.strokeColor = selectColorDialog.color;
+                                textModel.changeStrokeColor(layerIndex, dialog.strokeColor);
+                            };
+                            selectColorDialog.accepted.connect(selectColorDialog.currentAcceptHandler);
+                            selectColorDialog.open();
+                        }
+                    }
+                }
+
+                Item {
+                    width: 10
+                    height: 1
+                }
+
+                Rectangle {
+                    width: 52
+                    height: parent.height
+                    color: "#16161D"
+
+                    TextInput {
+                        id: strokeWidthInput
+                        text: strokeWidth
+                        font.pixelSize: 12
+                        anchors.fill: parent
+                        verticalAlignment: Text.AlignVCenter
+                        leftPadding: 5
+                        color: "#FFFFFF"
+                        clip: true
+                        autoScroll: false
+                        selectByMouse: true
+                        validator: RegularExpressionValidator {
+                            regularExpression: /[0-9]+\.[0-9]+/
+                        }
+                    }
+
+                    Label {
+                        height: parent.height
+                        text: qsTr("Width")
+                        font.pixelSize: 12
+                        color: "#7C7C7C"
+                        verticalAlignment: Text.AlignVCenter
+                        anchors.right: parent.right
+                        anchors.rightMargin: 0
+                        anchors.top: parent.top
+                    }
+                }
+            }
+
+            Item {
+                width: 1
+                height: 16
+            }
+
+            Row {
+                height: 40
+
+                Item {
+                    width: 20
+                    height: 1
+                }
+
+                Label {
+                    id: textLabel
+                    width: 28
+                    height: parent.height / 2
+                    text: qsTr("Text")
+                    font.pixelSize: 12
+                    verticalAlignment: Text.AlignVCenter
+                    color: "#9B9B9B"
+                }
+
+                Item {
+                    width: 6
+                    height: 1
+                }
+
+                Rectangle {
+                    width: 220
+                    height: parent.height
+                    color: "#16161D"
+
+                    Flickable {
+                        id: flick
+                        anchors.fill: parent
+                        contentWidth: textInput.paintedWidth
+                        contentHeight: textInput.paintedHeight
+                        boundsBehavior: Flickable.StopAtBounds
+                        clip: true
+
+                        TextEdit {
+                            id: textInput
+                            text: displatText
+                            font.pixelSize: 12
+                            width: flick.width
+                            selectByMouse: true
+                            leftPadding: 5
+                            color: "#FFFFFF"
+                            selectionColor: "#55FFFFFF"
+                            verticalAlignment: Text.AlignVCenter
+                            wrapMode: TextEdit.Wrap
+
+                            onTextChanged: {
+                                dialog.displatText = textInput.text;
+                                textModel.changeText(layerIndex, textInput.text);
+                            }
+                        }
+                    }
+                }
+            }
+
+            Item {
+                width: 1
+                height: 12
+            }
+
+            Row {
+                width: parent.width
+                height: 20
+                spacing: 0
+
+                Item {
+                    width: parent.width - confirmButton.width - 20
+                    height: 1
+                }
+
+                Button {
+                    id: confirmButton
+                    width: 60
+                    height: 20
+
+                    background: Rectangle {
+                        anchors.fill: parent
+                        opacity: enabled ? 1 : 0.3
+                        border.width: 1
+                        radius: 4
+                        color: "#3485F6"
+                    }
+
+                    Text {
+                        anchors.fill: parent
+                        text: qsTr("Confirm")
+                        font.pixelSize: 12
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        color: "#FFFFFF"
+                    }
+                    onClicked: {
+                        textModel.updateTextDocument(layerIndex);
+                        dialog.close();
+                    }
+                }
+            }
+        }
+    }
+
+    ColorDialog {
+        id: selectColorDialog
+
+        property var currentAcceptHandler: null
+
+        title: qsTr("Select Color")
+        color: "#AAAAAA"
+    }
+}

--- a/viewer/qml/TextEditDialog.qml
+++ b/viewer/qml/TextEditDialog.qml
@@ -134,8 +134,8 @@ Popup {
                     height: parent.height
                     topInset: 0
                     bottomInset: 0
-                    model: textModel ? textModel.getFontFamilies() : null
-                    currentIndex: textModel ? textModel.getFontFamilies().indexOf(currentValue) : -1
+                    model: textModel ? textModel.fontFamilies() : null
+                    currentIndex: textModel ? textModel.fontFamilies().indexOf(currentValue) : -1
 
                     background: Rectangle {
                         color: "#16161D"
@@ -185,12 +185,12 @@ Popup {
                             onClicked: {
                                 fontFamilyName.text = modelData;
                                 fontStyleComboBox.currentFontFamily = modelData;
-                                let index = textModel.getFontStyles(modelData).indexOf(fontStyleName.text);
+                                let index = textModel.fontStyles(modelData).indexOf(fontStyleName.text);
                                 if (index >= 0) {
-                                    cbFontStyle.currentIndex = index;
+                                    fontStyleComboBox.currentIndex = index;
                                 } else {
-                                    cbFontStyle.currentIndex = 0;
-                                    fontStyleName.text = textModel.getFontStyles(modelData)[0];
+                                    fontStyleComboBox.currentIndex = 0;
+                                    fontStyleName.text = textModel.fontStyles(modelData)[0];
                                 }
                                 fontFamilyComboBox.currentIndex = fontFamilyComboBox.model.indexOf(modelData);
                                 textModel.changeFontFamily(layerIndex, modelData);
@@ -257,8 +257,8 @@ Popup {
                     height: parent.height
                     topInset: 0
                     bottomInset: 0
-                    model: textModel ? textModel.getFontStyles(currentFontFamily) : null
-                    currentIndex: textModel ? textModel.getFontStyles(currentFontFamily).indexOf(currentValue) : -1
+                    model: textModel ? textModel.fontStyles(currentFontFamily) : null
+                    currentIndex: textModel ? textModel.fontStyles(currentFontFamily).indexOf(currentValue) : -1
 
                     background: Rectangle {
                         color: "#16161D"

--- a/viewer/qml/TextListView.qml
+++ b/viewer/qml/TextListView.qml
@@ -119,15 +119,15 @@ ListView {
                     onClicked: {
                         textModel.recordTextDocument(index);
                         textEditDialog.layerIndex = index;
-                        textEditDialog.fauxBold = textModel.getFauxBold(index);
-                        textEditDialog.fauxItalic = textModel.getFauxItalic(index);
-                        textEditDialog.strokeWidth = textModel.getStrokeWidth(index);
-                        textEditDialog.fillColor = textModel.getFillColor(index);
-                        textEditDialog.strokeColor = textModel.getStrokeColor(index);
-                        textEditDialog.fontSize = textModel.getFontSize(index);
-                        textEditDialog.fontFamily = textModel.getFontFamily(index);
-                        textEditDialog.fontStyle = textModel.getFontStyle(index);
-                        textEditDialog.displatText = textModel.getText(index);
+                        textEditDialog.fauxBold = textModel.fauxBold(index);
+                        textEditDialog.fauxItalic = textModel.fauxItalic(index);
+                        textEditDialog.strokeWidth = textModel.strokeWidth(index);
+                        textEditDialog.fillColor = textModel.fillColor(index);
+                        textEditDialog.strokeColor = textModel.strokeColor(index);
+                        textEditDialog.fontSize = textModel.fontSize(index);
+                        textEditDialog.fontFamily = textModel.fontFamily(index);
+                        textEditDialog.fontStyle = textModel.fontStyle(index);
+                        textEditDialog.displatText = textModel.text(index);
                         textEditDialog.open();
                     }
                 }

--- a/viewer/qml/TextListView.qml
+++ b/viewer/qml/TextListView.qml
@@ -1,0 +1,184 @@
+import QtQuick
+import QtQuick.Controls
+
+ListView {
+    id: listView
+
+    required property var textModel
+
+    property int textHeight: 40
+
+    property alias textEditDialog: textEditDialog
+
+    model: textModel
+    interactive: false
+    boundsBehavior: Flickable.StopAtBounds
+    boundsMovement: Flickable.StopAtBounds
+
+    delegate: Rectangle {
+        height: textHeight
+        width: listView.width
+        color: "#20202A"
+
+        Row {
+            spacing: 0
+            anchors.fill: parent
+
+            Rectangle {
+                width: 30
+                color: "#2D2D37"
+
+                anchors.top: parent.top
+                anchors.topMargin: 0
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: 1
+
+                Text {
+                    text: textModel.convertIndex(index)
+                    color: "#9B9B9B"
+                    font.pixelSize: 12
+                    renderType: Text.NativeRendering
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    anchors.fill: parent
+                }
+            }
+
+            Item {
+                width: 1
+                height: 1
+            }
+
+            Rectangle {
+                width: parent.width - 30 - 1
+                color: "#2D2D37"
+
+                anchors.top: parent.top
+                anchors.topMargin: 0
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: 1
+
+                TextInput {
+                    id: textEdit
+                    text: value
+                    font.pixelSize: 12
+                    horizontalAlignment: TextInput.AlignLeft
+                    verticalAlignment: TextInput.AlignVCenter
+                    renderType: Text.NativeRendering
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                    anchors.right: parent.right
+                    anchors.rightMargin: 100
+                    selectByMouse: true
+                    persistentSelection: true
+                    color: "#FFFFFF"
+                    selectionColor: "#444444"
+                    clip: true
+
+                    onEditingFinished: {
+                        if (!focus) {
+                            listView.textModel.changeText(index, text);
+                        }
+                    }
+
+                    onAccepted: {
+                        focus = false;
+                    }
+
+                    Component.onCompleted: {
+                        ensureVisible(0);
+                    }
+                }
+
+                Button {
+                    id: editButton
+                    height: 18
+                    width: 36
+                    enabled: textEditDialog !== null
+                    anchors.top: parent.top
+                    anchors.topMargin: (textHeight - height) / 2
+                    anchors.right: parent.right
+                    anchors.rightMargin: 32
+                    background: Rectangle {
+                        color: "#4A4A4A"
+                        radius: 9
+                        anchors.fill: parent
+
+                        Text {
+                            text: qsTr("Edit")
+                            font.pixelSize: 10
+                            color: "#FFFFFF"
+                            anchors.fill: parent
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+
+                    onClicked: {
+                        textModel.recordTextDocument(index);
+                        textEditDialog.layerIndex = index;
+                        textEditDialog.fauxBold = textModel.getFauxBold(index);
+                        textEditDialog.fauxItalic = textModel.getFauxItalic(index);
+                        textEditDialog.strokeWidth = textModel.getStrokeWidth(index);
+                        textEditDialog.fillColor = textModel.getFillColor(index);
+                        textEditDialog.strokeColor = textModel.getStrokeColor(index);
+                        textEditDialog.fontSize = textModel.getFontSize(index);
+                        textEditDialog.fontFamily = textModel.getFontFamily(index);
+                        textEditDialog.fontStyle = textModel.getFontStyle(index);
+                        textEditDialog.displatText = textModel.getText(index);
+                        textEditDialog.open();
+                    }
+                }
+
+                Button {
+                    width: 19
+                    height: 19
+                    anchors.top: parent.top
+                    anchors.topMargin: (textHeight - height) / 2 + 2
+                    anchors.right: parent.right
+                    anchors.rightMargin: 10
+                    enabled: canRevert
+                    padding: 0
+                    background: Image {
+                        id: textBack
+                        width: 19
+                        height: 19
+                        opacity: canRevert ? 1.0 : 0.3
+                        fillMode: Image.PreserveAspectFit
+                        source: "qrc:/images/revert.png"
+                    }
+                    onClicked: {
+                        textModel.revertText(index);
+                    }
+                }
+            }
+        }
+
+        Component.onCompleted: {
+            if (parent) {
+                anchors.left = parent.left;
+                anchors.right = parent.right;
+            }
+        }
+    }
+
+    TextEditDialog {
+        id: textEditDialog
+        textModel: listView.textModel
+
+        parent: Overlay.overlay
+
+        onOpened: {
+            if (parent) {
+                x = (parent.width - width) / 2;
+                y = (parent.height - height) / 2;
+            }
+        }
+
+        onClosed: {
+            layerIndex = -1;
+        }
+    }
+}

--- a/viewer/res.qrc
+++ b/viewer/res.qrc
@@ -18,6 +18,9 @@
         <file>images/icon-edit.png</file>
         <file>images/icon-save.png</file>
         <file>images/icon-close.png</file>
+        <file>images/revert.png</file>
+        <file>images/checked.png</file>
+        <file>images/unchecked.png</file>
 
         <!-- svg -->
         <file>images/close-dark.svg</file>
@@ -36,6 +39,8 @@
         <file>qml/FileTreeViewDelegate.qml</file>
         <file>qml/SaveFileDialog.qml</file>
         <file>qml/AttributeEditDialog.qml</file>
+        <file>qml/TextListView.qml</file>
+        <file>qml/TextEditDialog.qml</file>
         <file>qml/utils/qmldir</file>
         <file>qml/utils/Utils.qml</file>
         <file>qml/components/PAGMenu.qml</file>

--- a/viewer/src/editing/PAGTextLayerModel.cpp
+++ b/viewer/src/editing/PAGTextLayerModel.cpp
@@ -1,0 +1,391 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "PAGTextLayerModel.h"
+#include <QFontDatabase>
+#include <QRegularExpression>
+#include "utils/StringUtils.h"
+
+namespace pag {
+
+PAGTextLayerModel::PAGTextLayerModel(QObject* parent) : QAbstractListModel(parent) {
+}
+
+int PAGTextLayerModel::rowCount(const QModelIndex& parent) const {
+  Q_UNUSED(parent);
+  return static_cast<int>(textLayers.count());
+}
+
+QVariant PAGTextLayerModel::data(const QModelIndex& index, int role) const {
+  if ((index.row()) < 0 || (index.row() >= textLayers.count())) {
+    return {};
+  }
+
+  if (role == static_cast<int>(PAGTextLayerRoles::ValueRole)) {
+    return QString::fromStdString(textLayers[index.row()]->text);
+  }
+  if (role == static_cast<int>(PAGTextLayerRoles::RevertRole)) {
+    return {revertSet.find(index.row()) != revertSet.end()};
+  }
+
+  return {};
+}
+
+void PAGTextLayerModel::setFile(const std::shared_ptr<PAGFile>& pagFile,
+                                const std::string& filePath) {
+  Q_UNUSED(filePath);
+  beginResetModel();
+  textLayers.clear();
+  revertSet.clear();
+  endResetModel();
+
+  if (pagFile == nullptr) {
+    return;
+  }
+
+  this->pagFile = pagFile;
+  auto editableList = pagFile->getEditableIndices(LayerType::Text);
+  if (editableList.empty()) {
+    return;
+  }
+
+  beginResetModel();
+  for (auto i : editableList) {
+    textLayers.append(pagFile->getTextData(i));
+  }
+  endResetModel();
+}
+
+void PAGTextLayerModel::revertText(int index) {
+  if (index < 0 || index >= textLayers.count()) {
+    return;
+  }
+  pagFile->replaceText(convertIndex(index), nullptr);
+  beginResetModel();
+  revertSet.remove(index);
+  textLayers.removeAt(index);
+  auto newTextDocument = pagFile->getTextData(convertIndex(index));
+  textLayers.insert(index, newTextDocument);
+  endResetModel();
+}
+
+int PAGTextLayerModel::convertIndex(int index) {
+  auto editableIndices = pagFile->getEditableIndices(LayerType::Text);
+  if ((index < 0) || (index >= static_cast<int>(editableIndices.size()))) {
+    return index;
+  }
+
+  return editableIndices.at(index);
+}
+
+QStringList PAGTextLayerModel::getFontFamilies() {
+  if (fontFamilies.count() > 0) {
+    return fontFamilies;
+  }
+
+  fontFamilies = QFontDatabase::families();
+  fontFamilies.removeDuplicates();
+  return fontFamilies;
+}
+
+QStringList PAGTextLayerModel::getFontStyles(const QString& fontFamily) {
+  if (fontFamily.isEmpty()) {
+    return {};
+  }
+
+  return QFontDatabase::styles(fontFamily);
+}
+
+bool PAGTextLayerModel::getFauxBold(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return false;
+  }
+
+  return textLayers.at(index)->fauxBold;
+}
+
+bool PAGTextLayerModel::getFauxItalic(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return false;
+  }
+
+  return textLayers.at(index)->fauxItalic;
+}
+
+double PAGTextLayerModel::getFontSize(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return 0.0;
+  }
+
+  return textLayers.at(index)->fontSize;
+}
+
+double PAGTextLayerModel::getStrokeWidth(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return 0.0;
+  }
+
+  return textLayers.at(index)->strokeWidth;
+}
+
+QString PAGTextLayerModel::getText(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return "";
+  }
+
+  return QString::fromStdString(textLayers.at(index)->text);
+}
+
+QString PAGTextLayerModel::getFontStyle(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return "";
+  }
+
+  return QString::fromStdString(textLayers.at(index)->fontStyle);
+}
+
+QString PAGTextLayerModel::getFontFamily(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return "";
+  }
+
+  return QString::fromStdString(textLayers.at(index)->fontFamily);
+}
+
+QString PAGTextLayerModel::getFillColor(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return "";
+  }
+
+  return Utils::PAGColorToQString(textLayers.at(index)->fillColor);
+}
+
+QString PAGTextLayerModel::getStrokeColor(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return "";
+  }
+
+  return Utils::PAGColorToQString(textLayers.at(index)->strokeColor);
+}
+
+void PAGTextLayerModel::changeText(int index, const QString& text) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+  auto textDocument = textLayers.at(index);
+  if (textDocument->text == text) {
+    return;
+  }
+  auto textData = pagFile->getTextData(convertIndex(index))->text;
+  if (textData != text.toStdString()) {
+    revertSet.insert(index);
+  }
+  textDocument->text = text.toStdString();
+  beginResetModel();
+  endResetModel();
+  pagFile->replaceText(convertIndex(index), textDocument);
+}
+
+void PAGTextLayerModel::changeFontSize(int index, double fontSize) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+
+  auto textDocument = textLayers.at(index);
+  textDocument->fontSize = static_cast<float>(fontSize);
+  pagFile->replaceText(convertIndex(index), textDocument);
+}
+
+void PAGTextLayerModel::changeFontStyle(int index, const QString& fontStyle) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+
+  auto textDocument = textLayers.at(index);
+  textDocument->fontStyle = fontStyle.toStdString();
+  pagFile->replaceText(convertIndex(index), textDocument);
+}
+
+void PAGTextLayerModel::changeFontFamily(int index, const QString& fontFamily) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+
+  auto textDocument = textLayers.at(index);
+  textDocument->fontFamily = fontFamily.toStdString();
+  pagFile->replaceText(convertIndex(index), textDocument);
+}
+
+void PAGTextLayerModel::changeFillColor(int index, const QString& color) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+
+  auto textDocument = textLayers.at(index);
+  textDocument->fillColor = Utils::QStringToPAGColor(color);
+  pagFile->replaceText(convertIndex(index), textDocument);
+}
+
+void PAGTextLayerModel::changeStrokeColor(int index, const QString& color) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+
+  auto textDocument = textLayers.at(index);
+  textDocument->strokeColor = Utils::QStringToPAGColor(color);
+  pagFile->replaceText(convertIndex(index), textDocument);
+}
+
+void PAGTextLayerModel::changeStrokeWidth(int index, double width) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+
+  auto textDocument = textLayers.at(index);
+  textDocument->applyStroke = true;
+  textDocument->strokeWidth = static_cast<float>(width);
+  pagFile->replaceText(convertIndex(index), textDocument);
+}
+
+void PAGTextLayerModel::changeFauxBold(int index, bool bold) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+
+  auto textDocument = textLayers.at(index);
+  textDocument->fauxBold = bold;
+  pagFile->replaceText(convertIndex(index), textDocument);
+}
+
+void PAGTextLayerModel::changeFauxItalic(int index, bool italic) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+
+  auto textDocument = textLayers.at(index);
+  textDocument->fauxItalic = italic;
+  pagFile->replaceText(convertIndex(index), textDocument);
+}
+
+void PAGTextLayerModel::recordTextDocument(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+  auto textDocument = textLayers.at(index);
+  copyTextDocument(textDocument.get(), &oldTextDocument);
+}
+
+void PAGTextLayerModel::updateTextDocument(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+  auto textData = pagFile->getTextData(convertIndex(index));
+  auto textDucoument = textLayers.at(index);
+  if (compareTextDocument(textDucoument.get(), &oldTextDocument)) {
+    revertSet.remove(index);
+  } else {
+    revertSet.insert(index);
+  }
+
+  beginResetModel();
+  endResetModel();
+}
+
+void PAGTextLayerModel::revertTextDocument(int index) {
+  if (index < 0 || index >= textLayers.size()) {
+    return;
+  }
+
+  auto textDocument = textLayers.at(index);
+  copyTextDocument(&oldTextDocument, textDocument.get());
+
+  auto defaultTextDocument = pagFile->getTextData(convertIndex(index));
+  if (compareTextDocument(defaultTextDocument.get(), textDocument.get())) {
+    revertSet.remove(index);
+  } else {
+    revertSet.insert(index);
+  }
+
+  beginResetModel();
+  endResetModel();
+}
+
+QHash<int, QByteArray> PAGTextLayerModel::roleNames() const {
+  static QHash<int, QByteArray> roles = {
+      {static_cast<int>(PAGTextLayerRoles::ValueRole), "value"},
+      {static_cast<int>(PAGTextLayerRoles::RevertRole), "canRevert"}};
+  return roles;
+}
+
+void PAGTextLayerModel::copyTextDocument(TextDocument* oldTextDocument,
+                                         TextDocument* newTextDocument) {
+  newTextDocument->text = oldTextDocument->text;
+  newTextDocument->fauxBold = oldTextDocument->fauxBold;
+  newTextDocument->fauxItalic = oldTextDocument->fauxItalic;
+  newTextDocument->fontSize = oldTextDocument->fontSize;
+  newTextDocument->fontFamily = oldTextDocument->fontFamily;
+  newTextDocument->fontStyle = oldTextDocument->fontStyle;
+  newTextDocument->fillColor = oldTextDocument->fillColor;
+  newTextDocument->strokeColor = oldTextDocument->strokeColor;
+  if (oldTextDocument->applyStroke) {
+    newTextDocument->applyStroke = true;
+    newTextDocument->strokeWidth = oldTextDocument->strokeWidth;
+  } else {
+    newTextDocument->applyStroke = false;
+    newTextDocument->strokeWidth = 0;
+  }
+}
+
+bool PAGTextLayerModel::compareTextDocument(TextDocument* oldTextDocument,
+                                            TextDocument* newTextDocument) {
+  if ((oldTextDocument == nullptr) || (newTextDocument == nullptr)) {
+    return false;
+  }
+
+  if (oldTextDocument->applyStroke != newTextDocument->applyStroke) {
+    return false;
+  }
+  if (oldTextDocument->strokeWidth != newTextDocument->strokeWidth) {
+    return false;
+  }
+  if (oldTextDocument->strokeColor != newTextDocument->strokeColor) {
+    return false;
+  }
+  if (oldTextDocument->fauxBold != newTextDocument->fauxBold) {
+    return false;
+  }
+  if (oldTextDocument->fauxItalic != newTextDocument->fauxItalic) {
+    return false;
+  }
+  if (oldTextDocument->text != newTextDocument->text) {
+    return false;
+  }
+  if (oldTextDocument->fontSize != newTextDocument->fontSize) {
+    return false;
+  }
+  if (oldTextDocument->fontFamily != newTextDocument->fontFamily) {
+    return false;
+  }
+  if (oldTextDocument->fontStyle != newTextDocument->fontStyle) {
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace pag

--- a/viewer/src/editing/PAGTextLayerModel.cpp
+++ b/viewer/src/editing/PAGTextLayerModel.cpp
@@ -359,8 +359,6 @@ bool PAGTextLayerModel::compareTextDocument(TextDocument* oldTextDocument,
              newTextDocument->strokeWidth, newTextDocument->text, newTextDocument->justification,
              newTextDocument->leading, newTextDocument->tracking, newTextDocument->backgroundColor,
              newTextDocument->backgroundAlpha, newTextDocument->direction);
-
-  return true;
 }
 
 }  // namespace pag

--- a/viewer/src/editing/PAGTextLayerModel.cpp
+++ b/viewer/src/editing/PAGTextLayerModel.cpp
@@ -65,8 +65,8 @@ void PAGTextLayerModel::setFile(const std::shared_ptr<PAGFile>& pagFile,
   }
 
   beginResetModel();
-  for (auto i : editableList) {
-    textLayers.append(pagFile->getTextData(i));
+  for (auto layerIndex : editableList) {
+    textLayers.append(pagFile->getTextData(layerIndex));
   }
   endResetModel();
 }
@@ -93,17 +93,17 @@ int PAGTextLayerModel::convertIndex(int index) {
   return editableIndices.at(index);
 }
 
-QStringList PAGTextLayerModel::getFontFamilies() {
-  if (fontFamilies.count() > 0) {
-    return fontFamilies;
+QStringList PAGTextLayerModel::fontFamilies() {
+  if (fontFamilyList.count() > 0) {
+    return fontFamilyList;
   }
 
-  fontFamilies = QFontDatabase::families();
-  fontFamilies.removeDuplicates();
-  return fontFamilies;
+  fontFamilyList = QFontDatabase::families();
+  fontFamilyList.removeDuplicates();
+  return fontFamilyList;
 }
 
-QStringList PAGTextLayerModel::getFontStyles(const QString& fontFamily) {
+QStringList PAGTextLayerModel::fontStyles(const QString& fontFamily) {
   if (fontFamily.isEmpty()) {
     return {};
   }
@@ -111,7 +111,7 @@ QStringList PAGTextLayerModel::getFontStyles(const QString& fontFamily) {
   return QFontDatabase::styles(fontFamily);
 }
 
-bool PAGTextLayerModel::getFauxBold(int index) {
+bool PAGTextLayerModel::fauxBold(int index) {
   if (index < 0 || index >= textLayers.size()) {
     return false;
   }
@@ -119,7 +119,7 @@ bool PAGTextLayerModel::getFauxBold(int index) {
   return textLayers.at(index)->fauxBold;
 }
 
-bool PAGTextLayerModel::getFauxItalic(int index) {
+bool PAGTextLayerModel::fauxItalic(int index) {
   if (index < 0 || index >= textLayers.size()) {
     return false;
   }
@@ -127,7 +127,7 @@ bool PAGTextLayerModel::getFauxItalic(int index) {
   return textLayers.at(index)->fauxItalic;
 }
 
-double PAGTextLayerModel::getFontSize(int index) {
+double PAGTextLayerModel::fontSize(int index) {
   if (index < 0 || index >= textLayers.size()) {
     return 0.0;
   }
@@ -135,7 +135,7 @@ double PAGTextLayerModel::getFontSize(int index) {
   return textLayers.at(index)->fontSize;
 }
 
-double PAGTextLayerModel::getStrokeWidth(int index) {
+double PAGTextLayerModel::strokeWidth(int index) {
   if (index < 0 || index >= textLayers.size()) {
     return 0.0;
   }
@@ -143,7 +143,7 @@ double PAGTextLayerModel::getStrokeWidth(int index) {
   return textLayers.at(index)->strokeWidth;
 }
 
-QString PAGTextLayerModel::getText(int index) {
+QString PAGTextLayerModel::text(int index) {
   if (index < 0 || index >= textLayers.size()) {
     return "";
   }
@@ -151,7 +151,7 @@ QString PAGTextLayerModel::getText(int index) {
   return QString::fromStdString(textLayers.at(index)->text);
 }
 
-QString PAGTextLayerModel::getFontStyle(int index) {
+QString PAGTextLayerModel::fontStyle(int index) {
   if (index < 0 || index >= textLayers.size()) {
     return "";
   }
@@ -159,7 +159,7 @@ QString PAGTextLayerModel::getFontStyle(int index) {
   return QString::fromStdString(textLayers.at(index)->fontStyle);
 }
 
-QString PAGTextLayerModel::getFontFamily(int index) {
+QString PAGTextLayerModel::fontFamily(int index) {
   if (index < 0 || index >= textLayers.size()) {
     return "";
   }
@@ -167,20 +167,20 @@ QString PAGTextLayerModel::getFontFamily(int index) {
   return QString::fromStdString(textLayers.at(index)->fontFamily);
 }
 
-QString PAGTextLayerModel::getFillColor(int index) {
+QString PAGTextLayerModel::fillColor(int index) {
   if (index < 0 || index >= textLayers.size()) {
     return "";
   }
 
-  return Utils::PAGColorToQString(textLayers.at(index)->fillColor);
+  return Utils::ColorToQString(textLayers.at(index)->fillColor);
 }
 
-QString PAGTextLayerModel::getStrokeColor(int index) {
+QString PAGTextLayerModel::strokeColor(int index) {
   if (index < 0 || index >= textLayers.size()) {
     return "";
   }
 
-  return Utils::PAGColorToQString(textLayers.at(index)->strokeColor);
+  return Utils::ColorToQString(textLayers.at(index)->strokeColor);
 }
 
 void PAGTextLayerModel::changeText(int index, const QString& text) {
@@ -237,7 +237,7 @@ void PAGTextLayerModel::changeFillColor(int index, const QString& color) {
   }
 
   auto textDocument = textLayers.at(index);
-  textDocument->fillColor = Utils::QStringToPAGColor(color);
+  textDocument->fillColor = Utils::QStringToColor(color);
   pagFile->replaceText(convertIndex(index), textDocument);
 }
 
@@ -247,7 +247,7 @@ void PAGTextLayerModel::changeStrokeColor(int index, const QString& color) {
   }
 
   auto textDocument = textLayers.at(index);
-  textDocument->strokeColor = Utils::QStringToPAGColor(color);
+  textDocument->strokeColor = Utils::QStringToColor(color);
   pagFile->replaceText(convertIndex(index), textDocument);
 }
 

--- a/viewer/src/editing/PAGTextLayerModel.h
+++ b/viewer/src/editing/PAGTextLayerModel.h
@@ -67,7 +67,6 @@ class PAGTextLayerModel : public QAbstractListModel {
   QHash<int, QByteArray> roleNames() const Q_DECL_OVERRIDE;
 
  private:
-  void copyTextDocument(TextDocument* oldTextDocument, TextDocument* newTextDocument);
   bool compareTextDocument(TextDocument* oldTextDocument, TextDocument* newTextDocument);
 
  private:

--- a/viewer/src/editing/PAGTextLayerModel.h
+++ b/viewer/src/editing/PAGTextLayerModel.h
@@ -1,0 +1,81 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <QAbstractListModel>
+#include "pag/pag.h"
+
+namespace pag {
+
+class PAGTextLayerModel : public QAbstractListModel {
+  Q_OBJECT
+ public:
+  enum class PAGTextLayerRoles { ValueRole = Qt::UserRole + 1, RevertRole };
+
+  explicit PAGTextLayerModel(QObject* parent = nullptr);
+
+  int rowCount(const QModelIndex& parent) const Q_DECL_OVERRIDE;
+  QVariant data(const QModelIndex& index, int role) const Q_DECL_OVERRIDE;
+
+  Q_SLOT void setFile(const std::shared_ptr<PAGFile>& pagFile, const std::string& filePath);
+
+  Q_INVOKABLE void revertText(int index);
+  Q_INVOKABLE int convertIndex(int index);
+
+  Q_INVOKABLE QStringList getFontFamilies();
+  Q_INVOKABLE QStringList getFontStyles(const QString& fontFamily);
+  Q_INVOKABLE bool getFauxBold(int index);
+  Q_INVOKABLE bool getFauxItalic(int index);
+  Q_INVOKABLE double getFontSize(int index);
+  Q_INVOKABLE double getStrokeWidth(int index);
+  Q_INVOKABLE QString getText(int index);
+  Q_INVOKABLE QString getFontStyle(int index);
+  Q_INVOKABLE QString getFontFamily(int index);
+  Q_INVOKABLE QString getFillColor(int index);
+  Q_INVOKABLE QString getStrokeColor(int index);
+
+  Q_INVOKABLE void changeText(int index, const QString& text);
+  Q_INVOKABLE void changeFontSize(int index, double fontSize);
+  Q_INVOKABLE void changeFontStyle(int index, const QString& fontStyle);
+  Q_INVOKABLE void changeFontFamily(int index, const QString& fontFamily);
+  Q_INVOKABLE void changeFillColor(int index, const QString& color);
+  Q_INVOKABLE void changeStrokeColor(int index, const QString& color);
+  Q_INVOKABLE void changeStrokeWidth(int index, double width);
+  Q_INVOKABLE void changeFauxBold(int index, bool bold);
+  Q_INVOKABLE void changeFauxItalic(int index, bool italic);
+  Q_INVOKABLE void recordTextDocument(int index);
+  Q_INVOKABLE void updateTextDocument(int index);
+  Q_INVOKABLE void revertTextDocument(int index);
+
+ protected:
+  QHash<int, QByteArray> roleNames() const Q_DECL_OVERRIDE;
+
+ private:
+  void copyTextDocument(TextDocument* oldTextDocument, TextDocument* newTextDocument);
+  bool compareTextDocument(TextDocument* oldTextDocument, TextDocument* newTextDocument);
+
+ private:
+  TextDocument oldTextDocument = {};
+  QSet<int> revertSet = {};
+  QStringList fontFamilies = {};
+  QList<TextDocumentHandle> textLayers = {};
+  std::shared_ptr<PAGFile> pagFile = nullptr;
+};
+
+}  // namespace pag

--- a/viewer/src/editing/PAGTextLayerModel.h
+++ b/viewer/src/editing/PAGTextLayerModel.h
@@ -38,17 +38,17 @@ class PAGTextLayerModel : public QAbstractListModel {
   Q_INVOKABLE void revertText(int index);
   Q_INVOKABLE int convertIndex(int index);
 
-  Q_INVOKABLE QStringList getFontFamilies();
-  Q_INVOKABLE QStringList getFontStyles(const QString& fontFamily);
-  Q_INVOKABLE bool getFauxBold(int index);
-  Q_INVOKABLE bool getFauxItalic(int index);
-  Q_INVOKABLE double getFontSize(int index);
-  Q_INVOKABLE double getStrokeWidth(int index);
-  Q_INVOKABLE QString getText(int index);
-  Q_INVOKABLE QString getFontStyle(int index);
-  Q_INVOKABLE QString getFontFamily(int index);
-  Q_INVOKABLE QString getFillColor(int index);
-  Q_INVOKABLE QString getStrokeColor(int index);
+  Q_INVOKABLE QStringList fontFamilies();
+  Q_INVOKABLE QStringList fontStyles(const QString& fontFamily);
+  Q_INVOKABLE bool fauxBold(int index);
+  Q_INVOKABLE bool fauxItalic(int index);
+  Q_INVOKABLE double fontSize(int index);
+  Q_INVOKABLE double strokeWidth(int index);
+  Q_INVOKABLE QString text(int index);
+  Q_INVOKABLE QString fontStyle(int index);
+  Q_INVOKABLE QString fontFamily(int index);
+  Q_INVOKABLE QString fillColor(int index);
+  Q_INVOKABLE QString strokeColor(int index);
 
   Q_INVOKABLE void changeText(int index, const QString& text);
   Q_INVOKABLE void changeFontSize(int index, double fontSize);
@@ -73,7 +73,7 @@ class PAGTextLayerModel : public QAbstractListModel {
  private:
   TextDocument oldTextDocument = {};
   QSet<int> revertSet = {};
-  QStringList fontFamilies = {};
+  QStringList fontFamilyList = {};
   QList<TextDocumentHandle> textLayers = {};
   std::shared_ptr<PAGFile> pagFile = nullptr;
 };

--- a/viewer/src/rendering/PAGView.cpp
+++ b/viewer/src/rendering/PAGView.cpp
@@ -59,8 +59,8 @@ int PAGView::getPAGHeight() const {
   return pagFile->height();
 }
 
-int PAGView::getTextCount() const {
-  return textCount;
+int PAGView::getEditableTextLayerCount() const {
+  return editableTextLayerCount;
 }
 
 QString PAGView::getTotalFrame() const {
@@ -205,8 +205,8 @@ bool PAGView::setFile(const QString& filePath) {
   setProgress(0);
   setIsPlaying(true);
 
-  textCount = static_cast<int>(pagFile->getEditableIndices(LayerType::Text).size());
-  Q_EMIT textCountChanged(textCount);
+  editableTextLayerCount = static_cast<int>(pagFile->getEditableIndices(LayerType::Text).size());
+  Q_EMIT editableTextLayerCountChanged(editableTextLayerCount);
 
   return true;
 }

--- a/viewer/src/rendering/PAGView.cpp
+++ b/viewer/src/rendering/PAGView.cpp
@@ -59,6 +59,10 @@ int PAGView::getPAGHeight() const {
   return pagFile->height();
 }
 
+int PAGView::getTextCount() const {
+  return textCount;
+}
+
 QString PAGView::getTotalFrame() const {
   if (pagFile == nullptr) {
     return "0";
@@ -200,6 +204,9 @@ bool PAGView::setFile(const QString& filePath) {
   Q_EMIT fileChanged(pagFile, strPath);
   setProgress(0);
   setIsPlaying(true);
+
+  textCount = static_cast<int>(pagFile->getEditableIndices(LayerType::Text).size());
+  Q_EMIT textCountChanged(textCount);
 
   return true;
 }

--- a/viewer/src/rendering/PAGView.h
+++ b/viewer/src/rendering/PAGView.h
@@ -34,6 +34,7 @@ class PAGView : public QQuickItem {
 
   Q_PROPERTY(int pagWidth READ getPAGWidth)
   Q_PROPERTY(int pagHeight READ getPAGHeight)
+  Q_PROPERTY(int textCount READ getTextCount NOTIFY textCountChanged)
   Q_PROPERTY(bool isPlaying READ isPlaying WRITE setIsPlaying NOTIFY isPlayingChanged)
   Q_PROPERTY(bool showVideoFrames READ getShowVideoFrames WRITE setShowVideoFrames)
   Q_PROPERTY(double progress READ getProgress WRITE setProgress NOTIFY progressChanged)
@@ -47,6 +48,7 @@ class PAGView : public QQuickItem {
 
   int getPAGWidth() const;
   int getPAGHeight() const;
+  int getTextCount() const;
 
   bool isPlaying() const;
   bool getShowVideoFrames() const;
@@ -63,6 +65,7 @@ class PAGView : public QQuickItem {
   void setShowVideoFrames(bool isShow);
   void setProgress(double progress);
 
+  Q_SIGNAL void textCountChanged(int textCount);
   Q_SIGNAL void isPlayingChanged(bool isPlaying);
   Q_SIGNAL void progressChanged(double progress);
   Q_SIGNAL void fileChanged(const std::shared_ptr<pag::PAGFile>& pagFile,
@@ -80,6 +83,7 @@ class PAGView : public QQuickItem {
   PAGRenderThread* getRenderThread() const;
 
  private:
+  int textCount = 0;
   int64_t lastPlayTime = 0;
   bool isPlaying_ = true;
   qreal lastWidth = 0;

--- a/viewer/src/rendering/PAGView.h
+++ b/viewer/src/rendering/PAGView.h
@@ -34,7 +34,8 @@ class PAGView : public QQuickItem {
 
   Q_PROPERTY(int pagWidth READ getPAGWidth)
   Q_PROPERTY(int pagHeight READ getPAGHeight)
-  Q_PROPERTY(int textCount READ getTextCount NOTIFY textCountChanged)
+  Q_PROPERTY(int editableTextLayerCount READ getEditableTextLayerCount NOTIFY
+                 editableTextLayerCountChanged)
   Q_PROPERTY(bool isPlaying READ isPlaying WRITE setIsPlaying NOTIFY isPlayingChanged)
   Q_PROPERTY(bool showVideoFrames READ getShowVideoFrames WRITE setShowVideoFrames)
   Q_PROPERTY(double progress READ getProgress WRITE setProgress NOTIFY progressChanged)
@@ -48,7 +49,7 @@ class PAGView : public QQuickItem {
 
   int getPAGWidth() const;
   int getPAGHeight() const;
-  int getTextCount() const;
+  int getEditableTextLayerCount() const;
 
   bool isPlaying() const;
   bool getShowVideoFrames() const;
@@ -65,7 +66,7 @@ class PAGView : public QQuickItem {
   void setShowVideoFrames(bool isShow);
   void setProgress(double progress);
 
-  Q_SIGNAL void textCountChanged(int textCount);
+  Q_SIGNAL void editableTextLayerCountChanged(int editableTextLayerCount);
   Q_SIGNAL void isPlayingChanged(bool isPlaying);
   Q_SIGNAL void progressChanged(double progress);
   Q_SIGNAL void fileChanged(const std::shared_ptr<pag::PAGFile>& pagFile,
@@ -83,7 +84,7 @@ class PAGView : public QQuickItem {
   PAGRenderThread* getRenderThread() const;
 
  private:
-  int textCount = 0;
+  int editableTextLayerCount = 0;
   int64_t lastPlayTime = 0;
   bool isPlaying_ = true;
   qreal lastWidth = 0;

--- a/viewer/src/rendering/PAGWindow.cpp
+++ b/viewer/src/rendering/PAGWindow.cpp
@@ -52,12 +52,14 @@ void PAGWindow::open() {
   treeViewModel = std::make_unique<PAGTreeViewModel>();
   runTimeDataModel = std::make_unique<PAGRunTimeDataModel>();
   editAttributeModel = std::make_unique<PAGEditAttributeModel>();
+  textLayerModel = std::make_unique<PAGTextLayerModel>();
 
   auto context = engine->rootContext();
   context->setContextProperty("windowHelper", windowHelper.get());
   context->setContextProperty("treeViewModel", treeViewModel.get());
   context->setContextProperty("runTimeDataModel", runTimeDataModel.get());
   context->setContextProperty("editAttributeModel", editAttributeModel.get());
+  context->setContextProperty("textLayerModel", textLayerModel.get());
 
   engine->load(QUrl(QStringLiteral("qrc:/qml/Main.qml")));
 
@@ -81,6 +83,7 @@ void PAGWindow::open() {
   connect(pagView, &PAGView::fileChanged, editAttributeModel.get(),
           &PAGEditAttributeModel::setFile);
   connect(pagView, &PAGView::fileChanged, runTimeDataModel.get(), &PAGRunTimeDataModel::setFile);
+  connect(pagView, &PAGView::fileChanged, textLayerModel.get(), &PAGTextLayerModel::setFile);
   connect(renderThread, &PAGRenderThread::frameTimeMetricsReady, runTimeDataModel.get(),
           &PAGRunTimeDataModel::updateData);
 }

--- a/viewer/src/rendering/PAGWindow.h
+++ b/viewer/src/rendering/PAGWindow.h
@@ -23,6 +23,7 @@
 #include "PAGView.h"
 #include "PAGWindowHelper.h"
 #include "editing/PAGEditAttributeModel.h"
+#include "editing/PAGTextLayerModel.h"
 #include "editing/PAGTreeViewModel.h"
 #include "profiling/PAGRunTimeDataModel.h"
 
@@ -52,6 +53,7 @@ class PAGWindow : public QObject {
   std::unique_ptr<PAGTreeViewModel> treeViewModel = nullptr;
   std::unique_ptr<PAGRunTimeDataModel> runTimeDataModel = nullptr;
   std::unique_ptr<PAGEditAttributeModel> editAttributeModel = nullptr;
+  std::unique_ptr<PAGTextLayerModel> textLayerModel = nullptr;
 };
 
 }  // namespace pag

--- a/viewer/src/utils/StringUtils.cpp
+++ b/viewer/src/utils/StringUtils.cpp
@@ -84,7 +84,7 @@ std::string TagCodeToVersion(uint16_t tagCode) {
   return "Unknown";
 }
 
-pag::Color QStringToPAGColor(const QString& color) {
+pag::Color QStringToColor(const QString& color) {
   Color pagColor{};
   auto strColor = color.toStdString();
   auto strColor12 = strColor.substr(1, 2);
@@ -104,32 +104,10 @@ pag::Color QStringToPAGColor(const QString& color) {
   return pagColor;
 }
 
-QString PAGColorToQString(const Color& color) {
-  char R[10] = {0};
-  char G[10] = {0};
-  char B[10] = {0};
-  snprintf(R, 10, "%X", color.red);
-  snprintf(G, 10, "%X", color.green);
-  snprintf(B, 10, "%X", color.blue);
-
-  auto placeHolder = [](char* color) -> void {
-    if (color[1] == 0) {
-      color[1] = color[0];
-      color[0] = 48;
-    }
-  };
-
-  placeHolder(R);
-  placeHolder(G);
-  placeHolder(B);
-
-  QString qColor;
-  qColor.append("#");
-  qColor.append(R);
-  qColor.append(G);
-  qColor.append(B);
-
-  return qColor;
+QString ColorToQString(const Color& color) {
+  char hexColor[8] = {0};
+  snprintf(hexColor, 8, "#%02X%02X%02X", color.red, color.green, color.blue);
+  return {hexColor};
 }
 
 }  // namespace pag::Utils

--- a/viewer/src/utils/StringUtils.cpp
+++ b/viewer/src/utils/StringUtils.cpp
@@ -24,7 +24,6 @@ namespace pag::Utils {
 QString ToQString(double num) {
   QString result;
   return result.setNum(num, 'f', 2);
-  ;
 }
 
 QString ToQString(int32_t num) {
@@ -83,6 +82,54 @@ std::string TagCodeToVersion(uint16_t tagCode) {
     }
   }
   return "Unknown";
+}
+
+pag::Color QStringToPAGColor(const QString& color) {
+  Color pagColor{};
+  auto strColor = color.toStdString();
+  auto strColor12 = strColor.substr(1, 2);
+  auto r = strColor12.c_str();
+  auto strColor34 = strColor.substr(3, 2);
+  auto g = strColor34.c_str();
+  auto strColor56 = strColor.substr(5, 2);
+  auto b = strColor56.c_str();
+
+  char* str;
+  uint8_t red = strtol(r, &str, 16);
+  uint8_t green = strtol(g, &str, 16);
+  uint8_t blue = strtol(b, &str, 16);
+  pagColor.red = red;
+  pagColor.green = green;
+  pagColor.blue = blue;
+  return pagColor;
+}
+
+QString PAGColorToQString(const Color& color) {
+  char R[10] = {0};
+  char G[10] = {0};
+  char B[10] = {0};
+  snprintf(R, 10, "%X", color.red);
+  snprintf(G, 10, "%X", color.green);
+  snprintf(B, 10, "%X", color.blue);
+
+  auto placeHolder = [](char* color) -> void {
+    if (color[1] == 0) {
+      color[1] = color[0];
+      color[0] = 48;
+    }
+  };
+
+  placeHolder(R);
+  placeHolder(G);
+  placeHolder(B);
+
+  QString qColor;
+  qColor.append("#");
+  qColor.append(R);
+  qColor.append(G);
+  qColor.append(B);
+
+  return qColor;
 }
 
 }  // namespace pag::Utils

--- a/viewer/src/utils/StringUtils.h
+++ b/viewer/src/utils/StringUtils.h
@@ -29,7 +29,7 @@ QString ToQString(int64_t num);
 QString GetMemorySizeUnit(int64_t size);
 QString GetMemorySizeNumString(int64_t size);
 std::string TagCodeToVersion(uint16_t tagCode);
-Color QStringToPAGColor(const QString& color);
-QString PAGColorToQString(const Color& color);
+Color QStringToColor(const QString& color);
+QString ColorToQString(const Color& color);
 
 }  // namespace pag::Utils

--- a/viewer/src/utils/StringUtils.h
+++ b/viewer/src/utils/StringUtils.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <QString>
+#include "pag/types.h"
 
 namespace pag::Utils {
 
@@ -28,5 +29,7 @@ QString ToQString(int64_t num);
 QString GetMemorySizeUnit(int64_t size);
 QString GetMemorySizeNumString(int64_t size);
 std::string TagCodeToVersion(uint16_t tagCode);
+Color QStringToPAGColor(const QString& color);
+QString PAGColorToQString(const Color& color);
 
 }  // namespace pag::Utils


### PR DESCRIPTION
1、viewer支持显示可编辑的文本图层
2、viewer支持对可编辑的文本图层的文本进行编辑，支持设置字体、字体风格、字体大小、字体颜色、斜体、加粗、描边等属性