### PR TITLE
Optimize NativeDisplayLink to execute VSync callback on UI thread for OHOS platform.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,7 +417,7 @@ elseif (OHOS)
         find_library(NATIVE_BUFFER_LIB native_buffer)
         find_library(NATIVE_WINDOW_LIB native_window)
         find_library(NATIVE_IMAGE_LIB native_image)
-        find_library(NATIVE_VSYNC_LIB native_vsync)
+        find_library(NATIVE_DISPLAY_SOLOIST_LIB native_display_soloist)
         find_library(NATIVE_MEDIA_CODECBASE_LIB native_media_codecbase)
         find_library(NATIVE_MEDIA_CORE_LIB native_media_core)
         find_library(NATIVE_MEDIA_VDEC_LIB native_media_vdec)
@@ -426,7 +426,7 @@ elseif (OHOS)
                 ${IMAGE_SOURCE_LIB} ${ACE_NDK_LIB} ${HILOG_NDK_LIB} ${ACE_NAPI_LIB}
                 ${NATIVE_BUFFER_LIB} ${NATIVE_WINDOW_LIB} ${NATIVE_IMAGE_LIB}
                 ${NATIVE_MEDIA_CODECBASE_LIB} ${NATIVE_MEDIA_CORE_LIB} ${NATIVE_MEDIA_VDEC_LIB}
-                ${NATIVE_VSYNC_LIB} ${NATIVE_RAWFILE_Z_LIB})
+                ${NATIVE_DISPLAY_SOLOIST_LIB} ${NATIVE_RAWFILE_Z_LIB})
 
         file(GLOB_RECURSE PLATFORM_FILES src/platform/ohos/*.*)
         list(APPEND PAG_FILES ${PLATFORM_FILES})

--- a/src/platform/ohos/JPAG.cpp
+++ b/src/platform/ohos/JPAG.cpp
@@ -30,6 +30,7 @@
 #include "platform/ohos/JPAGText.h"
 #include "platform/ohos/JPAGView.h"
 #include "platform/ohos/JsHelper.h"
+#include "platform/ohos/NativeDisplayLink.h"
 
 namespace pag {
 static napi_value SDKVersion(napi_env env, napi_callback_info) {
@@ -67,7 +68,8 @@ static napi_value Init(napi_env env, napi_value exports) {
                 pag::JPAGText::Init(env, exports) && pag::JPAGImage::Init(env, exports) &&
                 pag::JPAGView::Init(env, exports) && pag::JPAGImageView::Init(env, exports) &&
                 pag::JPAGDiskCache::Init(env, exports) &&
-                pag::XComponentHandler::Init(env, exports);
+                pag::XComponentHandler::Init(env, exports) &&
+                pag::NativeDisplayLink::InitThreadSafeFunction(env);
   if (!result) {
     LOGE("PAG InitFailed");
   }

--- a/src/platform/ohos/NativeDisplayLink.cpp
+++ b/src/platform/ohos/NativeDisplayLink.cpp
@@ -17,35 +17,73 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "NativeDisplayLink.h"
-
+#include "base/utils/USE.h"
 namespace pag {
 
-void NativeDisplayLink::PAGVSyncCallback(long long, void* data) {
-  auto displayLink = static_cast<NativeDisplayLink*>(data);
-  displayLink->callback();
-  if (displayLink->playing) {
-    OH_NativeVSync_RequestFrame(displayLink->vSync, &PAGVSyncCallback, displayLink);
+static napi_threadsafe_function js_threadsafe_function = nullptr;
+void NativeDisplayLink::PAGDisplaySoloistCallback(long long timestamp, long long targetTimestamp,
+                                                  void* data) {
+  USE(timestamp);
+  USE(targetTimestamp);
+  if (js_threadsafe_function == nullptr) {
+    return;
   }
+  napi_call_threadsafe_function(js_threadsafe_function, data, napi_tsfn_blocking);
+}
+
+static void CallJsFunction(napi_env env, napi_value callBack, void* context, void* data) {
+  USE(env);
+  USE(callBack);
+  USE(context);
+  auto displayLink = static_cast<NativeDisplayLink*>(data);
+  if (displayLink) {
+    displayLink->update();
+  }
+};
+
+bool NativeDisplayLink::InitThreadSafeFunction(napi_env env) {
+  if (js_threadsafe_function != nullptr) {
+    napi_release_threadsafe_function(js_threadsafe_function, napi_tsfn_release);
+    js_threadsafe_function = nullptr;
+  }
+  napi_value resourceName = nullptr;
+  napi_create_string_utf8(env, "NativeDisplayLink Safe Function", NAPI_AUTO_LENGTH, &resourceName);
+  auto status =
+      napi_create_threadsafe_function(env, nullptr, nullptr, resourceName, 0, 1, nullptr, nullptr,
+                                      nullptr, CallJsFunction, &js_threadsafe_function);
+  return status;
 }
 
 NativeDisplayLink::NativeDisplayLink(std::function<void()> callback) : callback(callback) {
-  char name[] = "pag_vsync";
-  vSync = OH_NativeVSync_Create(name, strlen(name));
+  displaySoloist = OH_DisplaySoloist_Create(true);
+  DisplaySoloist_ExpectedRateRange expectedRateRange{60, 120, 120};
+  OH_DisplaySoloist_SetExpectedFrameRateRange(displaySoloist, &expectedRateRange);
 }
 
 void NativeDisplayLink::start() {
   if (playing == false) {
     playing = true;
-    OH_NativeVSync_RequestFrame(vSync, &PAGVSyncCallback, this);
+    OH_DisplaySoloist_Start(displaySoloist, &PAGDisplaySoloistCallback, this);
   }
 }
 
 void NativeDisplayLink::stop() {
   playing = false;
+  OH_DisplaySoloist_Stop(displaySoloist);
+}
+
+void NativeDisplayLink::update() {
+  if (playing) {
+    callback();
+  }
 }
 
 NativeDisplayLink::~NativeDisplayLink() {
-  OH_NativeVSync_Destroy(vSync);
+  OH_DisplaySoloist_Destroy(displaySoloist);
+  if (js_threadsafe_function != nullptr) {
+    napi_release_threadsafe_function(js_threadsafe_function, napi_tsfn_release);
+    js_threadsafe_function = nullptr;
+  }
 }
 
 }  // namespace pag

--- a/src/platform/ohos/NativeDisplayLink.h
+++ b/src/platform/ohos/NativeDisplayLink.h
@@ -20,24 +20,28 @@
 
 // clang-format off
 #include <stdint.h>
-#include <native_vsync/native_vsync.h>
+#include <napi/native_api.h>
+#include <native_display_soloist/native_display_soloist.h>
 // clang-format on
+#include <atomic>
 #include <functional>
-#include <mutex>
 #include "rendering/utils/DisplayLink.h"
 namespace pag {
 
 class NativeDisplayLink : public DisplayLink {
  public:
+  static bool InitThreadSafeFunction(napi_env env);
+
   explicit NativeDisplayLink(std::function<void()> callback);
   ~NativeDisplayLink() override;
 
   void start() override;
   void stop() override;
+  void update();
 
  private:
-  static void PAGVSyncCallback(long long timestamp, void* data);
-  OH_NativeVSync* vSync = nullptr;
+  static void PAGDisplaySoloistCallback(long long timestamp, long long targetTimestamp, void* data);
+  OH_DisplaySoloist* displaySoloist = nullptr;
   std::function<void()> callback = nullptr;
   std::atomic<bool> playing = false;
 };


### PR DESCRIPTION
优化 OHOS 平台的 NativeDisplayLink 实现，将 VSync 的回调从独立线程切换到 UI 线程（ArkTS 线程）执行。
同时使用 native_display_soloist 替换 native_vsync