### PR TITLE
Used the OpenGL context of the current thread binding as the shared context when creating a PAGDecoder.

### DIFF
--- a/include/pag/pag.h
+++ b/include/pag/pag.h
@@ -1644,6 +1644,7 @@ class PAG_API PAGDecoder {
   int _numFrames = 0;
   float _frameRate = 30.0f;
   float maxFrameRate = 30.0f;
+  void* sharedContext = nullptr;
   int lastReadIndex = -1;
   tgfx::ImageInfo* lastImageInfo = nullptr;
   uint32_t lastContentVersion = 0;
@@ -1661,7 +1662,7 @@ class PAG_API PAGDecoder {
                                                    int numFrames);
 
   PAGDecoder(std::shared_ptr<PAGComposition> composition, int width, int height, int numFrames,
-             float frameRate, float maxFrameRate);
+             float frameRate, float maxFrameRate, void* sharedContext = nullptr);
 
   bool readFrameInternal(int index, std::shared_ptr<BitmapBuffer> bitmap);
   bool renderFrame(std::shared_ptr<PAGComposition> composition, int index,

--- a/src/rendering/CompositionReader.cpp
+++ b/src/rendering/CompositionReader.cpp
@@ -19,11 +19,11 @@
 #include "CompositionReader.h"
 
 namespace pag {
-std::shared_ptr<CompositionReader> CompositionReader::Make(int width, int height) {
+std::shared_ptr<CompositionReader> CompositionReader::Make(int width, int height, void* sharedContext) {
   if (width <= 0 || height <= 0) {
     return nullptr;
   }
-  auto drawable = BitmapDrawable::Make(width, height);
+  auto drawable = BitmapDrawable::Make(width, height, sharedContext);
   if (drawable == nullptr) {
     return nullptr;
   }

--- a/src/rendering/CompositionReader.h
+++ b/src/rendering/CompositionReader.h
@@ -25,7 +25,7 @@
 namespace pag {
 class CompositionReader {
  public:
-  static std::shared_ptr<CompositionReader> Make(int width, int height);
+  static std::shared_ptr<CompositionReader> Make(int width, int height, void* sharedContext = nullptr);
 
   ~CompositionReader();
 

--- a/src/rendering/drawables/BitmapDrawable.cpp
+++ b/src/rendering/drawables/BitmapDrawable.cpp
@@ -20,8 +20,14 @@
 #include "tgfx/gpu/opengl/GLDevice.h"
 
 namespace pag {
-std::shared_ptr<BitmapDrawable> BitmapDrawable::Make(int width, int height) {
-  auto device = tgfx::GLDevice::MakeWithFallback();
+std::shared_ptr<BitmapDrawable> BitmapDrawable::Make(int width, int height, void* sharedContext) {
+  std::shared_ptr<tgfx::GLDevice> device = nullptr;
+  if (sharedContext != nullptr) {
+    device = tgfx::GLDevice::Make(sharedContext);
+  }
+  if (device == nullptr) {
+    device = tgfx::GLDevice::MakeWithFallback();
+  }
   if (device == nullptr || width <= 0 || height <= 0) {
     return nullptr;
   }

--- a/src/rendering/drawables/BitmapDrawable.h
+++ b/src/rendering/drawables/BitmapDrawable.h
@@ -24,7 +24,7 @@
 namespace pag {
 class BitmapDrawable : public Drawable {
  public:
-  static std::shared_ptr<BitmapDrawable> Make(int width, int height);
+  static std::shared_ptr<BitmapDrawable> Make(int width, int height, void* sharedContext = nullptr);
 
   int width() const override {
     return _width;


### PR DESCRIPTION
创建PAGDecoder时，使用当前线程绑定的OpenGL上下文作为SharedContent，解决UE插件中使用UE纹理替换PAGDecoder中占位图，因Context检查失败导致的效果异常问题。