### PR TITLE
Add modulemap copy step for non-Xcode generators when building framework.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,11 @@ if (PAG_BUILD_FRAMEWORK)
             MACOSX_FRAMEWORK_BUNDLE_VERSION ${PAG_VERSION}
             MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${PAG_VERSION})
     set(CMAKE_XCODE_ATTRIBUTE_DEFINES_MODULE YES)
+    if(IOS)
+        set(CMAKE_XCODE_ATTRIBUTE_MODULEMAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/ios/libpag.modulemap)
+    elseif(MACOS)
+        set(CMAKE_XCODE_ATTRIBUTE_MODULEMAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/mac/libpag.modulemap)
+    endif()    
     set(CMAKE_XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER ${PAG_IDENTIFIER})
     if (HasParent)
         set(CMAKE_XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER ${CMAKE_XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER} PARENT_SCOPE)
@@ -593,6 +598,23 @@ if (PAG_BUILD_FRAMEWORK)
     foreach (header ${PAG_PLATFORM_HEADERS})
         set_source_files_properties(${header} PROPERTIES MACOSX_PACKAGE_LOCATION "Headers")
     endforeach ()
+    if (NOT CMAKE_GENERATOR MATCHES "Xcode")
+        if (MACOS)
+            add_custom_command(TARGET pag POST_BUILD
+                WORKING_DIRECTORY "$<TARGET_FILE_DIR:pag>/../../"
+                COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:pag>/Modules"
+                COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_XCODE_ATTRIBUTE_MODULEMAP_FILE}" "$<TARGET_FILE_DIR:pag>/Modules/module.modulemap"
+                COMMAND ${CMAKE_COMMAND} -E create_symlink "Versions/Current/Modules" "Modules"
+                COMMENT "Copying modulemap file to framework/Versions/A/Modules/module.modulemap"
+            )
+        else ()
+            add_custom_command(TARGET pag POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:pag>/Modules"
+                COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_XCODE_ATTRIBUTE_MODULEMAP_FILE}" "$<TARGET_FILE_DIR:pag>/Modules/module.modulemap"
+                COMMENT "Copying modulemap file to framework/Modules/module.modulemap"
+            )
+        endif ()
+    endif ()
 endif ()
 
 if (PAG_BUILD_TESTS)

--- a/ios/libpag.modulemap
+++ b/ios/libpag.modulemap
@@ -1,0 +1,6 @@
+framework module libpag {
+  umbrella header "libpag.h"
+  export *
+
+  module * { export * }
+}

--- a/mac/libpag.modulemap
+++ b/mac/libpag.modulemap
@@ -1,0 +1,6 @@
+framework module libpag {
+  umbrella header "libpag.h"
+  export *
+
+  module * { export * }
+}


### PR DESCRIPTION
## 修改说明

在构建 framework 时，当使用非 Xcode 生成器（如 Ninja、Unix Makefiles 等）时，CMake 不会自动生成 modulemap 配置
本次修改添加了构建后步骤，确保正确生成 modulemap 配置。同时 iOS macOS 的 framework 默认结构不一样，所以进行了针对性的处理逻辑
