### PR TITLE
Fix playground homepage showing checkerboard grid through semi-transparent drop zone.

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <div id="container" class="container">
-    <canvas class="canvas" id="pagx-canvas"></canvas>
+    <canvas class="canvas hidden" id="pagx-canvas"></canvas>
     <div id="nav-btns" class="nav-btns">
         <a id="samples-btn" class="nav-btn" href="#samples" title="Samples">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">


### PR DESCRIPTION
修复 playground 首页概率性显示棋盘格背景的问题。原因是 canvas 元素默认没有 hidden class，而 animation loop 在 WASM 加载完成后无条件渲染棋盘格，由于 drop-zone 背景只有 95% 不透明度，棋盘格会透出来。给 canvas 添加默认的 hidden class 即可，文件加载完成后已有逻辑移除 hidden 显示 canvas。