### PR TITLE
Fix Chinese path display issue on Windows for viewer

### DIFF
--- a/viewer/src/main.cpp
+++ b/viewer/src/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
   QApplication::setWindowIcon(QIcon(":/images/window-icon.png"));
   qmlRegisterType<pag::PAGView>("PAG", 1, 0, "PAGView");
   qmlRegisterType<pag::PAGTaskFactory>("PAG", 1, 0, "PAGTaskFactory");
-  app.openFile(filePath.data());
+  app.openFile(QString::fromLocal8Bit(filePath.data()));
 
   pag::InitUpdater();
 

--- a/viewer/src/rendering/PAGView.cpp
+++ b/viewer/src/rendering/PAGView.cpp
@@ -140,7 +140,7 @@ QString PAGView::getFilePath() const {
     return "";
   }
 
-  return QString::fromStdString(pagFile->path());
+  return QString::fromLocal8Bit(pagFile->path().data());
 }
 
 QString PAGView::getDisplayedTime() const {


### PR DESCRIPTION
修复viewer在windows上显示中文路径为乱码的问题