### PR TITLE
Limit PAGDecoder scale to 1.0 for pure bitmap sequence compositions to avoid unnecessary upscaling.

### DIFF
--- a/include/pag/pag.h
+++ b/include/pag/pag.h
@@ -951,6 +951,12 @@ class PAG_API PAGComposition : public PAGLayer {
    */
   std::vector<std::shared_ptr<PAGLayer>> getLayersUnderPoint(float localX, float localY);
 
+  /**
+   * Returns true if this PAGComposition and all its descendants contain only BitmapSequences,
+   * without any vector graphics (Shape, Text, Solid layers) or VideoSequences.
+   */
+  bool hasBitmapSequenceOnly() const;
+
  protected:
   int _width = 0;
   int _height = 0;

--- a/src/rendering/PAGDecoder.cpp
+++ b/src/rendering/PAGDecoder.cpp
@@ -107,6 +107,10 @@ std::shared_ptr<PAGDecoder> PAGDecoder::MakeFrom(std::shared_ptr<PAGComposition>
   if (composition == nullptr || maxFrameRate <= 0 || scale <= 0) {
     return nullptr;
   }
+  // Limit scale to 1.0 for pure bitmap sequence compositions
+  if (composition->hasBitmapSequenceOnly()) {
+    scale = std::min(scale, 1.0f);
+  }
   auto width = roundf(static_cast<float>(composition->width()) * scale);
   auto height = roundf(static_cast<float>(composition->height()) * scale);
   auto result = GetFrameCountAndRate(composition, maxFrameRate);

--- a/src/rendering/layers/PAGComposition.cpp
+++ b/src/rendering/layers/PAGComposition.cpp
@@ -680,4 +680,41 @@ void PAGComposition::updateDurationAndFrameRate() {
   }
 }
 
+bool PAGComposition::hasBitmapSequenceOnly() const {
+  auto composition = static_cast<PreComposeLayer*>(layer)->composition;
+  if (composition != nullptr) {
+    auto type = composition->type();
+    if (type == CompositionType::Bitmap || type == CompositionType::Video) {
+      return true;
+    }
+  }
+
+  bool hasSequenceContent = false;
+  for (const auto& childLayer : layers) {
+    auto layerType = childLayer->layerType();
+    switch (layerType) {
+      case LayerType::Shape:
+      case LayerType::Text:
+      case LayerType::Solid:
+      case LayerType::Image:
+        return false;
+      case LayerType::PreCompose: {
+        auto childComposition = std::static_pointer_cast<PAGComposition>(childLayer);
+        if (!childComposition->hasBitmapSequenceOnly()) {
+          return false;
+        }
+        hasSequenceContent = true;
+        break;
+      }
+      case LayerType::Null:
+      case LayerType::Camera:
+        break;
+      default:
+        return false;
+    }
+  }
+
+  return hasSequenceContent;
+}
+
 }  // namespace pag


### PR DESCRIPTION
为纯位图序列的 PAGComposition 添加缩放限制，避免无意义的放大操作，节省内存和性能。