### PR TITLE
Fix PAGImageView setScaleMode(None) not resetting matrix on HarmonyOS

### DIFF
--- a/src/platform/ohos/JPAGImageView.cpp
+++ b/src/platform/ohos/JPAGImageView.cpp
@@ -730,13 +730,9 @@ bool JPAGImageView::flush() {
 }
 
 void JPAGImageView::refreshMatrixFromScaleMode() {
-  if (_scaleMode == PAGScaleMode::None) {
-    return;
-  }
   if (_decoder == nullptr) {
     return;
   }
-
   _matrix = ToTGFX(ApplyScaleMode(_scaleMode, _decoder->width() / _renderScale,
                                   _decoder->height() / _renderScale, _width, _height));
 }


### PR DESCRIPTION
## Problem

On HarmonyOS, PAGImageView and PAGView behave differently when calling setScaleMode(0):
- PAGView: matrix is correctly reset
- PAGImageView: matrix keeps previous mode effect

Related: https://github.com/Tencent/libpag/discussions/2914

## Solution

Remove early return when scaleMode is None. ApplyScaleMode() already returns identity matrix for None.