### PR TITLE
Update tgfx to b8251c0d and adapt to new GPU API for instanced drawing support.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "92250f90c3cdd7de1c2d9800ee3faf9eea4a5fb7",
+        "commit": "b8251c0dd494a24fafa9735de3c265c20b144c7e",
         "dir": "third_party/tgfx"
       },
       {

--- a/src/rendering/filters/RuntimeFilter.cpp
+++ b/src/rendering/filters/RuntimeFilter.cpp
@@ -100,7 +100,7 @@ std::shared_ptr<tgfx::RenderPipeline> RuntimeFilter::createPipeline(tgfx::GPU* g
   }
 
   tgfx::RenderPipelineDescriptor descriptor = {};
-  descriptor.vertex = tgfx::VertexDescriptor(vertexAttributes());
+  descriptor.vertex.bufferLayouts = {tgfx::VertexBufferLayout(vertexAttributes())};
   descriptor.vertex.module = vertexShader;
   descriptor.fragment.module = fragmentShader;
   tgfx::PipelineColorAttachment colorAttachment = {};
@@ -257,7 +257,7 @@ bool RuntimeFilter::onDraw(tgfx::CommandEncoder* encoder,
   memcpy(data, vertices.data(), vertices.size() * sizeof(float));
   vertexBuffer->unmap();
 
-  renderPass->setVertexBuffer(vertexBuffer);
+  renderPass->setVertexBuffer(0, vertexBuffer);
   renderPass->setTexture(0, inputTextures[0], resources->sampler);
 
   for (size_t i = 1; i < inputTextures.size(); i++) {
@@ -266,7 +266,7 @@ bool RuntimeFilter::onDraw(tgfx::CommandEncoder* encoder,
 
   onUpdateUniforms(renderPass.get(), gpu, inputTextures, offset);
 
-  renderPass->draw(tgfx::PrimitiveType::TriangleStrip, 0, vertexCount());
+  renderPass->draw(tgfx::PrimitiveType::TriangleStrip, vertexCount());
   renderPass->end();
   return true;
 }


### PR DESCRIPTION
## Summary
更新 tgfx 依赖到 b8251c0d 版本，适配新的 GPU API 变更：

- 将 `VertexDescriptor(attributes)` 改为 `VertexBufferLayout` 方式
- `setVertexBuffer` 添加 slot 参数
- `draw` 函数签名调整，参数顺序变化

## Test plan
- [x] 本地编译通过
- [x] 193 个测试用例全部通过