### PR TITLE
fix: move disk cache IO operations to background thread

### DIFF
--- a/src/rendering/caches/DiskCache.cpp
+++ b/src/rendering/caches/DiskCache.cpp
@@ -26,6 +26,84 @@
 
 namespace pag {
 
+// ============================================================================
+// DiskIOQueue Implementation
+// ============================================================================
+
+DiskIOQueue* DiskIOQueue::GetInstance() {
+  static auto& instance = *new DiskIOQueue();
+  return &instance;
+}
+
+DiskIOQueue::DiskIOQueue() {
+  workerThread = std::thread(&DiskIOQueue::workerLoop, this);
+}
+
+DiskIOQueue::~DiskIOQueue() {
+  {
+    std::lock_guard<std::mutex> lock(locker);
+    stopped = true;
+  }
+  condition.notify_one();
+  if (workerThread.joinable()) {
+    workerThread.join();
+  }
+}
+
+void DiskIOQueue::submit(std::function<void()> task) {
+  if (task == nullptr) {
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> lock(locker);
+    tasks.push(std::move(task));
+  }
+  condition.notify_one();
+}
+
+void DiskIOQueue::waitAll() {
+  std::unique_lock<std::mutex> lock(locker);
+  // Wait until the queue is empty AND no task is currently executing.
+  idleCondition.wait(lock, [this] { return tasks.empty() && !executing; });
+}
+
+void DiskIOQueue::workerLoop() {
+  while (true) {
+    std::function<void()> task;
+    {
+      std::unique_lock<std::mutex> lock(locker);
+      condition.wait(lock, [this] { return stopped || !tasks.empty(); });
+      if (stopped && tasks.empty()) {
+        return;
+      }
+      task = std::move(tasks.front());
+      tasks.pop();
+      executing = true;
+    }
+    if (task) {
+      task();
+    }
+    {
+      std::lock_guard<std::mutex> lock(locker);
+      executing = false;
+      if (tasks.empty()) {
+        idleCondition.notify_all();
+      }
+    }
+  }
+}
+
+// ============================================================================
+// DiskCache Implementation
+// ============================================================================
+
+void DiskCache::removeFileAsync(const std::string& filePath) {
+  if (filePath.empty()) {
+    return;
+  }
+  DiskIOQueue::GetInstance()->submit([path = filePath]() { remove(path.c_str()); });
+}
+
 class FileInfo {
  public:
   FileInfo(std::string cacheKey, uint32_t fileID, size_t fileSize = 0)
@@ -71,7 +149,7 @@ void DiskCache::setCacheDir(const std::string& dir) {
     cacheFolder = Directory::JoinPath(cacheDir, "files");
     if (!readConfig()) {
       Directory::VisitFiles(cacheFolder,
-                            [&](const std::string& path, size_t) { remove(path.c_str()); });
+                            [](const std::string& path, size_t) { removeFileAsync(path); });
     }
   }
 }
@@ -102,7 +180,7 @@ DiskCache::DiskCache() {
     cacheFolder = Directory::JoinPath(cacheDir, "files");
     if (!readConfig()) {
       Directory::VisitFiles(cacheFolder,
-                            [&](const std::string& path, size_t) { remove(path.c_str()); });
+                            [](const std::string& path, size_t) { removeFileAsync(path); });
     }
   }
 }
@@ -133,7 +211,7 @@ void DiskCache::removeAll() {
     if (openedFiles.count(fileID) > 0) {
       return;
     }
-    remove(path.c_str());
+    removeFileAsync(path);
   });
   cachedFileIDs.clear();
   cachedFiles.clear();
@@ -258,7 +336,7 @@ bool DiskCache::checkDiskSpace(size_t maxSize) {
       break;
     }
     auto filePath = fileIDToPath(fileInfo->fileID);
-    remove(filePath.c_str());
+    removeFileAsync(filePath);
     totalDiskSize -= fileInfo->fileSize;
     removeFromCachedFiles(fileInfo);
     changed = true;
@@ -332,7 +410,7 @@ bool DiskCache::readConfig() {
     auto fileID = filePathToID(path);
     auto result = cachedFileInfos.find(fileID);
     if (result == cachedFileInfos.end()) {
-      remove(path.c_str());
+      removeFileAsync(path);
     } else {
       result->second->fileSize = fileSize;
     }
@@ -355,17 +433,22 @@ bool DiskCache::readConfig() {
 }
 
 void DiskCache::saveConfig() {
-  Directory::CreateRecursively(Directory::GetParentDirectory(configPath));
-  auto file = fopen(configPath.c_str(), "wb");
-  if (file == nullptr) {
-    return;
-  }
+  // Serialize the config data in memory while still holding the lock (caller holds locker).
   size_t bufferSize = 0;
   for (auto& item : cachedFiles) {
     bufferSize += 8 + item->cacheKey.size();
   }
-  tgfx::Buffer buffer(bufferSize);
-  tgfx::DataView dataView(buffer.bytes(), buffer.size());
+  // If there's nothing to save, write an empty config file synchronously (it's fast).
+  if (bufferSize == 0) {
+    Directory::CreateRecursively(Directory::GetParentDirectory(configPath));
+    auto file = fopen(configPath.c_str(), "wb");
+    if (file != nullptr) {
+      fclose(file);
+    }
+    return;
+  }
+  auto data = std::make_shared<tgfx::Buffer>(bufferSize);
+  tgfx::DataView dataView(data->bytes(), data->size());
   size_t pos = 0;
   for (auto item = cachedFiles.rbegin(); item != cachedFiles.rend(); item++) {
     auto& fileInfo = *item;
@@ -376,8 +459,35 @@ void DiskCache::saveConfig() {
     memcpy(dataView.writableBytes() + pos, cacheKey.data(), cacheKey.size());
     pos += cacheKey.size();
   }
-  fwrite(buffer.data(), 1, bufferSize, file);
-  fclose(file);
+  // Increment the version to coalesce multiple rapid saves. If a newer save is queued
+  // before this one executes, skip this write entirely.
+  auto currentVersion = ++configSaveVersion;
+  auto* versionPtr = &configSaveVersion;
+  // Write to disk asynchronously via DiskIOQueue to avoid blocking the calling thread on IO.
+  // Uses temp file + rename for atomic write to prevent corruption if app exits mid-write.
+  auto path = configPath;
+  auto tempPath = configPath + ".tmp";
+  DiskIOQueue::GetInstance()->submit([path, tempPath, data, bufferSize, currentVersion,
+                                      versionPtr]() {
+    // Skip this write if a newer version has been queued.
+    if (currentVersion != versionPtr->load(std::memory_order_acquire)) {
+      return;
+    }
+    Directory::CreateRecursively(Directory::GetParentDirectory(path));
+    auto file = fopen(tempPath.c_str(), "wb");
+    if (file == nullptr) {
+      return;
+    }
+    auto written = fwrite(data->data(), 1, bufferSize, file);
+    fclose(file);
+    if (written == bufferSize) {
+      // Atomic rename to replace the config file.
+      rename(tempPath.c_str(), path.c_str());
+    } else {
+      // Write failed, remove the incomplete temp file.
+      remove(tempPath.c_str());
+    }
+  });
 }
 
 uint32_t DiskCache::getFileID(const std::string& key) {
@@ -423,7 +533,7 @@ void DiskCache::notifyFileClosed(uint32_t fileID) {
   auto result = cachedFileInfos.find(fileID);
   if (result == cachedFileInfos.end()) {
     auto filePath = fileIDToPath(fileID);
-    remove(filePath.c_str());
+    removeFileAsync(filePath);
   } else {
     auto fileInfo = result->second;
     moveToBeforeOpenedFiles(fileInfo);

--- a/src/rendering/caches/DiskCache.h
+++ b/src/rendering/caches/DiskCache.h
@@ -18,13 +18,53 @@
 
 #pragma once
 
+#include <atomic>
+#include <condition_variable>
+#include <functional>
 #include <list>
+#include <mutex>
+#include <queue>
+#include <thread>
 #include <unordered_map>
 #include "SequenceFile.h"
 #include "pag/types.h"
 
 namespace pag {
 class FileInfo;
+
+/**
+ * A simple serial task queue that executes disk IO tasks on a dedicated background thread.
+ * This ensures ordered execution and provides the ability to wait for all pending tasks.
+ */
+class DiskIOQueue {
+ public:
+  static DiskIOQueue* GetInstance();
+
+  ~DiskIOQueue();
+
+  /**
+   * Submits a task for asynchronous execution on the background thread.
+   */
+  void submit(std::function<void()> task);
+
+  /**
+   * Waits for all pending tasks to complete. Useful during app shutdown.
+   */
+  void waitAll();
+
+ private:
+  DiskIOQueue();
+
+  void workerLoop();
+
+  std::mutex locker;
+  std::condition_variable condition;
+  std::condition_variable idleCondition;
+  std::queue<std::function<void()>> tasks;
+  std::thread workerThread;
+  std::atomic<bool> stopped{false};
+  bool executing = false;  // Tracks if a task is currently being executed
+};
 
 class DiskCache {
  public:
@@ -90,6 +130,18 @@ class DiskCache {
   uint32_t filePathToID(const std::string& path);
   void notifyFileClosed(uint32_t fileID);
   void notifyFileSizeChanged(uint32_t fileID, size_t fileSize);
+
+  /**
+   * Removes the file at the given path asynchronously on the DiskIOQueue to avoid blocking the
+   * calling thread (which may be the main/render thread) on synchronous IO.
+   */
+  static void removeFileAsync(const std::string& filePath);
+
+  /**
+   * Version counter for saveConfig(). Incremented on each call to allow coalescing multiple
+   * rapid saves into a single disk write. Atomic to allow safe access from the IO thread.
+   */
+  std::atomic<uint32_t> configSaveVersion{0};
 
   friend class SequenceFile;
   friend class PAGDiskCache;

--- a/src/rendering/caches/SequenceFile.cpp
+++ b/src/rendering/caches/SequenceFile.cpp
@@ -93,11 +93,30 @@ SequenceFile::SequenceFile(const std::string& filePath, const tgfx::ImageInfo& i
 }
 
 SequenceFile::~SequenceFile() {
-  if (file != nullptr) {
-    fclose(file);
+  // Move the synchronous file IO (fclose flushes buffers) and the DiskCache notification (which
+  // may trigger further disk operations like checkDiskSpace/saveConfig) to the DiskIOQueue to
+  // avoid blocking the calling thread (which could be the main/render thread).
+  FILE* fileToClose = nullptr;
+  DiskCache* cache = nullptr;
+  uint32_t id = 0;
+  {
+    // Lock to safely read and clear file/diskCache, preventing races with writeFrame().
+    std::lock_guard<std::mutex> autoLock(locker);
+    fileToClose = file;
+    cache = diskCache;
+    id = fileID;
+    file = nullptr;
+    diskCache = nullptr;
   }
-  if (diskCache) {
-    diskCache->notifyFileClosed(fileID);
+  if (fileToClose != nullptr || cache != nullptr) {
+    DiskIOQueue::GetInstance()->submit([fileToClose, cache, id]() {
+      if (fileToClose != nullptr) {
+        fclose(fileToClose);
+      }
+      if (cache != nullptr) {
+        cache->notifyFileClosed(id);
+      }
+    });
   }
 }
 


### PR DESCRIPTION
## Problem

Main thread blocking (~5 seconds) caused by synchronous file deletion (`remove()`/`unlink()`) in the DiskCache module on iOS devices.

**Stack trace:**
```
__unlink → unlink → remove → libpag
pag::ContentCache::update() / pag::ContentCache::createCache()
```

**Device:** iPhone 14 Plus, iOS 16.0.3  
**Evidence:** cpuIdle=87% indicating pure IO wait

## Root Cause

NAND flash storage can cause `remove()` to block for several seconds due to:
- Garbage collection triggered when storage is near capacity
- Wear leveling operations
- Large file deletions requiring multiple erase cycles

## Solution

- Added `DiskIOQueue` class: A serial task queue with a dedicated background thread for disk IO operations
- Made file deletion asynchronous via `DiskIOQueue::submit()`
- Made config file writes asynchronous with version-based coalescing to skip redundant writes
- Made `SequenceFile` destructor async to avoid blocking on `fclose()`

## Thread Safety

- Added `std::atomic<uint32_t> configSaveVersion` for safe cross-thread access
- Added proper mutex locking in `SequenceFile` destructor
- `DiskIOQueue` uses `executing` flag for accurate `waitAll()` behavior
