### PR TITLE
Update pagx npm package repository URL and add homepage.

### DIFF
--- a/cli/npm/package.json
+++ b/cli/npm/package.json
@@ -5,8 +5,9 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/libpag/libpag"
+    "url": "https://github.com/Tencent/libpag"
   },
+  "homepage": "https://github.com/Tencent/libpag#readme",
   "bin": {
     "pagx": "bin/pagx.js"
   },


### PR DESCRIPTION
将 pagx npm 包的仓库 URL 从 libpag/libpag 更新为 Tencent/libpag，并添加 homepage 字段指向正确的仓库地址。