### PR TITLE
Fixed an issue where the incorrect calculation of the scaling value of the 3D layer caused the depth test to fail and was not displayed.

### DIFF
--- a/src/rendering/renderers/FilterRenderer.cpp
+++ b/src/rendering/renderers/FilterRenderer.cpp
@@ -40,6 +40,9 @@
 namespace pag {
 
 static float GetScaleFactorLimit(Layer* layer) {
+  if (layer->transform3D != nullptr) {
+    return FLT_MAX;
+  }
   auto scaleFactorLimit = layer->type() == LayerType::Image ? 1.0f : FLT_MAX;
   return scaleFactorLimit;
 }


### PR DESCRIPTION
修复3D图片图层，因最大缩放值限制为1.0影响NDC计算，进而导致深度测试失败图层被剔除不能正常渲染的问题。