### PR TITLE
Fix incorrect scale mode caused by File::editableImages is nullptr when all image layers are editable

### DIFF
--- a/src/codec/Codec.cpp
+++ b/src/codec/Codec.cpp
@@ -304,11 +304,18 @@ void Codec::UpdateFileAttributes(std::shared_ptr<File> file, CodecContext* conte
   file->editableImages = context->editableImages;
   file->editableTexts = context->editableTexts;
   file->imageScaleModes = context->imageScaleModes;
-  if (file->editableImages == nullptr && file->imageScaleModes != nullptr &&
-      file->imageLayers.size() == file->imageScaleModes->size()) {
-    file->editableImages = new std::vector<int>(file->imageScaleModes->size());
-    for (size_t i = 0; i < file->editableImages->size(); i++) {
+  if (file->editableImages == nullptr) {
+    auto maxIndex = file->numImages();
+    file->editableImages = new std::vector<int>(maxIndex);
+    for (int i = 0; i < maxIndex; i++) {
       file->editableImages->at(i) = i;
+    }
+  }
+  if (file->editableTexts == nullptr) {
+    auto maxIndex = file->numTexts();
+    file->editableTexts = new std::vector<int>(maxIndex);
+    for (int i = 0; i < maxIndex; i++) {
+      file->editableTexts->at(i) = i;
     }
   }
 }

--- a/src/codec/Codec.cpp
+++ b/src/codec/Codec.cpp
@@ -304,5 +304,12 @@ void Codec::UpdateFileAttributes(std::shared_ptr<File> file, CodecContext* conte
   file->editableImages = context->editableImages;
   file->editableTexts = context->editableTexts;
   file->imageScaleModes = context->imageScaleModes;
+  if (file->editableImages == nullptr && file->imageScaleModes != nullptr &&
+      file->imageLayers.size() == file->imageScaleModes->size()) {
+    file->editableImages = new std::vector<int>(file->imageScaleModes->size());
+    for (size_t i = 0; i < file->editableImages->size(); i++) {
+      file->editableImages->at(i) = i;
+    }
+  }
 }
 }  // namespace pag

--- a/src/codec/tags/EditableIndices.cpp
+++ b/src/codec/tags/EditableIndices.cpp
@@ -34,7 +34,8 @@ void ReadEditableIndices(DecodeStream* stream) {
 }
 
 TagCode WriteEditableIndices(EncodeStream* stream, const File* file) {
-  if (file->editableImages != nullptr) {
+  if (file->editableImages != nullptr &&
+      file->editableImages->size() != static_cast<size_t>(file->numImages())) {
     stream->writeEncodedUint32(static_cast<uint32_t>(file->editableImages->size()));
     for (int index : *file->editableImages) {
       stream->writeEncodedInt32(index);
@@ -43,7 +44,8 @@ TagCode WriteEditableIndices(EncodeStream* stream, const File* file) {
     stream->writeEncodedUint32(0);
   }
 
-  if (file->editableTexts != nullptr) {
+  if (file->editableTexts != nullptr &&
+      file->editableTexts->size() != static_cast<size_t>(file->numTexts())) {
     stream->writeEncodedUint32(static_cast<uint32_t>(file->editableTexts->size()));
     for (int index : *file->editableTexts) {
       stream->writeEncodedInt32(index);

--- a/src/codec/tags/FileTags.cpp
+++ b/src/codec/tags/FileTags.cpp
@@ -178,7 +178,10 @@ void WriteTagsOfFile(EncodeStream* stream, const File* file, PerformanceData* pe
   if (!file->images.empty()) {
     WriteImages(stream, &(file->images));
   }
-  if (file->editableImages != nullptr || file->editableTexts != nullptr) {
+  if ((file->editableImages != nullptr &&
+       file->editableImages->size() != static_cast<size_t>(file->numImages())) ||
+      (file->editableTexts != nullptr &&
+       file->editableTexts->size() != static_cast<size_t>(file->numTexts()))) {
     WriteTag(stream, file, WriteEditableIndices);
   }
   if (file->imageScaleModes != nullptr) {

--- a/src/rendering/layers/PAGFile.cpp
+++ b/src/rendering/layers/PAGFile.cpp
@@ -227,8 +227,6 @@ std::vector<int> PAGFile::getEditableIndices(LayerType layerType) {
         return *file->editableTexts;
       }
       break;
-    case LayerType::Solid:
-      return {-1};
     default:
       break;
   }

--- a/src/rendering/layers/PAGFile.cpp
+++ b/src/rendering/layers/PAGFile.cpp
@@ -216,30 +216,23 @@ bool PAGFile::isPAGFile() const {
 }
 
 std::vector<int> PAGFile::getEditableIndices(LayerType layerType) {
-  int maxIndex = 0;
   switch (layerType) {
     case LayerType::Image:
       if (file->editableImages != nullptr) {
         return *file->editableImages;
       }
-      maxIndex = file->numImages();
       break;
     case LayerType::Text:
       if (file->editableTexts != nullptr) {
         return *file->editableTexts;
       }
-      maxIndex = file->numTexts();
       break;
     case LayerType::Solid:
       return {-1};
     default:
       break;
   }
-  std::vector<int> result;
-  for (int i = 0; i < maxIndex; i++) {
-    result.emplace_back(i);
-  }
-  return result;
+  return {};
 }
 
 Frame PAGFile::stretchedFrameDuration() const {

--- a/src/rendering/layers/PAGImageLayer.cpp
+++ b/src/rendering/layers/PAGImageLayer.cpp
@@ -682,17 +682,13 @@ PAGScaleMode PAGImageLayer::getDefaultScaleMode() {
   if (imageLayer && imageLayer->imageFillRule) {
     return imageLayer->imageFillRule->scaleMode;
   }
-  if (file != nullptr && file->imageScaleModes != nullptr) {
-    if (file->editableImages != nullptr) {
-      auto iter =
-          std::find(file->editableImages->begin(), file->editableImages->end(), editableIndex());
-      auto distance = std::distance(file->editableImages->begin(), iter);
-      if (iter != file->editableImages->end() &&
-          static_cast<size_t>(distance) < file->imageScaleModes->size()) {
-        return file->imageScaleModes->at(distance);
-      }
-    } else if (file->imageScaleModes->size() > static_cast<size_t>(editableIndex())) {
-      return file->imageScaleModes->at(editableIndex());
+  if (file && file->editableImages != nullptr && file->imageScaleModes != nullptr) {
+    auto iter =
+        std::find(file->editableImages->begin(), file->editableImages->end(), editableIndex());
+    auto distance = std::distance(file->editableImages->begin(), iter);
+    if (iter != file->editableImages->end() &&
+        static_cast<size_t>(distance) < file->imageScaleModes->size()) {
+      return file->imageScaleModes->at(distance);
     }
   }
 

--- a/src/rendering/layers/PAGImageLayer.cpp
+++ b/src/rendering/layers/PAGImageLayer.cpp
@@ -682,13 +682,17 @@ PAGScaleMode PAGImageLayer::getDefaultScaleMode() {
   if (imageLayer && imageLayer->imageFillRule) {
     return imageLayer->imageFillRule->scaleMode;
   }
-  if (file && file->editableImages != nullptr && file->imageScaleModes != nullptr) {
-    auto iter =
-        std::find(file->editableImages->begin(), file->editableImages->end(), editableIndex());
-    auto distance = std::distance(file->editableImages->begin(), iter);
-    if (iter != file->editableImages->end() &&
-        static_cast<size_t>(distance) < file->imageScaleModes->size()) {
-      return file->imageScaleModes->at(distance);
+  if (file != nullptr && file->imageScaleModes != nullptr) {
+    if (file->editableImages != nullptr) {
+      auto iter =
+          std::find(file->editableImages->begin(), file->editableImages->end(), editableIndex());
+      auto distance = std::distance(file->editableImages->begin(), iter);
+      if (iter != file->editableImages->end() &&
+          static_cast<size_t>(distance) < file->imageScaleModes->size()) {
+        return file->imageScaleModes->at(distance);
+      }
+    } else if (file->imageScaleModes->size() > static_cast<size_t>(editableIndex())) {
+      return file->imageScaleModes->at(editableIndex());
     }
   }
 


### PR DESCRIPTION
修复File::editableImages在所有image layer都可以编辑的情况下为nullptr导致的image layer的scale mode错误的问题