### PR TITLE
Add PathData deduplication during PAGX export

### DIFF
--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -17,8 +17,12 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "pagx/PAGXExporter.h"
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 #include "pagx/PAGXDefaults.h"
 #include "pagx/PAGXDocument.h"
 #include "pagx/nodes/BackgroundBlurStyle.h"
@@ -328,6 +332,50 @@ static bool ShouldSkipPosition(const Point& position, const Point& defaultPos, f
   return (hasH && hasV) || isDefault;
 }
 
+/**
+ * Export-time state for PathData deduplication without modifying the original document.
+ */
+struct ExportContext {
+  std::unordered_map<std::string, std::string> pathDataContentToId;
+  std::unordered_map<const PathData*, std::string> pathDataToOutputId;
+  std::unordered_set<std::string> writtenResourceIds;
+  int pathDataIdCounter = 0;
+
+  std::string getPathDataOutputId(const PathData* pathData) {
+    if (pathData == nullptr) {
+      return "";
+    }
+    auto it = pathDataToOutputId.find(pathData);
+    if (it != pathDataToOutputId.end()) {
+      return it->second;
+    }
+    if (!pathData->id.empty()) {
+      pathDataToOutputId[pathData] = pathData->id;
+      return pathData->id;
+    }
+    std::string svgContent = PathDataToSVGString(*pathData);
+    if (svgContent.empty()) {
+      return "";
+    }
+    auto contentIt = pathDataContentToId.find(svgContent);
+    if (contentIt != pathDataContentToId.end()) {
+      pathDataToOutputId[pathData] = contentIt->second;
+      return contentIt->second;
+    }
+    std::string newId = "__pd_" + std::to_string(pathDataIdCounter++);
+    pathDataContentToId[svgContent] = newId;
+    pathDataToOutputId[pathData] = newId;
+    return newId;
+  }
+
+  bool markResourceWritten(const std::string& id) {
+    if (id.empty()) {
+      return false;
+    }
+    return writtenResourceIds.insert(id).second;
+  }
+};
+
 //==============================================================================
 // Forward declarations
 //==============================================================================
@@ -335,11 +383,14 @@ static bool ShouldSkipPosition(const Point& position, const Point& defaultPos, f
 using Options = PAGXExporter::Options;
 
 static void WriteColorSource(XMLBuilder& xml, const ColorSource* node);
-static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Options& options);
+static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Options& options,
+                               ExportContext& ctx);
 static void WriteLayerStyle(XMLBuilder& xml, const LayerStyle* node);
 static void WriteLayerFilter(XMLBuilder& xml, const LayerFilter* node);
-static void WriteResource(XMLBuilder& xml, const Node* node, const Options& options);
-static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& options);
+static void WriteResource(XMLBuilder& xml, const Node* node, const Options& options,
+                          ExportContext& ctx);
+static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& options,
+                       ExportContext& ctx);
 
 static void WriteCustomData(XMLBuilder& xml, const Node* node) {
   for (const auto& [key, value] : node->customData) {
@@ -496,7 +547,8 @@ static void WriteColorSource(XMLBuilder& xml, const ColorSource* node) {
 // VectorElement writing
 //==============================================================================
 
-static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Options& options) {
+static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Options& options,
+                               ExportContext& ctx) {
   switch (node->nodeType()) {
     case NodeType::Rectangle: {
       auto rect = static_cast<const Rectangle*>(node);
@@ -577,12 +629,13 @@ static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Optio
     case NodeType::Path: {
       auto path = static_cast<const Path*>(node);
       xml.openElement("Path");
-      if (path->data != nullptr && !path->data->id.empty()) {
-        // Use the reference to PathData resource.
-        xml.addAttribute("data", "@" + path->data->id);
-      } else if (path->data != nullptr && !path->data->isEmpty()) {
-        // Inline the path data.
-        xml.addAttribute("data", PathDataToSVGString(*path->data));
+      if (path->data != nullptr && !path->data->isEmpty()) {
+        std::string outputId = ctx.getPathDataOutputId(path->data);
+        if (!outputId.empty()) {
+          xml.addAttribute("data", "@" + outputId);
+        } else {
+          xml.addAttribute("data", PathDataToSVGString(*path->data));
+        }
       }
       xml.addAttribute("reversed", path->reversed, Default<Path>().reversed);
       if (!ShouldSkipPosition(path->position, {0, 0}, path->left, path->top, path->right,
@@ -859,12 +912,13 @@ static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Optio
     case NodeType::TextPath: {
       auto textPath = static_cast<const TextPath*>(node);
       xml.openElement("TextPath");
-      if (textPath->path != nullptr && !textPath->path->id.empty()) {
-        // Use the reference to PathData resource.
-        xml.addAttribute("path", "@" + textPath->path->id);
-      } else if (textPath->path != nullptr && !textPath->path->isEmpty()) {
-        // Inline the path data.
-        xml.addAttribute("path", PathDataToSVGString(*textPath->path));
+      if (textPath->path != nullptr && !textPath->path->isEmpty()) {
+        std::string outputId = ctx.getPathDataOutputId(textPath->path);
+        if (!outputId.empty()) {
+          xml.addAttribute("path", "@" + outputId);
+        } else {
+          xml.addAttribute("path", PathDataToSVGString(*textPath->path));
+        }
       }
       if (textPath->baselineOrigin != Default<TextPath>().baselineOrigin) {
         xml.addAttribute("baselineOrigin", PointToString(textPath->baselineOrigin));
@@ -940,7 +994,7 @@ static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Optio
       } else {
         xml.closeElementStart();
         for (const auto& element : textBox->elements) {
-          WriteVectorElement(xml, element, options);
+          WriteVectorElement(xml, element, options, ctx);
         }
         xml.closeElement();
       }
@@ -1004,7 +1058,7 @@ static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Optio
       } else {
         xml.closeElementStart();
         for (const auto& element : group->elements) {
-          WriteVectorElement(xml, element, options);
+          WriteVectorElement(xml, element, options, ctx);
         }
         xml.closeElement();
       }
@@ -1148,7 +1202,8 @@ static void WriteLayerFilter(XMLBuilder& xml, const LayerFilter* node) {
 // Resource writing
 //==============================================================================
 
-static void WriteResource(XMLBuilder& xml, const Node* node, const Options& options) {
+static void WriteResource(XMLBuilder& xml, const Node* node, const Options& options,
+                          ExportContext& ctx) {
   switch (node->nodeType()) {
     case NodeType::Image: {
       auto image = static_cast<const Image*>(node);
@@ -1185,7 +1240,7 @@ static void WriteResource(XMLBuilder& xml, const Node* node, const Options& opti
       } else {
         xml.closeElementStart();
         for (const auto& layer : comp->layers) {
-          WriteLayer(xml, layer, options);
+          WriteLayer(xml, layer, options, ctx);
         }
         xml.closeElement();
       }
@@ -1253,7 +1308,8 @@ static void WriteResource(XMLBuilder& xml, const Node* node, const Options& opti
 // Layer writing
 //==============================================================================
 
-static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& options) {
+static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& options,
+                       ExportContext& ctx) {
   xml.openElement("Layer");
   if (!node->id.empty()) {
     xml.addAttribute("id", node->id);
@@ -1345,7 +1401,7 @@ static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& option
 
   // Write VectorElement (contents) directly without container node.
   for (const auto& element : node->contents) {
-    WriteVectorElement(xml, element, options);
+    WriteVectorElement(xml, element, options, ctx);
   }
 
   // Write LayerStyle (styles) directly without container node.
@@ -1360,7 +1416,7 @@ static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& option
 
   // Write child Layers.
   for (const auto& child : node->children) {
-    WriteLayer(xml, child, options);
+    WriteLayer(xml, child, options, ctx);
   }
 
   xml.closeElement();
@@ -1372,6 +1428,8 @@ static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& option
 
 std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options) {
   XMLBuilder xml = {};
+  ExportContext ctx = {};
+
   xml.appendDeclaration();
 
   xml.openElement("pagx");
@@ -1381,30 +1439,49 @@ std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options)
   WriteCustomData(xml, &doc);
   xml.closeElementStart();
 
-  // Write Layers first (for better readability)
   for (const auto& layer : doc.layers) {
-    WriteLayer(xml, layer, options);
+    WriteLayer(xml, layer, options, ctx);
   }
 
-  // Write Resources section at the end (only if there are exportable resources)
-  bool hasResources = false;
+  bool hasOriginalResources = false;
   for (const auto& resource : doc.nodes) {
     if (!resource->id.empty()) {
       if (options.skipGlyphData && resource->nodeType() == NodeType::Font) {
         continue;
       }
-      hasResources = true;
+      hasOriginalResources = true;
       break;
     }
   }
+  bool hasDedupPathData = !ctx.pathDataContentToId.empty();
+  bool hasResources = hasOriginalResources || hasDedupPathData;
+
   if (hasResources) {
     xml.openElement("Resources");
     xml.closeElementStart();
 
     for (const auto& resource : doc.nodes) {
       if (!resource->id.empty()) {
-        WriteResource(xml, resource.get(), options);
+        if (!ctx.markResourceWritten(resource->id)) {
+          continue;
+        }
+        WriteResource(xml, resource.get(), options, ctx);
       }
+    }
+
+    // Write deduplicated PathData, sorted by ID for deterministic output.
+    std::vector<std::pair<std::string, std::string>> sortedPathData(ctx.pathDataContentToId.begin(),
+                                                                    ctx.pathDataContentToId.end());
+    std::sort(sortedPathData.begin(), sortedPathData.end(),
+              [](const auto& a, const auto& b) { return a.second < b.second; });
+    for (const auto& [svgContent, pathId] : sortedPathData) {
+      if (!ctx.markResourceWritten(pathId)) {
+        continue;
+      }
+      xml.openElement("PathData");
+      xml.addAttribute("id", pathId);
+      xml.addAttribute("data", svgContent);
+      xml.closeElementSelfClosing();
     }
 
     xml.closeElement();

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -326,6 +326,203 @@ PAGX_TEST(PAGXTest, PathDataForEach) {
 }
 
 /**
+ * Test case: PathData deduplication during export
+ *
+ * Verifies that:
+ * 1. Multiple Path elements with identical PathData content share the same ID in output
+ * 2. PathData resources are written only once in the Resources section
+ * 3. Export output is deterministic (same input produces same output)
+ */
+PAGX_TEST(PAGXTest, PathDataDeduplication) {
+  auto doc = pagx::PAGXDocument::Make(400, 300);
+
+  // Create a layer with three Path elements using identical PathData content
+  auto layer = doc->makeNode<pagx::Layer>();
+  layer->id = "dedup_layer";
+
+  // Path 1: Triangle at position (10, 10)
+  auto path1 = doc->makeNode<pagx::Path>();
+  path1->data = doc->makeNode<pagx::PathData>();
+  path1->data->moveTo(0, 0);
+  path1->data->lineTo(50, 0);
+  path1->data->lineTo(25, 40);
+  path1->data->close();
+  path1->position = {10, 10};
+  layer->contents.push_back(path1);
+
+  // Path 2: Same triangle shape at different position (100, 10)
+  auto path2 = doc->makeNode<pagx::Path>();
+  path2->data = doc->makeNode<pagx::PathData>();
+  path2->data->moveTo(0, 0);
+  path2->data->lineTo(50, 0);
+  path2->data->lineTo(25, 40);
+  path2->data->close();
+  path2->position = {100, 10};
+  layer->contents.push_back(path2);
+
+  // Path 3: Different shape (rectangle)
+  auto path3 = doc->makeNode<pagx::Path>();
+  path3->data = doc->makeNode<pagx::PathData>();
+  path3->data->moveTo(0, 0);
+  path3->data->lineTo(60, 0);
+  path3->data->lineTo(60, 30);
+  path3->data->lineTo(0, 30);
+  path3->data->close();
+  path3->position = {200, 10};
+  layer->contents.push_back(path3);
+
+  // Path 4: Same as path1/path2 (third instance of triangle)
+  auto path4 = doc->makeNode<pagx::Path>();
+  path4->data = doc->makeNode<pagx::PathData>();
+  path4->data->moveTo(0, 0);
+  path4->data->lineTo(50, 0);
+  path4->data->lineTo(25, 40);
+  path4->data->close();
+  path4->position = {10, 100};
+  layer->contents.push_back(path4);
+
+  auto fill = doc->makeNode<pagx::Fill>();
+  auto solid = doc->makeNode<pagx::SolidColor>();
+  solid->color = {0, 0, 1, 1};
+  fill->color = solid;
+  layer->contents.push_back(fill);
+
+  doc->layers.push_back(layer);
+
+  // Export to XML
+  std::string xml = pagx::PAGXExporter::ToXML(*doc);
+  ASSERT_FALSE(xml.empty());
+
+  // Verify deduplication: All Path elements should reference PathData by ID
+  // Path 1, 2, 4 have identical content, should share "__pd_0"
+  // Path 3 has different content, should get "__pd_1"
+
+  // Count occurrences of PathData references in Path elements
+  size_t pd0RefCount = 0;
+  size_t pd1RefCount = 0;
+  size_t pos = 0;
+  while ((pos = xml.find("data=\"@__pd_0\"", pos)) != std::string::npos) {
+    pd0RefCount++;
+    pos++;
+  }
+  pos = 0;
+  while ((pos = xml.find("data=\"@__pd_1\"", pos)) != std::string::npos) {
+    pd1RefCount++;
+    pos++;
+  }
+
+  // path1, path2, path4 should reference __pd_0 (3 references)
+  // path3 should reference __pd_1 (1 reference)
+  EXPECT_EQ(pd0RefCount, 3u) << "Triangle paths should share __pd_0";
+  EXPECT_EQ(pd1RefCount, 1u) << "Rectangle path should use __pd_1";
+
+  // Verify PathData resources are written only once each in Resources section
+  size_t pd0DefCount = 0;
+  size_t pd1DefCount = 0;
+  pos = 0;
+  while ((pos = xml.find("<PathData id=\"__pd_0\"", pos)) != std::string::npos) {
+    pd0DefCount++;
+    pos++;
+  }
+  pos = 0;
+  while ((pos = xml.find("<PathData id=\"__pd_1\"", pos)) != std::string::npos) {
+    pd1DefCount++;
+    pos++;
+  }
+
+  EXPECT_EQ(pd0DefCount, 1u) << "PathData __pd_0 should be defined exactly once";
+  EXPECT_EQ(pd1DefCount, 1u) << "PathData __pd_1 should be defined exactly once";
+
+  // Verify deterministic output: export again and compare
+  std::string xml2 = pagx::PAGXExporter::ToXML(*doc);
+  EXPECT_EQ(xml, xml2) << "Export should be deterministic";
+
+  // Verify round-trip: import and re-export should preserve structure
+  auto doc2 = pagx::PAGXImporter::FromXML(xml);
+  ASSERT_TRUE(doc2 != nullptr);
+  EXPECT_TRUE(doc2->errors.empty());
+  ASSERT_EQ(doc2->layers.size(), 1u);
+
+  // The imported document should have the same number of Path elements
+  auto* importedLayer = doc2->layers[0];
+  int pathCount = 0;
+  for (const auto* element : importedLayer->contents) {
+    if (element->nodeType() == pagx::NodeType::Path) {
+      pathCount++;
+    }
+  }
+  EXPECT_EQ(pathCount, 4) << "Should have 4 Path elements after import";
+}
+
+/**
+ * Test case: PathData deduplication with existing IDs
+ *
+ * Verifies that PathData with user-defined IDs are preserved and not deduplicated.
+ */
+PAGX_TEST(PAGXTest, PathDataDeduplicationWithExistingId) {
+  auto doc = pagx::PAGXDocument::Make(300, 200);
+
+  auto layer = doc->makeNode<pagx::Layer>();
+
+  // Create a PathData with explicit ID (makeNode already adds it to doc->nodes)
+  auto sharedPathData = doc->makeNode<pagx::PathData>("myTriangle");
+  sharedPathData->moveTo(0, 0);
+  sharedPathData->lineTo(40, 0);
+  sharedPathData->lineTo(20, 30);
+  sharedPathData->close();
+
+  // Path 1: Uses the shared PathData by reference
+  auto path1 = doc->makeNode<pagx::Path>();
+  path1->data = sharedPathData;
+  path1->position = {10, 10};
+  layer->contents.push_back(path1);
+
+  // Path 2: Uses the same shared PathData
+  auto path2 = doc->makeNode<pagx::Path>();
+  path2->data = sharedPathData;
+  path2->position = {100, 10};
+  layer->contents.push_back(path2);
+
+  // Path 3: Has identical content but created separately (no ID)
+  auto path3 = doc->makeNode<pagx::Path>();
+  path3->data = doc->makeNode<pagx::PathData>();
+  path3->data->moveTo(0, 0);
+  path3->data->lineTo(40, 0);
+  path3->data->lineTo(20, 30);
+  path3->data->close();
+  path3->position = {200, 10};
+  layer->contents.push_back(path3);
+
+  auto fill = doc->makeNode<pagx::Fill>();
+  auto solid = doc->makeNode<pagx::SolidColor>();
+  solid->color = {1, 0, 0, 1};
+  fill->color = solid;
+  layer->contents.push_back(fill);
+
+  doc->layers.push_back(layer);
+
+  std::string xml = pagx::PAGXExporter::ToXML(*doc);
+  ASSERT_FALSE(xml.empty());
+
+  // path1 and path2 should reference "@myTriangle" (the explicit ID)
+  size_t myTriangleRefCount = 0;
+  size_t pos = 0;
+  while ((pos = xml.find("data=\"@myTriangle\"", pos)) != std::string::npos) {
+    myTriangleRefCount++;
+    pos++;
+  }
+  EXPECT_EQ(myTriangleRefCount, 2u) << "Paths using shared PathData should reference @myTriangle";
+
+  // path3 should get a generated ID like "__pd_0"
+  EXPECT_NE(xml.find("data=\"@__pd_0\""), std::string::npos)
+      << "Path with unnamed PathData should get generated ID";
+
+  // Verify the explicit PathData resource exists
+  EXPECT_NE(xml.find("<PathData id=\"myTriangle\""), std::string::npos)
+      << "User-defined PathData should be in Resources";
+}
+
+/**
  * Test case: PAGXDocument creation and XML export
  */
 PAGX_TEST(PAGXTest, PAGXDocumentXMLExport) {


### PR DESCRIPTION
在 PAGX 导出时实现 PathData 去重功能。

主要变更：
- 新增 ExportContext 结构管理导出时的 PathData 映射状态
- 相同路径内容的 PathData 共享同一个生成的 ID（如 __pd_0、__pd_1）
- 用户定义的 PathData ID 保持不变
- 输出按 ID 排序，确保确定性
- 添加 PathDataDeduplication 和 PathDataDeduplicationWithExistingId 测试用例