### PR TITLE
Fix issue where PAG files containing videos fail to play in WeChat browser

### DIFF
--- a/web/src/core/video-reader.ts
+++ b/web/src/core/video-reader.ts
@@ -109,6 +109,7 @@ export class VideoReader {
     if (UHD_RESOLUTION < width || UHD_RESOLUTION < height) {
       this.disablePlaybackRate = true;
     }
+    this.linkPlayer(PAGModule.currentPlayer);
   }
 
   public async prepare(targetFrame: number, playbackRate: number): Promise<void> {
@@ -123,6 +124,7 @@ export class VideoReader {
             await waitVideoCanPlay(this.videoEl!);
           } else {
             try {
+              await waitVideoCanPlay(this.videoEl!);
               await this.play();
             } catch (e) {
               this.setError(e);


### PR DESCRIPTION
1、修复微信浏览器中播放带视频的 pag 文件失败的问题