### PR TITLE
Fix codeformat script for PEP 668 and apply code formatting.

### DIFF
--- a/codeformat.sh
+++ b/codeformat.sh
@@ -1,35 +1,40 @@
 #!/usr/bin/env bash
+CLANG_FORMAT="${HOME}/.local/bin/clang-format"
+if [ ! -f "$CLANG_FORMAT" ]; then
+  CLANG_FORMAT=$(which clang-format 2>/dev/null || true)
+fi
+
 if [[ $(uname) == 'Darwin' ]]; then
-  MAC_REQUIRED_TOOLS="python3"
-  for TOOL in ${MAC_REQUIRED_TOOLS[@]}; do
-    if [ ! $(which $TOOL) ]; then
-      if [ ! $(which brew) ]; then
-        echo "Homebrew not found. Trying to install..."
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" ||
-          exit 1
-      fi
-      echo "$TOOL not found. Trying to install..."
-      brew install $TOOL || exit 1
-    fi
-  done
-  clangformat=`clang-format --version`
-  if [[ $clangformat =~ "14." ]]
-  then
-      echo "----$clangformat----"
+  clangformat=$($CLANG_FORMAT --version 2>/dev/null)
+  if [[ $clangformat =~ "14." ]]; then
+    echo "----$clangformat----"
   else
-      echo "----install clang-format----"
-      pip3 install clang-format==14
+    MAC_REQUIRED_TOOLS="python3 pipx"
+    for TOOL in ${MAC_REQUIRED_TOOLS[@]}; do
+      if [ ! $(which $TOOL) ]; then
+        if [ ! $(which brew) ]; then
+          echo "Homebrew not found. Trying to install..."
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" ||
+            exit 1
+        fi
+        echo "$TOOL not found. Trying to install..."
+        brew install $TOOL || exit 1
+      fi
+    done
+    echo "----install clang-format----"
+    pipx install clang-format==14
+    CLANG_FORMAT="${HOME}/.local/bin/clang-format"
   fi
 fi
 
 echo "----begin to scan code format----"
-find include/ -iname '*.h' -print0 | xargs clang-format -i
+find include/ -iname '*.h' -print0 | xargs $CLANG_FORMAT -i
 # shellcheck disable=SC2038
-find src -name "*.cpp" -print  -o -name "*.h" -print  -o -name "*.mm" -print  -o -name "*.m" -print | xargs clang-format -i
+find src -name "*.cpp" -print  -o -name "*.h" -print  -o -name "*.mm" -print  -o -name "*.m" -print | xargs $CLANG_FORMAT -i
 # shellcheck disable=SC2038
-find test \( -path test/framework/lzma \) -prune -o -name "*.cpp" -print  -o -name "*.h" -print | xargs clang-format -i
-find viewer/src  -name "*.cpp" -print  -o -name "*.h" -print  -o -name "*.mm" -print -o -name "*.m" -print -o -name "*.hpp" -print | xargs clang-format -i
-find exporter/src  -name "*.cpp" -print  -o -name "*.h" -print  -o -name "*.mm" -print -o -name "*.m" -print -o -name "*.hpp" -print | xargs clang-format -i
+find test \( -path test/framework/lzma \) -prune -o -name "*.cpp" -print  -o -name "*.h" -print | xargs $CLANG_FORMAT -i
+find viewer/src  -name "*.cpp" -print  -o -name "*.h" -print  -o -name "*.mm" -print -o -name "*.m" -print -o -name "*.hpp" -print | xargs $CLANG_FORMAT -i
+find exporter/src  -name "*.cpp" -print  -o -name "*.h" -print  -o -name "*.mm" -print -o -name "*.m" -print -o -name "*.hpp" -print | xargs $CLANG_FORMAT -i
 
 git diff
 result=`git diff`


### PR DESCRIPTION
修复 codeformat.sh 在新版 Python (3.12+) 环境下安装 clang-format 失败的问题，改用 pipx 安装。

主要改动：
- pip3 install 改为 pipx install，避免 PEP 668 限制
- 设置 PATH 优先使用 pipx 安装的 clang-format 版本
- 应用 clang-format 14.0.0 格式化修正

参考：https://github.com/Tencent/libpag/discussions/3118