### PR TITLE
Set ES6 target for esbuild output to ensure compatibility with WeChat Mini Program

### DIFF
--- a/web/script/plugin/replace-config.js
+++ b/web/script/plugin/replace-config.js
@@ -313,7 +313,7 @@ export const replaceFunctionConfig = [
   {
     name: 'replace _scriptDir',
     type: 'string',
-    start: `var _scriptDir = import.meta.url;`,
+    start: `var _scriptDir = import_meta.url;`,
     replaceStr: `var _scriptDir = typeof document !== "undefined" && document.currentScript ? document.currentScript.src : void 0;`,
   },
 ];

--- a/web/script/rollup.config.wx.dev.js
+++ b/web/script/rollup.config.wx.dev.js
@@ -16,7 +16,7 @@ export default [
       { banner, file: 'demo/wechat-miniprogram/utils/libpag.js', format: 'cjs', exports: 'auto', sourcemap: false },
     ],
     plugins: [
-      esbuild({ tsconfig: 'tsconfig.json', minify: false }),
+      esbuild({ tsconfig: 'tsconfig.json', minify: false,target: 'es6', }),
       resolve({ extensions: ['.ts', '.js'] }),
       commonJs(),
       replaceFunc(),

--- a/web/script/rollup.config.wx.js
+++ b/web/script/rollup.config.wx.js
@@ -14,7 +14,7 @@ export default [
     input: 'src/wechat/pag.ts',
     output: [{ banner, file: 'wechat/lib/libpag.js', format: 'cjs', exports: 'auto', sourcemap: true }],
     plugins: [
-      esbuild({ tsconfig: 'tsconfig.json', minify: false }),
+      esbuild({ tsconfig: 'tsconfig.json', minify: false,target: 'es6', }),
       resolve({ extensions: ['.ts', '.js'] }),
       commonJs(),
       replaceFunc(),


### PR DESCRIPTION
1、微信小程序中执行npm构建时不支持js代码中使用可选链操作符，因此将esbuild 输出目标设置为 ES6 ，使得生成的js代码中不使用可选链操作符