### PR TITLE
Fix JNI crash when jBytes is null in SafeConvertToStdString

### DIFF
--- a/src/platform/android/JStringUtil.cpp
+++ b/src/platform/android/JStringUtil.cpp
@@ -48,6 +48,10 @@ std::string SafeConvertToStdString(JNIEnv* env, jstring jText) {
   auto encoding = env->NewStringUTF("utf-8");
   auto jBytes = (jbyteArray)env->CallObjectMethod(jText, GetBytesID, encoding);
   env->DeleteLocalRef(encoding);
+  if (jBytes == nullptr || env->ExceptionCheck()) {
+    env->ExceptionClear();
+    return "";
+  }
   auto textLength = env->GetArrayLength(jBytes);
   if (textLength > 0) {
     char* bytes = new char[textLength];


### PR DESCRIPTION
## Problem

When calling `SafeConvertToStdString`, if `String.getBytes()` returns null (due to OOM or other JNI exceptions), the subsequent `GetArrayLength(jBytes)` call will crash with:

```
JNI DETECTED ERROR IN APPLICATION: java_array == null
```

Related issue: https://github.com/Tencent/libpag/discussions/3045

## Solution

Add null check and exception handling for `jBytes` before calling `GetArrayLength`:

```cpp
if (jBytes == nullptr || env->ExceptionCheck()) {
  env->ExceptionClear();
  return "";
}
```

## Changes

- Added null check for `jBytes` after `CallObjectMethod`
- Added `ExceptionCheck()` to detect pending JNI exceptions
- Call `ExceptionClear()` to clear any pending exception before returning