### PR TITLE
Fix intermittent H264EncoderTools not found issue on Windows by waiting for devenv to complete.

### DIFF
--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -139,8 +139,8 @@ if (-not $?) {
     Write-Host "Build H264EncoderTools-x64 failed" -ForegroundColor Red
     exit 1
 }
-& $VSDevEnv $EncoderToolsSlnPath /Rebuild "Release|x64"
-if (-not $?) {
+$process = Start-Process -FilePath $VSDevEnv -ArgumentList "`"$EncoderToolsSlnPath`" /Rebuild `"Release|x64`"" -Wait -PassThru
+if ($process.ExitCode -ne 0) {
     Write-Host "Build H264EncoderTools-x64 failed" -ForegroundColor Red
     exit 1
 }
@@ -179,6 +179,10 @@ Copy-Item -Path $LibFfaudioPath -Destination $ExeDir -Force
 $GeneratedEncorderToolsPath = Join-Path $EncoderToolsSourceDir -ChildPath "x64" |
                               Join-Path -ChildPath "Release" |
                               Join-Path -ChildPath "H264EncoderTools.exe"
+if (-not (Test-Path $GeneratedEncorderToolsPath)) {
+    Write-Host "H264EncoderTools.exe not found at $GeneratedEncorderToolsPath" -ForegroundColor Red
+    exit 1
+}
 Copy-Item -Path $GeneratedEncorderToolsPath -Destination $ExeDir -Force
 
 # 3.3 Copy symbol files


### PR DESCRIPTION
修复 Windows 平台上偶现的无法找到 H264EncoderTools 的问题。

问题原因：devenv.exe 默认异步启动，编译任务在后台进行时脚本已继续执行，导致复制编译产物时文件可能不存在。

修复方案：
1. 使用 Start-Process -Wait -PassThru 确保等待 devenv.exe 完成编译后再继续
2. 添加 H264EncoderTools.exe 存在性检查，若文件不存在则报错退出