### PR TITLE
Fixed a compilation error when the PAG_USE_C option was enabled on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,10 +445,10 @@ else ()
 endif ()
 
 if (PAG_USE_C)
-    if (ANDROID OR WIN32)
+    if (ANDROID OR (WIN32 AND PAG_USE_ANGLE))
         file(GLOB PLATFORM_FILES src/c/ext/egl/pag_egl_globals.cpp)
         list(APPEND PAG_FILES ${PLATFORM_FILES})
-    endif ()
+    endif()
 endif ()
 
 list(APPEND PAG_INCLUDES ${TGFX_DIR}/include)


### PR DESCRIPTION
修复Windows平台下，开启PAG_USE_C编译选项时的编译错误。