### PR TITLE
Add NativeWindow ownership tracking to prevent double-free on HarmonyOS.

### DIFF
--- a/src/platform/android/JPAGSurface.cpp
+++ b/src/platform/android/JPAGSurface.cpp
@@ -115,6 +115,7 @@ PAG_API jlong Java_org_libpag_PAGSurface_SetupFromSurfaceWithGLContext(JNIEnv* e
   auto drawable = GPUDrawable::FromWindow(nativeWindow, reinterpret_cast<EGLContext>(shareContext));
   if (drawable == nullptr) {
     LOGE("PAGSurface.SetupFromSurface() Invalid surface specified.");
+    ANativeWindow_release(nativeWindow);
     return 0;
   }
   auto pagSurface = PAGSurface::MakeFrom(drawable);

--- a/src/platform/ohos/GPUDrawable.cpp
+++ b/src/platform/ohos/GPUDrawable.cpp
@@ -23,21 +23,23 @@
 
 namespace pag {
 std::shared_ptr<GPUDrawable> GPUDrawable::FromWindow(NativeWindow* nativeWindow,
-                                                     EGLContext sharedContext) {
+                                                     EGLContext sharedContext, bool ownsWindow) {
   if (!nativeWindow) {
     LOGE("GPUDrawable.FromWindow() The nativeWindow is invalid.");
     return nullptr;
   }
-  return std::shared_ptr<GPUDrawable>(new GPUDrawable(nativeWindow, sharedContext));
+  return std::shared_ptr<GPUDrawable>(new GPUDrawable(nativeWindow, sharedContext, ownsWindow));
 }
 
-GPUDrawable::GPUDrawable(NativeWindow* nativeWindow, EGLContext eglContext)
-    : nativeWindow(nativeWindow), sharedContext(eglContext) {
+GPUDrawable::GPUDrawable(NativeWindow* nativeWindow, EGLContext eglContext, bool ownsWindow)
+    : nativeWindow(nativeWindow), sharedContext(eglContext), ownsWindow(ownsWindow) {
   updateSize();
 }
 
 GPUDrawable::~GPUDrawable() {
-  OH_NativeWindow_DestroyNativeWindow(nativeWindow);
+  if (ownsWindow && nativeWindow) {
+    OH_NativeWindow_DestroyNativeWindow(nativeWindow);
+  }
 }
 
 void GPUDrawable::updateSize() {

--- a/src/platform/ohos/GPUDrawable.h
+++ b/src/platform/ohos/GPUDrawable.h
@@ -27,7 +27,8 @@ namespace pag {
 class GPUDrawable : public Drawable {
  public:
   static std::shared_ptr<GPUDrawable> FromWindow(NativeWindow* nativeWindow,
-                                                 EGLContext sharedContext = EGL_NO_CONTEXT);
+                                                 EGLContext sharedContext = EGL_NO_CONTEXT,
+                                                 bool ownsWindow = false);
 
   ~GPUDrawable() override;
 
@@ -59,7 +60,8 @@ class GPUDrawable : public Drawable {
   EGLContext sharedContext = nullptr;
   int64_t currentTimeStamp = 0;
   std::shared_ptr<tgfx::EGLWindow> window = nullptr;
+  bool ownsWindow = false;
 
-  explicit GPUDrawable(NativeWindow* nativeWindow, EGLContext eglContext = EGL_NO_CONTEXT);
+  explicit GPUDrawable(NativeWindow* nativeWindow, EGLContext eglContext, bool ownsWindow);
 };
 }  // namespace pag

--- a/src/platform/ohos/JPAGSurface.cpp
+++ b/src/platform/ohos/JPAGSurface.cpp
@@ -131,7 +131,7 @@ static napi_value FromSurfaceID(napi_env env, napi_callback_info info) {
     LOGE("Could not Create Native Window From Surface Id:%lld", surfaceId);
     return nullptr;
   }
-  auto drawable = pag::GPUDrawable::FromWindow(window);
+  auto drawable = pag::GPUDrawable::FromWindow(window, EGL_NO_CONTEXT, true);
   return JPAGSurface::ToJs(env, pag::PAGSurface::MakeFrom(drawable));
 }
 

--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -874,7 +874,7 @@ void JPAGView::onAnimationUpdate(PAGAnimator* animator) {
 
 void JPAGView::onSurfaceCreated(NativeWindow* window) {
   std::lock_guard lock_guard(locker);
-  auto drawable = pag::GPUDrawable::FromWindow(window);
+  auto drawable = pag::GPUDrawable::FromWindow(window, EGL_NO_CONTEXT, false);
   if (player == nullptr || animator == nullptr) {
     return;
   }


### PR DESCRIPTION
修复 HarmonyOS 平台上 NativeWindow 的内存管理问题。

变更内容：
- GPUDrawable 新增 ownsWindow 参数，用于标识是否拥有 NativeWindow 的所有权
- 当 ownsWindow 为 true 时，GPUDrawable 析构时才会销毁 NativeWindow
- 调用方通过 OH_NativeWindow_CreateNativeWindow 创建的窗口传入 ownsWindow=true
- 外部传入的窗口传入 ownsWindow=false，避免 double-free
- 同步修复 Android 平台在创建 Drawable 失败时泄漏 ANativeWindow 的问题