### PR TITLE
Fix publish script to update PAGX_MIN in source cli.md before comparing directories

### DIFF
--- a/.codebuddy/skills/pagx/references/cli.md
+++ b/.codebuddy/skills/pagx/references/cli.md
@@ -9,7 +9,7 @@ The `pagx` binary is provided by the `pagx` npm package. Before running any comm
 ensure it is installed and meets the minimum version:
 
 ```bash
-PAGX_MIN="0.1.2"
+PAGX_MIN="0.1.3"
 if ! command -v pagx &>/dev/null; then
   npm install -g @libpag/pagx
 elif [ "$(printf '%s\n' "$PAGX_MIN" "$(pagx -v | awk '{print $2}')" | sort -V | head -1)" != "$PAGX_MIN" ]; then

--- a/cli/npm/package.json
+++ b/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libpag/pagx",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "PAGX command-line tool for validation, rendering, optimization and formatting",
   "license": "Apache-2.0",
   "repository": {

--- a/playground/script/publish.js
+++ b/playground/script/publish.js
@@ -246,14 +246,38 @@ function getCliVersion() {
 }
 
 /**
+ * Update PAGX_MIN version in the source cli.md to match cli/npm/package.json version.
+ */
+function updateSkillCliVersion(cliVersion) {
+  if (!cliVersion) {
+    return;
+  }
+  const cliMdPath = path.join(SKILLS_DIR, 'pagx', 'references', 'cli.md');
+  if (!fs.existsSync(cliMdPath)) {
+    return;
+  }
+  try {
+    let content = fs.readFileSync(cliMdPath, 'utf-8');
+    const updated = content.replace(/PAGX_MIN="[\d.]+"/, `PAGX_MIN="${cliVersion}"`);
+    if (updated !== content) {
+      fs.writeFileSync(cliMdPath, updated, 'utf-8');
+      console.log(`  Updated: ${cliMdPath} (PAGX_MIN="${cliVersion}")`);
+    }
+  } catch (error) {
+    console.warn(`  Warning: Failed to update ${cliMdPath}: ${error.message}`);
+  }
+}
+
+/**
  * Publish skills as static files, zip archives, and documentation pages.
  */
 function publishSkills(outputDir, names) {
   const skillsOutputDir = path.join(outputDir, 'skills');
   let skillsChanged = false;
 
-  // Read CLI version once before the loop to avoid redundant file reads
-  const cliVersion = getCliVersion();
+  // Update PAGX_MIN in source cli.md before comparing, so the source stays in sync
+  // with cli/npm/package.json and dirsEqual caching works correctly.
+  updateSkillCliVersion(getCliVersion());
 
   for (const name of names) {
     const skillSrcDir = path.join(SKILLS_DIR, name);
@@ -277,19 +301,6 @@ function publishSkills(outputDir, names) {
       fs.rmSync(skillDestDir, { recursive: true });
     }
     copyDir(skillSrcDir, skillDestDir);
-
-    // Update PAGX_MIN version in cli.md to match cli/npm/package.json version
-    const cliMdPath = path.join(skillDestDir, 'references', 'cli.md');
-    if (cliVersion && fs.existsSync(cliMdPath)) {
-      try {
-        let cliMdContent = fs.readFileSync(cliMdPath, 'utf-8');
-        cliMdContent = cliMdContent.replace(/PAGX_MIN="[\d.]+"/, `PAGX_MIN="${cliVersion}"`);
-        fs.writeFileSync(cliMdPath, cliMdContent, 'utf-8');
-        console.log(`  Updated: ${cliMdPath} (PAGX_MIN="${cliVersion}")`);
-      } catch (error) {
-        console.warn(`  Warning: Failed to update ${cliMdPath}: ${error.message}`);
-      }
-    }
 
     fs.mkdirSync(skillsOutputDir, { recursive: true });
     if (fs.existsSync(zipPath)) {


### PR DESCRIPTION
修复 publish 脚本中 CLI 版本同步的问题。原来的逻辑是在复制 skills 目录到输出目录之后才修改目标副本中的 PAGX_MIN 版本号，从未更新过源文件，导致源 cli.md 始终停留在旧版本。

改为在 dirsEqual 比较之前先更新源文件中的 PAGX_MIN，使其与 cli/npm/package.json 保持同步，后续复制自然携带最新版本，缓存跳过逻辑也能正确工作。