### PR TITLE
Add PathData deduplication with ID collision avoidance during PAGX export

### DIFF
--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -368,6 +368,17 @@ struct ExportContext {
     auto digest = MD5::Calculate(svgContent.data(), svgContent.size());
     std::string digestKey(reinterpret_cast<const char*>(digest.data()), digest.size());
     if (!pathData->id.empty()) {
+      auto existing = pathDataContentToOutputId.find(digestKey);
+      if (existing != pathDataContentToOutputId.end() && existing->second != pathData->id) {
+        // An unnamed PathData with the same content was registered first under a generated ID.
+        // Retarget all cached pointers that point to the old generated ID to use the named ID.
+        const std::string& oldId = existing->second;
+        for (auto& entry : pathDataToOutputId) {
+          if (entry.second == oldId) {
+            entry.second = pathData->id;
+          }
+        }
+      }
       pathDataContentToOutputId[digestKey] = pathData->id;
       pathDataToOutputId[pathData] = pathData->id;
       return pathData->id;

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -1463,6 +1463,12 @@ static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& option
 // Main Export function
 //==============================================================================
 
+using PtrEntry = std::unordered_map<const PathData*, std::string>::const_iterator;
+
+static bool ComparePtrEntryById(const PtrEntry& a, const PtrEntry& b) {
+  return a->second < b->second;
+}
+
 std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options) {
   XMLBuilder xml = {};
   ExportContext ctx = {};
@@ -1512,14 +1518,12 @@ std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options)
     }
 
     // Write deduplicated PathData, sorted by ID for deterministic output.
-    using PtrEntry = std::unordered_map<const PathData*, std::string>::const_iterator;
     std::vector<PtrEntry> sortedPathData;
     sortedPathData.reserve(ctx.pathDataToOutputId.size());
     for (auto it = ctx.pathDataToOutputId.cbegin(); it != ctx.pathDataToOutputId.cend(); ++it) {
       sortedPathData.push_back(it);
     }
-    std::sort(sortedPathData.begin(), sortedPathData.end(),
-              [](const PtrEntry& a, const PtrEntry& b) { return a->second < b->second; });
+    std::sort(sortedPathData.begin(), sortedPathData.end(), ComparePtrEntryById);
     for (const auto& entry : sortedPathData) {
       const PathData* pathData = entry->first;
       const auto& pathId = entry->second;

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -369,17 +369,6 @@ struct ExportContext {
     auto digest = MD5::Calculate(svgContent.data(), svgContent.size());
     std::string digestKey(reinterpret_cast<const char*>(digest.data()), digest.size());
     if (!pathData->id.empty()) {
-      auto existing = pathDataContentToOutputId.find(digestKey);
-      if (existing != pathDataContentToOutputId.end() && existing->second != pathData->id) {
-        // An unnamed PathData with the same content was registered first under a generated ID.
-        // Retarget all cached pointers that point to the old generated ID to use the named ID.
-        const std::string& oldId = existing->second;
-        for (auto& entry : pathDataToOutputId) {
-          if (entry.second == oldId) {
-            entry.second = pathData->id;
-          }
-        }
-      }
       pathDataContentToOutputId[digestKey] = pathData->id;
       pathDataToOutputId[pathData] = pathData->id;
       return pathData->id;
@@ -1471,6 +1460,48 @@ static bool ComparePtrEntryById(const PtrEntry& a, const PtrEntry& b) {
   return a->second < b->second;
 }
 
+static void CollectElementPathData(const Element* node, ExportContext& ctx);
+
+static void CollectLayerPathData(const Layer* layer, ExportContext& ctx) {
+  for (const auto& element : layer->contents) {
+    CollectElementPathData(element, ctx);
+  }
+  for (const auto& child : layer->children) {
+    CollectLayerPathData(child, ctx);
+  }
+}
+
+static void CollectElementPathData(const Element* node, ExportContext& ctx) {
+  switch (node->nodeType()) {
+    case NodeType::Path: {
+      auto path = static_cast<const Path*>(node);
+      ctx.getPathDataOutputId(path->data);
+      break;
+    }
+    case NodeType::TextPath: {
+      auto textPath = static_cast<const TextPath*>(node);
+      ctx.getPathDataOutputId(textPath->path);
+      break;
+    }
+    case NodeType::Group: {
+      auto group = static_cast<const Group*>(node);
+      for (const auto& element : group->elements) {
+        CollectElementPathData(element, ctx);
+      }
+      break;
+    }
+    case NodeType::TextBox: {
+      auto textBox = static_cast<const TextBox*>(node);
+      for (const auto& element : textBox->elements) {
+        CollectElementPathData(element, ctx);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
 std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options) {
   XMLBuilder xml = {};
   ExportContext ctx = {};
@@ -1478,6 +1509,18 @@ std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options)
   // Reserve all existing resource IDs to avoid collision with generated IDs.
   for (const auto& resource : doc.nodes) {
     ctx.reserveId(resource->id);
+  }
+
+  // Phase 0: pre-collect all PathData references before writing any XML so that named PathData
+  // nodes are registered first, preventing unnamed same-content PathData from claiming a
+  // generated ID that would then appear in the Layer XML before the named ID is known.
+  for (const auto& resource : doc.nodes) {
+    if (resource->nodeType() == NodeType::PathData && !resource->id.empty()) {
+      ctx.getPathDataOutputId(static_cast<const PathData*>(resource.get()));
+    }
+  }
+  for (const auto& layer : doc.layers) {
+    CollectLayerPathData(layer, ctx);
   }
 
   xml.appendDeclaration();

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -61,6 +61,7 @@
 #include "pagx/nodes/TrimPath.h"
 #include "pagx/svg/SVGPathParser.h"
 #include "pagx/utils/Base64.h"
+#include "pagx/utils/MD5.h"
 #include "pagx/utils/StringParser.h"
 
 namespace pagx {
@@ -338,6 +339,8 @@ namespace {
  * Export-time state for PathData deduplication without modifying the original document.
  */
 struct ExportContext {
+  // Maps MD5 digest of SVG content (16-byte string) to output ID, used for deduplication.
+  // Storing only the digest avoids holding large SVG strings in memory.
   std::unordered_map<std::string, std::string> pathDataContentToOutputId;
   std::unordered_map<const PathData*, std::string> pathDataToOutputId;
   std::unordered_set<std::string> writtenResourceIds;
@@ -358,19 +361,18 @@ struct ExportContext {
     if (it != pathDataToOutputId.end()) {
       return it->second;
     }
-    if (!pathData->id.empty()) {
-      std::string svgContent = PathDataToSVGString(*pathData);
-      if (!svgContent.empty()) {
-        pathDataContentToOutputId[svgContent] = pathData->id;
-      }
-      pathDataToOutputId[pathData] = pathData->id;
-      return pathData->id;
-    }
     std::string svgContent = PathDataToSVGString(*pathData);
     if (svgContent.empty()) {
       return "";
     }
-    auto contentIt = pathDataContentToOutputId.find(svgContent);
+    auto digest = MD5::Calculate(svgContent.data(), svgContent.size());
+    std::string digestKey(reinterpret_cast<const char*>(digest.data()), digest.size());
+    if (!pathData->id.empty()) {
+      pathDataContentToOutputId[digestKey] = pathData->id;
+      pathDataToOutputId[pathData] = pathData->id;
+      return pathData->id;
+    }
+    auto contentIt = pathDataContentToOutputId.find(digestKey);
     if (contentIt != pathDataContentToOutputId.end()) {
       pathDataToOutputId[pathData] = contentIt->second;
       return contentIt->second;
@@ -385,7 +387,7 @@ struct ExportContext {
         break;
       }
     }
-    pathDataContentToOutputId[svgContent] = newId;
+    pathDataContentToOutputId[digestKey] = newId;
     pathDataToOutputId[pathData] = newId;
     return newId;
   }
@@ -1499,19 +1501,22 @@ std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options)
     }
 
     // Write deduplicated PathData, sorted by ID for deterministic output.
-    using MapEntry = std::unordered_map<std::string, std::string>::const_iterator;
-    std::vector<MapEntry> sortedPathData;
-    sortedPathData.reserve(ctx.pathDataContentToOutputId.size());
-    for (auto it = ctx.pathDataContentToOutputId.cbegin();
-         it != ctx.pathDataContentToOutputId.cend(); ++it) {
+    using PtrEntry = std::unordered_map<const PathData*, std::string>::const_iterator;
+    std::vector<PtrEntry> sortedPathData;
+    sortedPathData.reserve(ctx.pathDataToOutputId.size());
+    for (auto it = ctx.pathDataToOutputId.cbegin(); it != ctx.pathDataToOutputId.cend(); ++it) {
       sortedPathData.push_back(it);
     }
     std::sort(sortedPathData.begin(), sortedPathData.end(),
-              [](const MapEntry& a, const MapEntry& b) { return a->second < b->second; });
+              [](const PtrEntry& a, const PtrEntry& b) { return a->second < b->second; });
     for (const auto& entry : sortedPathData) {
-      const auto& svgContent = entry->first;
+      const PathData* pathData = entry->first;
       const auto& pathId = entry->second;
       if (!ctx.markResourceWritten(pathId)) {
+        continue;
+      }
+      std::string svgContent = PathDataToSVGString(*pathData);
+      if (svgContent.empty()) {
         continue;
       }
       xml.openElement("PathData");

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -339,7 +339,14 @@ struct ExportContext {
   std::unordered_map<std::string, std::string> pathDataContentToId;
   std::unordered_map<const PathData*, std::string> pathDataToOutputId;
   std::unordered_set<std::string> writtenResourceIds;
+  std::unordered_set<std::string> reservedIds;
   int pathDataIdCounter = 0;
+
+  void reserveId(const std::string& id) {
+    if (!id.empty()) {
+      reservedIds.insert(id);
+    }
+  }
 
   std::string getPathDataOutputId(const PathData* pathData) {
     if (pathData == nullptr) {
@@ -362,7 +369,10 @@ struct ExportContext {
       pathDataToOutputId[pathData] = contentIt->second;
       return contentIt->second;
     }
-    std::string newId = "__pd_" + std::to_string(pathDataIdCounter++);
+    std::string newId;
+    do {
+      newId = "__pd_" + std::to_string(pathDataIdCounter++);
+    } while (reservedIds.count(newId) > 0);
     pathDataContentToId[svgContent] = newId;
     pathDataToOutputId[pathData] = newId;
     return newId;
@@ -1429,6 +1439,11 @@ static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& option
 std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options) {
   XMLBuilder xml = {};
   ExportContext ctx = {};
+
+  // Reserve all existing resource IDs to avoid collision with generated IDs.
+  for (const auto& resource : doc.nodes) {
+    ctx.reserveId(resource->id);
+  }
 
   xml.appendDeclaration();
 

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -346,6 +346,7 @@ struct ExportContext {
   std::unordered_set<std::string> writtenResourceIds;
   std::unordered_set<std::string> reservedIds;
   int pathDataIdCounter = 0;
+  bool hasAnonymousPathData = false;
 
   void reserveId(const std::string& id) {
     if (!id.empty()) {
@@ -400,6 +401,7 @@ struct ExportContext {
     }
     pathDataContentToOutputId[digestKey] = newId;
     pathDataToOutputId[pathData] = newId;
+    hasAnonymousPathData = true;
     return newId;
   }
 
@@ -1501,7 +1503,7 @@ std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options)
       break;
     }
   }
-  bool hasDedupPathData = !ctx.pathDataContentToOutputId.empty();
+  bool hasDedupPathData = ctx.hasAnonymousPathData;
   bool hasResources = hasOriginalResources || hasDedupPathData;
 
   if (hasResources) {

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -357,6 +357,10 @@ struct ExportContext {
       return it->second;
     }
     if (!pathData->id.empty()) {
+      std::string svgContent = PathDataToSVGString(*pathData);
+      if (!svgContent.empty()) {
+        pathDataContentToId[svgContent] = pathData->id;
+      }
       pathDataToOutputId[pathData] = pathData->id;
       return pathData->id;
     }
@@ -370,9 +374,15 @@ struct ExportContext {
       return contentIt->second;
     }
     std::string newId;
-    do {
+    // At most reservedIds.size() + 1 attempts are needed: in the worst case all reserved IDs
+    // match the __pd_N pattern consecutively, so we skip at most reservedIds.size() of them.
+    size_t maxAttempts = reservedIds.size() + 1;
+    for (size_t i = 0; i < maxAttempts; i++) {
       newId = "__pd_" + std::to_string(pathDataIdCounter++);
-    } while (reservedIds.count(newId) > 0);
+      if (reservedIds.count(newId) == 0) {
+        break;
+      }
+    }
     pathDataContentToId[svgContent] = newId;
     pathDataToOutputId[pathData] = newId;
     return newId;

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -332,11 +332,13 @@ static bool ShouldSkipPosition(const Point& position, const Point& defaultPos, f
   return (hasH && hasV) || isDefault;
 }
 
+namespace {
+
 /**
  * Export-time state for PathData deduplication without modifying the original document.
  */
 struct ExportContext {
-  std::unordered_map<std::string, std::string> pathDataContentToId;
+  std::unordered_map<std::string, std::string> pathDataContentToOutputId;
   std::unordered_map<const PathData*, std::string> pathDataToOutputId;
   std::unordered_set<std::string> writtenResourceIds;
   std::unordered_set<std::string> reservedIds;
@@ -359,7 +361,7 @@ struct ExportContext {
     if (!pathData->id.empty()) {
       std::string svgContent = PathDataToSVGString(*pathData);
       if (!svgContent.empty()) {
-        pathDataContentToId[svgContent] = pathData->id;
+        pathDataContentToOutputId[svgContent] = pathData->id;
       }
       pathDataToOutputId[pathData] = pathData->id;
       return pathData->id;
@@ -368,8 +370,8 @@ struct ExportContext {
     if (svgContent.empty()) {
       return "";
     }
-    auto contentIt = pathDataContentToId.find(svgContent);
-    if (contentIt != pathDataContentToId.end()) {
+    auto contentIt = pathDataContentToOutputId.find(svgContent);
+    if (contentIt != pathDataContentToOutputId.end()) {
       pathDataToOutputId[pathData] = contentIt->second;
       return contentIt->second;
     }
@@ -383,7 +385,7 @@ struct ExportContext {
         break;
       }
     }
-    pathDataContentToId[svgContent] = newId;
+    pathDataContentToOutputId[svgContent] = newId;
     pathDataToOutputId[pathData] = newId;
     return newId;
   }
@@ -395,6 +397,8 @@ struct ExportContext {
     return writtenResourceIds.insert(id).second;
   }
 };
+
+}  // namespace
 
 //==============================================================================
 // Forward declarations
@@ -1478,7 +1482,7 @@ std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options)
       break;
     }
   }
-  bool hasDedupPathData = !ctx.pathDataContentToId.empty();
+  bool hasDedupPathData = !ctx.pathDataContentToOutputId.empty();
   bool hasResources = hasOriginalResources || hasDedupPathData;
 
   if (hasResources) {
@@ -1495,11 +1499,18 @@ std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options)
     }
 
     // Write deduplicated PathData, sorted by ID for deterministic output.
-    std::vector<std::pair<std::string, std::string>> sortedPathData(ctx.pathDataContentToId.begin(),
-                                                                    ctx.pathDataContentToId.end());
+    using MapEntry = std::unordered_map<std::string, std::string>::const_iterator;
+    std::vector<MapEntry> sortedPathData;
+    sortedPathData.reserve(ctx.pathDataContentToOutputId.size());
+    for (auto it = ctx.pathDataContentToOutputId.cbegin();
+         it != ctx.pathDataContentToOutputId.cend(); ++it) {
+      sortedPathData.push_back(it);
+    }
     std::sort(sortedPathData.begin(), sortedPathData.end(),
-              [](const auto& a, const auto& b) { return a.second < b.second; });
-    for (const auto& [svgContent, pathId] : sortedPathData) {
+              [](const MapEntry& a, const MapEntry& b) { return a->second < b->second; });
+    for (const auto& entry : sortedPathData) {
+      const auto& svgContent = entry->first;
+      const auto& pathId = entry->second;
       if (!ctx.markResourceWritten(pathId)) {
         continue;
       }

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -17,8 +17,12 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "pagx/PAGXExporter.h"
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 #include "pagx/PAGXDefaults.h"
 #include "pagx/PAGXDocument.h"
 #include "pagx/nodes/BackgroundBlurStyle.h"
@@ -328,6 +332,50 @@ static bool ShouldSkipPosition(const Point& position, const Point& defaultPos, f
   return (hasH && hasV) || isDefault;
 }
 
+/**
+ * Export-time state for PathData deduplication without modifying the original document.
+ */
+struct ExportContext {
+  std::unordered_map<std::string, std::string> pathDataContentToId;
+  std::unordered_map<const PathData*, std::string> pathDataToOutputId;
+  std::unordered_set<std::string> writtenResourceIds;
+  int pathDataIdCounter = 0;
+
+  std::string getPathDataOutputId(const PathData* pathData) {
+    if (pathData == nullptr) {
+      return "";
+    }
+    auto it = pathDataToOutputId.find(pathData);
+    if (it != pathDataToOutputId.end()) {
+      return it->second;
+    }
+    if (!pathData->id.empty()) {
+      pathDataToOutputId[pathData] = pathData->id;
+      return pathData->id;
+    }
+    std::string svgContent = PathDataToSVGString(*pathData);
+    if (svgContent.empty()) {
+      return "";
+    }
+    auto contentIt = pathDataContentToId.find(svgContent);
+    if (contentIt != pathDataContentToId.end()) {
+      pathDataToOutputId[pathData] = contentIt->second;
+      return contentIt->second;
+    }
+    std::string newId = "__pd_" + std::to_string(pathDataIdCounter++);
+    pathDataContentToId[svgContent] = newId;
+    pathDataToOutputId[pathData] = newId;
+    return newId;
+  }
+
+  bool markResourceWritten(const std::string& id) {
+    if (id.empty()) {
+      return false;
+    }
+    return writtenResourceIds.insert(id).second;
+  }
+};
+
 //==============================================================================
 // Forward declarations
 //==============================================================================
@@ -335,11 +383,14 @@ static bool ShouldSkipPosition(const Point& position, const Point& defaultPos, f
 using Options = PAGXExporter::Options;
 
 static void WriteColorSource(XMLBuilder& xml, const ColorSource* node);
-static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Options& options);
+static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Options& options,
+                               ExportContext& ctx);
 static void WriteLayerStyle(XMLBuilder& xml, const LayerStyle* node);
 static void WriteLayerFilter(XMLBuilder& xml, const LayerFilter* node);
-static void WriteResource(XMLBuilder& xml, const Node* node, const Options& options);
-static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& options);
+static void WriteResource(XMLBuilder& xml, const Node* node, const Options& options,
+                          ExportContext& ctx);
+static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& options,
+                       ExportContext& ctx);
 
 static void WriteCustomData(XMLBuilder& xml, const Node* node) {
   for (const auto& [key, value] : node->customData) {
@@ -496,7 +547,8 @@ static void WriteColorSource(XMLBuilder& xml, const ColorSource* node) {
 // VectorElement writing
 //==============================================================================
 
-static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Options& options) {
+static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Options& options,
+                               ExportContext& ctx) {
   switch (node->nodeType()) {
     case NodeType::Rectangle: {
       auto rect = static_cast<const Rectangle*>(node);
@@ -577,12 +629,13 @@ static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Optio
     case NodeType::Path: {
       auto path = static_cast<const Path*>(node);
       xml.openElement("Path");
-      if (path->data != nullptr && !path->data->id.empty()) {
-        // Use the reference to PathData resource.
-        xml.addAttribute("data", "@" + path->data->id);
-      } else if (path->data != nullptr && !path->data->isEmpty()) {
-        // Inline the path data.
-        xml.addAttribute("data", PathDataToSVGString(*path->data));
+      if (path->data != nullptr && !path->data->isEmpty()) {
+        std::string outputId = ctx.getPathDataOutputId(path->data);
+        if (!outputId.empty()) {
+          xml.addAttribute("data", "@" + outputId);
+        } else {
+          xml.addAttribute("data", PathDataToSVGString(*path->data));
+        }
       }
       xml.addAttribute("reversed", path->reversed, Default<Path>().reversed);
       if (!ShouldSkipPosition(path->position, {0, 0}, path->left, path->top, path->right,
@@ -859,12 +912,13 @@ static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Optio
     case NodeType::TextPath: {
       auto textPath = static_cast<const TextPath*>(node);
       xml.openElement("TextPath");
-      if (textPath->path != nullptr && !textPath->path->id.empty()) {
-        // Use the reference to PathData resource.
-        xml.addAttribute("path", "@" + textPath->path->id);
-      } else if (textPath->path != nullptr && !textPath->path->isEmpty()) {
-        // Inline the path data.
-        xml.addAttribute("path", PathDataToSVGString(*textPath->path));
+      if (textPath->path != nullptr && !textPath->path->isEmpty()) {
+        std::string outputId = ctx.getPathDataOutputId(textPath->path);
+        if (!outputId.empty()) {
+          xml.addAttribute("path", "@" + outputId);
+        } else {
+          xml.addAttribute("path", PathDataToSVGString(*textPath->path));
+        }
       }
       if (textPath->baselineOrigin != Default<TextPath>().baselineOrigin) {
         xml.addAttribute("baselineOrigin", PointToString(textPath->baselineOrigin));
@@ -940,7 +994,7 @@ static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Optio
       } else {
         xml.closeElementStart();
         for (const auto& element : textBox->elements) {
-          WriteVectorElement(xml, element, options);
+          WriteVectorElement(xml, element, options, ctx);
         }
         xml.closeElement();
       }
@@ -1004,7 +1058,7 @@ static void WriteVectorElement(XMLBuilder& xml, const Element* node, const Optio
       } else {
         xml.closeElementStart();
         for (const auto& element : group->elements) {
-          WriteVectorElement(xml, element, options);
+          WriteVectorElement(xml, element, options, ctx);
         }
         xml.closeElement();
       }
@@ -1148,7 +1202,8 @@ static void WriteLayerFilter(XMLBuilder& xml, const LayerFilter* node) {
 // Resource writing
 //==============================================================================
 
-static void WriteResource(XMLBuilder& xml, const Node* node, const Options& options) {
+static void WriteResource(XMLBuilder& xml, const Node* node, const Options& options,
+                          ExportContext& ctx) {
   switch (node->nodeType()) {
     case NodeType::Image: {
       auto image = static_cast<const Image*>(node);
@@ -1185,7 +1240,7 @@ static void WriteResource(XMLBuilder& xml, const Node* node, const Options& opti
       } else {
         xml.closeElementStart();
         for (const auto& layer : comp->layers) {
-          WriteLayer(xml, layer, options);
+          WriteLayer(xml, layer, options, ctx);
         }
         xml.closeElement();
       }
@@ -1253,7 +1308,8 @@ static void WriteResource(XMLBuilder& xml, const Node* node, const Options& opti
 // Layer writing
 //==============================================================================
 
-static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& options) {
+static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& options,
+                       ExportContext& ctx) {
   xml.openElement("Layer");
   if (!node->id.empty()) {
     xml.addAttribute("id", node->id);
@@ -1345,7 +1401,7 @@ static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& option
 
   // Write VectorElement (contents) directly without container node.
   for (const auto& element : node->contents) {
-    WriteVectorElement(xml, element, options);
+    WriteVectorElement(xml, element, options, ctx);
   }
 
   // Write LayerStyle (styles) directly without container node.
@@ -1360,7 +1416,7 @@ static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& option
 
   // Write child Layers.
   for (const auto& child : node->children) {
-    WriteLayer(xml, child, options);
+    WriteLayer(xml, child, options, ctx);
   }
 
   xml.closeElement();
@@ -1372,6 +1428,8 @@ static void WriteLayer(XMLBuilder& xml, const Layer* node, const Options& option
 
 std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options) {
   XMLBuilder xml = {};
+  ExportContext ctx = {};
+
   xml.appendDeclaration();
 
   xml.openElement("pagx");
@@ -1381,30 +1439,49 @@ std::string PAGXExporter::ToXML(const PAGXDocument& doc, const Options& options)
   WriteCustomData(xml, &doc);
   xml.closeElementStart();
 
-  // Write Layers first (for better readability)
   for (const auto& layer : doc.layers) {
-    WriteLayer(xml, layer, options);
+    WriteLayer(xml, layer, options, ctx);
   }
 
-  // Write Resources section at the end (only if there are exportable resources)
-  bool hasResources = false;
+  bool hasOriginalResources = false;
   for (const auto& resource : doc.nodes) {
     if (!resource->id.empty()) {
       if (options.skipGlyphData && resource->nodeType() == NodeType::Font) {
         continue;
       }
-      hasResources = true;
+      hasOriginalResources = true;
       break;
     }
   }
+  bool hasDedupPathData = !ctx.pathDataContentToId.empty();
+  bool hasResources = hasOriginalResources || hasDedupPathData;
+
   if (hasResources) {
     xml.openElement("Resources");
     xml.closeElementStart();
 
     for (const auto& resource : doc.nodes) {
       if (!resource->id.empty()) {
-        WriteResource(xml, resource.get(), options);
+        if (!ctx.markResourceWritten(resource->id)) {
+          continue;
+        }
+        WriteResource(xml, resource.get(), options, ctx);
       }
+    }
+
+    // Write deduplicated PathData, sorted by ID for deterministic output.
+    std::vector<std::pair<std::string, std::string>> sortedPathData(ctx.pathDataContentToId.begin(),
+                                                                    ctx.pathDataContentToId.end());
+    std::sort(sortedPathData.begin(), sortedPathData.end(),
+              [](const auto& a, const auto& b) { return a.second < b.second; });
+    for (const auto& [svgContent, pathId] : sortedPathData) {
+      if (!ctx.markResourceWritten(pathId)) {
+        continue;
+      }
+      xml.openElement("PathData");
+      xml.addAttribute("id", pathId);
+      xml.addAttribute("data", svgContent);
+      xml.closeElementSelfClosing();
     }
 
     xml.closeElement();

--- a/src/pagx/svg/SVGPathParser.cpp
+++ b/src/pagx/svg/SVGPathParser.cpp
@@ -21,12 +21,29 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include "base/utils/MathUtil.h"
 
 namespace pagx {
 
 using pag::PI;
+
+static std::string FloatToString(float value) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%.9g", value);
+  // Normalize exponent to always use 2 digits (e.g. "e-06" not "e-006") for cross-platform
+  // consistency.
+  char* e = strchr(buf, 'e');
+  if (e != nullptr) {
+    char* sign = e + 1;
+    char* digits = (*sign == '+' || *sign == '-') ? sign + 1 : sign;
+    while (*digits == '0' && *(digits + 1) != '\0') {
+      memmove(digits, digits + 1, strlen(digits));
+    }
+  }
+  return buf;
+}
 
 std::string PathDataToSVGString(const PathData& pathData) {
   std::string result;
@@ -35,29 +52,47 @@ std::string PathDataToSVGString(const PathData& pathData) {
   const auto& points = pathData.points();
   result.reserve(verbs.size() * 24);
 
-  char buf[128] = {};
   for (auto verb : verbs) {
     const Point* pts = points.data() + pointIndex;
     switch (verb) {
       case PathVerb::Move:
-        snprintf(buf, sizeof(buf), "M%g %g", pts[0].x, pts[0].y);
-        result += buf;
+        result += 'M';
+        result += FloatToString(pts[0].x);
+        result += ' ';
+        result += FloatToString(pts[0].y);
         break;
       case PathVerb::Line:
-        snprintf(buf, sizeof(buf), "L%g %g", pts[0].x, pts[0].y);
-        result += buf;
+        result += 'L';
+        result += FloatToString(pts[0].x);
+        result += ' ';
+        result += FloatToString(pts[0].y);
         break;
       case PathVerb::Quad:
-        snprintf(buf, sizeof(buf), "Q%g %g %g %g", pts[0].x, pts[0].y, pts[1].x, pts[1].y);
-        result += buf;
+        result += 'Q';
+        result += FloatToString(pts[0].x);
+        result += ' ';
+        result += FloatToString(pts[0].y);
+        result += ' ';
+        result += FloatToString(pts[1].x);
+        result += ' ';
+        result += FloatToString(pts[1].y);
         break;
       case PathVerb::Cubic:
-        snprintf(buf, sizeof(buf), "C%g %g %g %g %g %g", pts[0].x, pts[0].y, pts[1].x, pts[1].y,
-                 pts[2].x, pts[2].y);
-        result += buf;
+        result += 'C';
+        result += FloatToString(pts[0].x);
+        result += ' ';
+        result += FloatToString(pts[0].y);
+        result += ' ';
+        result += FloatToString(pts[1].x);
+        result += ' ';
+        result += FloatToString(pts[1].y);
+        result += ' ';
+        result += FloatToString(pts[2].x);
+        result += ' ';
+        result += FloatToString(pts[2].y);
         break;
       case PathVerb::Close:
-        result += "Z";
+        result += 'Z';
         break;
     }
     pointIndex += PathData::PointsPerVerb(verb);

--- a/src/pagx/svg/SVGPathParser.cpp
+++ b/src/pagx/svg/SVGPathParser.cpp
@@ -31,7 +31,7 @@ using pag::PI;
 
 static std::string FloatToString(float value) {
   char buf[32];
-  snprintf(buf, sizeof(buf), "%.9g", value);
+  snprintf(buf, sizeof(buf), "%g", value);
   // Strip leading zeros from exponent (e.g. "e-006" → "e-6", "e-06" → "e-6") for cross-platform
   // consistency.
   char* e = strchr(buf, 'e');

--- a/src/pagx/svg/SVGPathParser.cpp
+++ b/src/pagx/svg/SVGPathParser.cpp
@@ -32,7 +32,7 @@ using pag::PI;
 static std::string FloatToString(float value) {
   char buf[32];
   snprintf(buf, sizeof(buf), "%.9g", value);
-  // Normalize exponent to always use 2 digits (e.g. "e-06" not "e-006") for cross-platform
+  // Strip leading zeros from exponent (e.g. "e-006" → "e-6", "e-06" → "e-6") for cross-platform
   // consistency.
   char* e = strchr(buf, 'e');
   if (e != nullptr) {

--- a/src/pagx/utils/MD5.cpp
+++ b/src/pagx/utils/MD5.cpp
@@ -2,12 +2,12 @@
 //
 //  Tencent is pleased to support the open source community by making libpag available.
 //
-//  Copyright (C) 2025 Tencent. All rights reserved.
+//  Copyright (C) 2026 Tencent. All rights reserved.
 //
-//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
-//  in compliance with the License. You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
 //
-//      https://opensource.org/licenses/BSD-3-Clause
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 //  unless required by applicable law or agreed to in writing, software distributed under the
 //  license is distributed on an "as is" basis, without warranties or conditions of any kind,

--- a/src/pagx/utils/MD5.cpp
+++ b/src/pagx/utils/MD5.cpp
@@ -1,0 +1,160 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2025 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "MD5.h"
+
+namespace pagx {
+
+namespace {
+inline uint32_t F(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & y) | (~x & z);
+}
+inline uint32_t G(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & z) | (y & ~z);
+}
+inline uint32_t H(uint32_t x, uint32_t y, uint32_t z) {
+  return x ^ y ^ z;
+}
+inline uint32_t I(uint32_t x, uint32_t y, uint32_t z) {
+  return y ^ (x | ~z);
+}
+inline uint32_t rotate_left(uint32_t x, uint32_t n) {
+  return (x << n) | (x >> (32 - n));
+}
+
+const uint32_t k[64] = {
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+    0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+    0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+    0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c, 0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+    0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+    0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391};
+const uint32_t r[] = {7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+                      5, 9,  14, 20, 5, 9,  14, 20, 5, 9,  14, 20, 5, 9,  14, 20,
+                      4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+                      6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21};
+
+class MD5Impl {
+ public:
+  MD5Impl() {
+    init();
+  }
+
+  void update(const uint8_t* input, size_t length) {
+    size_t index = (count / 8) % 64;
+    count += length * 8;
+    size_t partLen = 64 - index;
+    size_t i = 0;
+    if (length >= partLen) {
+      std::memcpy(&buffer[index], input, partLen);
+      transform(buffer);
+      for (i = partLen; i + 63 < length; i += 64) {
+        transform(&input[i]);
+      }
+      index = 0;
+    }
+    std::memcpy(&buffer[index], &input[i], length - i);
+  }
+
+  MD5::Digest finalize() {
+    MD5::Digest digest = {};
+    static const uint8_t PADDING[64] = {0x80};
+    uint8_t bits[8];
+    for (int i = 0; i < 8; ++i) bits[i] = (count >> (8 * i)) & 0xff;
+    size_t index = (count / 8) % 64;
+    size_t padLen = (index < 56) ? (56 - index) : (120 - index);
+    update(PADDING, padLen);
+    update(bits, 8);
+    for (uint32_t i = 0; i < 4; ++i) {
+      digest[(static_cast<size_t>(i) * 4) + 0] = static_cast<uint8_t>((state[i]) & 0xff);
+      digest[(static_cast<size_t>(i) * 4) + 1] = static_cast<uint8_t>((state[i] >> 8) & 0xff);
+      digest[(static_cast<size_t>(i) * 4) + 2] = static_cast<uint8_t>((state[i] >> 16) & 0xff);
+      digest[(static_cast<size_t>(i) * 4) + 3] = static_cast<uint8_t>((state[i] >> 24) & 0xff);
+    }
+    return digest;
+  }
+
+ private:
+  void init() {
+    count = 0;
+    state[0] = 0x67452301;
+    state[1] = 0xefcdab89;
+    state[2] = 0x98badcfe;
+    state[3] = 0x10325476;
+    std::memset(buffer, 0, sizeof(buffer));
+  }
+
+  void transform(const uint8_t block[64]) {
+    uint32_t a = state[0];
+    uint32_t b = state[1];
+    uint32_t c = state[2];
+    uint32_t d = state[3];
+    uint32_t m[16];
+    for (uint32_t i = 0; i < 16; ++i) {
+      m[i] = static_cast<uint32_t>(block[(i * 4) + 0]) |
+             (static_cast<uint32_t>(block[(i * 4) + 1]) << 8) |
+             (static_cast<uint32_t>(block[(i * 4) + 2]) << 16) |
+             (static_cast<uint32_t>(block[(i * 4) + 3]) << 24);
+    }
+    for (uint32_t i = 0; i < 64; ++i) {
+      uint32_t f;
+      uint32_t g;
+      if (i < 16) {
+        f = F(b, c, d);
+        g = i;
+      } else if (i < 32) {
+        f = G(b, c, d);
+        g = static_cast<uint32_t>((5 * i + 1) % 16);
+      } else if (i < 48) {
+        f = H(b, c, d);
+        g = static_cast<uint32_t>((3 * i + 5) % 16);
+      } else {
+        f = I(b, c, d);
+        g = static_cast<uint32_t>((7 * i) % 16);
+      }
+      uint32_t temp = d;
+      d = c;
+      c = b;
+      b = b + rotate_left(a + f + k[i] + m[g], r[i]);
+      a = temp;
+    }
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+  }
+
+  uint32_t state[4];
+  uint64_t count;
+  uint8_t buffer[64];
+};
+}  // namespace
+
+MD5::Digest MD5::Calculate(const void* bytes, size_t size) {
+  Digest digest = {};
+  if (bytes == nullptr || size == 0) {
+    return digest;
+  }
+  MD5Impl impl;
+  impl.update(static_cast<const uint8_t*>(bytes), size);
+  return impl.finalize();
+}
+
+}  // namespace pagx

--- a/src/pagx/utils/MD5.cpp
+++ b/src/pagx/utils/MD5.cpp
@@ -33,11 +33,11 @@ inline uint32_t H(uint32_t x, uint32_t y, uint32_t z) {
 inline uint32_t I(uint32_t x, uint32_t y, uint32_t z) {
   return y ^ (x | ~z);
 }
-inline uint32_t rotate_left(uint32_t x, uint32_t n) {
+inline uint32_t RotateLeft(uint32_t x, uint32_t n) {
   return (x << n) | (x >> (32 - n));
 }
 
-const uint32_t k[64] = {
+const uint32_t K[64] = {
     0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
     0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
     0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
@@ -46,7 +46,7 @@ const uint32_t k[64] = {
     0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
     0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
     0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391};
-const uint32_t r[] = {7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+const uint32_t R[] = {7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
                       5, 9,  14, 20, 5, 9,  14, 20, 5, 9,  14, 20, 5, 9,  14, 20,
                       4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
                       6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21};
@@ -132,7 +132,7 @@ class MD5Impl {
       uint32_t temp = d;
       d = c;
       c = b;
-      b = b + rotate_left(a + f + k[i] + m[g], r[i]);
+      b = b + RotateLeft(a + f + K[i] + m[g], R[i]);
       a = temp;
     }
     state[0] += a;

--- a/src/pagx/utils/MD5.h
+++ b/src/pagx/utils/MD5.h
@@ -20,7 +20,6 @@
 
 #include <array>
 #include <cstdint>
-#include <cstring>
 
 namespace pagx {
 

--- a/src/pagx/utils/MD5.h
+++ b/src/pagx/utils/MD5.h
@@ -2,12 +2,12 @@
 //
 //  Tencent is pleased to support the open source community by making libpag available.
 //
-//  Copyright (C) 2025 Tencent. All rights reserved.
+//  Copyright (C) 2026 Tencent. All rights reserved.
 //
-//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
-//  in compliance with the License. You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
 //
-//      https://opensource.org/licenses/BSD-3-Clause
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 //  unless required by applicable law or agreed to in writing, software distributed under the
 //  license is distributed on an "as is" basis, without warranties or conditions of any kind,

--- a/src/pagx/utils/MD5.h
+++ b/src/pagx/utils/MD5.h
@@ -1,0 +1,34 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2025 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+namespace pagx {
+
+class MD5 {
+ public:
+  using Digest = std::array<uint8_t, 16>;
+
+  static Digest Calculate(const void* bytes, size_t size);
+};
+
+}  // namespace pagx

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -549,6 +549,70 @@ PAGX_TEST(PAGXTest, PathDataDeduplicationWithExistingId) {
 }
 
 /**
+ * Test case: PathData deduplication when unnamed PathData is processed before named same-content
+ *
+ * Verifies that if an unnamed PathData with the same content as a named PathData is encountered
+ * first during export, the output still uses the named ID for both, without producing duplicate
+ * PathData resources.
+ */
+PAGX_TEST(PAGXTest, PathDataDeduplicationUnnamedBeforeNamed) {
+  auto doc = pagx::PAGXDocument::Make(300, 200);
+
+  auto layer = doc->makeNode<pagx::Layer>();
+
+  // Create a PathData with explicit ID in doc->nodes (registered as a resource)
+  auto namedPathData = doc->makeNode<pagx::PathData>("myTriangle");
+  namedPathData->moveTo(0, 0);
+  namedPathData->lineTo(40, 0);
+  namedPathData->lineTo(20, 30);
+  namedPathData->close();
+
+  // Path 1: Uses an UNNAMED PathData with identical content (unnamed comes FIRST in layer)
+  auto path1 = doc->makeNode<pagx::Path>();
+  path1->data = doc->makeNode<pagx::PathData>();
+  path1->data->moveTo(0, 0);
+  path1->data->lineTo(40, 0);
+  path1->data->lineTo(20, 30);
+  path1->data->close();
+  path1->position = {10, 10};
+  layer->contents.push_back(path1);
+
+  // Path 2: Uses the named PathData (named comes SECOND in layer)
+  auto path2 = doc->makeNode<pagx::Path>();
+  path2->data = namedPathData;
+  path2->position = {100, 10};
+  layer->contents.push_back(path2);
+
+  doc->layers.push_back(layer);
+
+  std::string xml = pagx::PAGXExporter::ToXML(*doc);
+  ASSERT_FALSE(xml.empty());
+
+  // Both paths should reference "@myTriangle": unnamed is merged to named ID.
+  size_t refCount = 0;
+  size_t pos = 0;
+  while ((pos = xml.find("data=\"@myTriangle\"", pos)) != std::string::npos) {
+    refCount++;
+    pos++;
+  }
+  EXPECT_EQ(refCount, 2u) << "Both paths should reference @myTriangle";
+
+  // There should be no generated __pd_ IDs in Resources.
+  EXPECT_EQ(xml.find("<PathData id=\"__pd_"), std::string::npos)
+      << "No generated PathData IDs should exist when all content matches named PathData";
+
+  // The named PathData resource should appear exactly once.
+  std::string tag = "<PathData id=\"myTriangle\"";
+  size_t defCount = 0;
+  size_t defPos = 0;
+  while ((defPos = xml.find(tag, defPos)) != std::string::npos) {
+    defCount++;
+    defPos++;
+  }
+  EXPECT_EQ(defCount, 1u) << "Named PathData should be defined exactly once in Resources";
+}
+
+/**
  * Test case: PathData deduplication avoids ID collision with user-defined IDs
  *
  * Verifies that generated IDs skip over user-defined IDs that match the generation pattern.

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -523,6 +523,61 @@ PAGX_TEST(PAGXTest, PathDataDeduplicationWithExistingId) {
 }
 
 /**
+ * Test case: PathData deduplication avoids ID collision with user-defined IDs
+ *
+ * Verifies that generated IDs skip over user-defined IDs that match the generation pattern.
+ */
+PAGX_TEST(PAGXTest, PathDataDeduplicationIdCollision) {
+  auto doc = pagx::PAGXDocument::Make(300, 200);
+
+  auto layer = doc->makeNode<pagx::Layer>();
+
+  // User defines a PathData with ID "__pd_0" (matches the generation pattern)
+  auto userPathData = doc->makeNode<pagx::PathData>("__pd_0");
+  userPathData->moveTo(0, 0);
+  userPathData->lineTo(100, 0);
+  userPathData->lineTo(100, 100);
+  userPathData->close();
+
+  // Path using user-defined PathData
+  auto path1 = doc->makeNode<pagx::Path>();
+  path1->data = userPathData;
+  path1->position = {10, 10};
+  layer->contents.push_back(path1);
+
+  // Path with new PathData (should get "__pd_1", skipping "__pd_0")
+  auto path2 = doc->makeNode<pagx::Path>();
+  path2->data = doc->makeNode<pagx::PathData>();
+  path2->data->moveTo(0, 0);
+  path2->data->lineTo(50, 50);
+  path2->data->close();
+  path2->position = {150, 10};
+  layer->contents.push_back(path2);
+
+  auto fill = doc->makeNode<pagx::Fill>();
+  auto solid = doc->makeNode<pagx::SolidColor>();
+  solid->color = {0, 1, 0, 1};
+  fill->color = solid;
+  layer->contents.push_back(fill);
+
+  doc->layers.push_back(layer);
+
+  std::string xml = pagx::PAGXExporter::ToXML(*doc);
+  ASSERT_FALSE(xml.empty());
+
+  // path1 should reference user's "__pd_0"
+  EXPECT_NE(xml.find("data=\"@__pd_0\""), std::string::npos);
+
+  // path2 should get "__pd_1" (skipping "__pd_0" which is reserved)
+  EXPECT_NE(xml.find("data=\"@__pd_1\""), std::string::npos)
+      << "Generated ID should skip reserved '__pd_0' and use '__pd_1'";
+
+  // Both PathData resources should exist
+  EXPECT_NE(xml.find("<PathData id=\"__pd_0\""), std::string::npos);
+  EXPECT_NE(xml.find("<PathData id=\"__pd_1\""), std::string::npos);
+}
+
+/**
  * Test case: PAGXDocument creation and XML export
  */
 PAGX_TEST(PAGXTest, PAGXDocumentXMLExport) {

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -21,6 +21,8 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <map>
+#include <set>
 #include <unordered_map>
 #include "cli/CommandResolve.h"
 #include "cli/CommandVerify.h"
@@ -397,59 +399,79 @@ PAGX_TEST(PAGXTest, PathDataDeduplication) {
   // Path 1, 2, 4 have identical content, should share "__pd_0"
   // Path 3 has different content, should get "__pd_1"
 
-  // Count occurrences of PathData references in Path elements
-  size_t pd0RefCount = 0;
-  size_t pd1RefCount = 0;
+  // Verify deduplication by behavior: count unique PathData IDs referenced and defined.
+  // Extract all data="@..." references from Path elements.
+  std::set<std::string> referencedIds;
+  std::map<std::string, int> referenceCount;
   size_t pos = 0;
-  while ((pos = xml.find("data=\"@__pd_0\"", pos)) != std::string::npos) {
-    pd0RefCount++;
-    pos++;
-  }
-  pos = 0;
-  while ((pos = xml.find("data=\"@__pd_1\"", pos)) != std::string::npos) {
-    pd1RefCount++;
-    pos++;
-  }
-
-  // path1, path2, path4 should reference __pd_0 (3 references)
-  // path3 should reference __pd_1 (1 reference)
-  EXPECT_EQ(pd0RefCount, 3u) << "Triangle paths should share __pd_0";
-  EXPECT_EQ(pd1RefCount, 1u) << "Rectangle path should use __pd_1";
-
-  // Verify PathData resources are written only once each in Resources section
-  size_t pd0DefCount = 0;
-  size_t pd1DefCount = 0;
-  pos = 0;
-  while ((pos = xml.find("<PathData id=\"__pd_0\"", pos)) != std::string::npos) {
-    pd0DefCount++;
-    pos++;
-  }
-  pos = 0;
-  while ((pos = xml.find("<PathData id=\"__pd_1\"", pos)) != std::string::npos) {
-    pd1DefCount++;
-    pos++;
+  while (pos < xml.size()) {
+    size_t found = xml.find("data=\"@", pos);
+    if (found == std::string::npos) {
+      break;
+    }
+    size_t idStart = found + 7;
+    size_t idEnd = xml.find('"', idStart);
+    if (idEnd == std::string::npos) {
+      break;
+    }
+    std::string id = xml.substr(idStart, idEnd - idStart);
+    referencedIds.insert(id);
+    referenceCount[id]++;
+    pos = idEnd + 1;
   }
 
-  EXPECT_EQ(pd0DefCount, 1u) << "PathData __pd_0 should be defined exactly once";
-  EXPECT_EQ(pd1DefCount, 1u) << "PathData __pd_1 should be defined exactly once";
+  // path1, path2, path4 share identical content -> one shared ID with 3 references
+  // path3 has different content -> a separate ID with 1 reference
+  EXPECT_EQ(referencedIds.size(), 2u) << "Should deduplicate to exactly 2 unique PathData IDs";
+  bool foundSharedId = false;
+  bool foundUniqueId = false;
+  for (const auto& [id, count] : referenceCount) {
+    if (count == 3) {
+      foundSharedId = true;
+    }
+    if (count == 1) {
+      foundUniqueId = true;
+    }
+  }
+  EXPECT_TRUE(foundSharedId) << "Triangle paths should share one PathData ID (3 references)";
+  EXPECT_TRUE(foundUniqueId) << "Rectangle path should have its own PathData ID (1 reference)";
+
+  // Verify each referenced PathData is defined exactly once in Resources.
+  for (const auto& id : referencedIds) {
+    std::string tag = "<PathData id=\"" + id + "\"";
+    size_t defCount = 0;
+    size_t defPos = 0;
+    while ((defPos = xml.find(tag, defPos)) != std::string::npos) {
+      defCount++;
+      defPos++;
+    }
+    EXPECT_EQ(defCount, 1u) << "PathData " << id << " should be defined exactly once";
+  }
 
   // Verify deterministic output: export again and compare
   std::string xml2 = pagx::PAGXExporter::ToXML(*doc);
   EXPECT_EQ(xml, xml2) << "Export should be deterministic";
 
-  // Verify round-trip: import and re-export should preserve structure
+  // Verify round-trip: import and re-export should preserve structure and path content.
   auto doc2 = pagx::PAGXImporter::FromXML(xml);
   ASSERT_TRUE(doc2 != nullptr);
   EXPECT_TRUE(doc2->errors.empty());
   ASSERT_EQ(doc2->layers.size(), 1u);
 
-  // The imported document should have the same number of Path elements
   auto* importedLayer = doc2->layers[0];
   int pathCount = 0;
   for (const auto* element : importedLayer->contents) {
-    if (element->nodeType() == pagx::NodeType::Path) {
-      pathCount++;
+    if (element->nodeType() != pagx::NodeType::Path) {
+      continue;
     }
+    pathCount++;
+    auto* importedPath = static_cast<const pagx::Path*>(element);
+    ASSERT_TRUE(importedPath->data != nullptr);
+    // Each imported path data must be non-empty and have the triangle (4 verbs) or
+    // rectangle (5 verbs) shape.
+    const auto& verbs = importedPath->data->verbs();
+    EXPECT_TRUE(verbs.size() == 4u || verbs.size() == 5u)
+        << "Imported path should have triangle (4 verbs) or rectangle (5 verbs) shape";
   }
   EXPECT_EQ(pathCount, 4) << "Should have 4 Path elements after import";
 }
@@ -513,9 +535,12 @@ PAGX_TEST(PAGXTest, PathDataDeduplicationWithExistingId) {
   }
   EXPECT_EQ(myTriangleRefCount, 2u) << "Paths using shared PathData should reference @myTriangle";
 
-  // path3 should get a generated ID like "__pd_0"
-  EXPECT_NE(xml.find("data=\"@__pd_0\""), std::string::npos)
-      << "Path with unnamed PathData should get generated ID";
+  // path3 has identical content to sharedPathData -> should be merged and reference myTriangle.
+  EXPECT_NE(xml.find("data=\"@myTriangle\""), std::string::npos)
+      << "Path with unnamed but identical PathData should reference the named PathData";
+  // There should be no extra generated PathData IDs in Resources.
+  EXPECT_EQ(xml.find("<PathData id=\"__pd_"), std::string::npos)
+      << "No generated PathData IDs should exist when all content matches named PathData";
 
   // Verify the explicit PathData resource exists
   EXPECT_NE(xml.find("<PathData id=\"myTriangle\""), std::string::npos)
@@ -575,6 +600,89 @@ PAGX_TEST(PAGXTest, PathDataDeduplicationIdCollision) {
   // Both PathData resources should exist
   EXPECT_NE(xml.find("<PathData id=\"__pd_0\""), std::string::npos);
   EXPECT_NE(xml.find("<PathData id=\"__pd_1\""), std::string::npos);
+}
+
+/**
+ * Test case: PathData deduplication for TextPath elements
+ *
+ * Verifies that TextPath elements sharing identical PathData content are deduplicated
+ * in the same way as Path elements.
+ */
+PAGX_TEST(PAGXTest, PathDataDeduplicationTextPath) {
+  auto doc = pagx::PAGXDocument::Make(400, 300);
+
+  auto layer = doc->makeNode<pagx::Layer>();
+
+  // TextPath 1: curve at top
+  auto textPath1 = doc->makeNode<pagx::TextPath>();
+  textPath1->path = doc->makeNode<pagx::PathData>();
+  textPath1->path->moveTo(0, 100);
+  textPath1->path->lineTo(400, 100);
+
+  // TextPath 2: identical curve
+  auto textPath2 = doc->makeNode<pagx::TextPath>();
+  textPath2->path = doc->makeNode<pagx::PathData>();
+  textPath2->path->moveTo(0, 100);
+  textPath2->path->lineTo(400, 100);
+
+  // TextPath 3: different curve
+  auto textPath3 = doc->makeNode<pagx::TextPath>();
+  textPath3->path = doc->makeNode<pagx::PathData>();
+  textPath3->path->moveTo(0, 200);
+  textPath3->path->lineTo(400, 200);
+
+  layer->contents.push_back(textPath1);
+  layer->contents.push_back(textPath2);
+  layer->contents.push_back(textPath3);
+  doc->layers.push_back(layer);
+
+  std::string xml = pagx::PAGXExporter::ToXML(*doc);
+  ASSERT_FALSE(xml.empty());
+
+  // Collect all path="@..." references from TextPath elements.
+  std::map<std::string, int> referenceCount;
+  size_t pos = 0;
+  while (pos < xml.size()) {
+    size_t found = xml.find("path=\"@", pos);
+    if (found == std::string::npos) {
+      break;
+    }
+    size_t idStart = found + 7;
+    size_t idEnd = xml.find('"', idStart);
+    if (idEnd == std::string::npos) {
+      break;
+    }
+    referenceCount[xml.substr(idStart, idEnd - idStart)]++;
+    pos = idEnd + 1;
+  }
+
+  // textPath1 and textPath2 share identical content -> one shared ID with 2 references.
+  // textPath3 has different content -> a separate ID with 1 reference.
+  EXPECT_EQ(referenceCount.size(), 2u) << "Should deduplicate to exactly 2 unique PathData IDs";
+  bool foundSharedId = false;
+  bool foundUniqueId = false;
+  for (const auto& [id, count] : referenceCount) {
+    if (count == 2) {
+      foundSharedId = true;
+    }
+    if (count == 1) {
+      foundUniqueId = true;
+    }
+  }
+  EXPECT_TRUE(foundSharedId) << "Identical TextPath curves should share one PathData ID";
+  EXPECT_TRUE(foundUniqueId) << "Different TextPath curve should have its own PathData ID";
+
+  // Each referenced PathData must be defined exactly once in Resources.
+  for (const auto& [id, count] : referenceCount) {
+    std::string tag = "<PathData id=\"" + id + "\"";
+    size_t defCount = 0;
+    size_t defPos = 0;
+    while ((defPos = xml.find(tag, defPos)) != std::string::npos) {
+      defCount++;
+      defPos++;
+    }
+    EXPECT_EQ(defCount, 1u) << "PathData " << id << " should be defined exactly once";
+  }
 }
 
 /**

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -326,6 +326,203 @@ PAGX_TEST(PAGXTest, PathDataForEach) {
 }
 
 /**
+ * Test case: PathData deduplication during export
+ *
+ * Verifies that:
+ * 1. Multiple Path elements with identical PathData content share the same ID in output
+ * 2. PathData resources are written only once in the Resources section
+ * 3. Export output is deterministic (same input produces same output)
+ */
+PAGX_TEST(PAGXTest, PathDataDeduplication) {
+  auto doc = pagx::PAGXDocument::Make(400, 300);
+
+  // Create a layer with three Path elements using identical PathData content
+  auto layer = doc->makeNode<pagx::Layer>();
+  layer->id = "dedup_layer";
+
+  // Path 1: Triangle at position (10, 10)
+  auto path1 = doc->makeNode<pagx::Path>();
+  path1->data = doc->makeNode<pagx::PathData>();
+  path1->data->moveTo(0, 0);
+  path1->data->lineTo(50, 0);
+  path1->data->lineTo(25, 40);
+  path1->data->close();
+  path1->position = {10, 10};
+  layer->contents.push_back(path1);
+
+  // Path 2: Same triangle shape at different position (100, 10)
+  auto path2 = doc->makeNode<pagx::Path>();
+  path2->data = doc->makeNode<pagx::PathData>();
+  path2->data->moveTo(0, 0);
+  path2->data->lineTo(50, 0);
+  path2->data->lineTo(25, 40);
+  path2->data->close();
+  path2->position = {100, 10};
+  layer->contents.push_back(path2);
+
+  // Path 3: Different shape (rectangle)
+  auto path3 = doc->makeNode<pagx::Path>();
+  path3->data = doc->makeNode<pagx::PathData>();
+  path3->data->moveTo(0, 0);
+  path3->data->lineTo(60, 0);
+  path3->data->lineTo(60, 30);
+  path3->data->lineTo(0, 30);
+  path3->data->close();
+  path3->position = {200, 10};
+  layer->contents.push_back(path3);
+
+  // Path 4: Same as path1/path2 (third instance of triangle)
+  auto path4 = doc->makeNode<pagx::Path>();
+  path4->data = doc->makeNode<pagx::PathData>();
+  path4->data->moveTo(0, 0);
+  path4->data->lineTo(50, 0);
+  path4->data->lineTo(25, 40);
+  path4->data->close();
+  path4->position = {10, 100};
+  layer->contents.push_back(path4);
+
+  auto fill = doc->makeNode<pagx::Fill>();
+  auto solid = doc->makeNode<pagx::SolidColor>();
+  solid->color = {0, 0, 1, 1};
+  fill->color = solid;
+  layer->contents.push_back(fill);
+
+  doc->layers.push_back(layer);
+
+  // Export to XML
+  std::string xml = pagx::PAGXExporter::ToXML(*doc);
+  ASSERT_FALSE(xml.empty());
+
+  // Verify deduplication: All Path elements should reference PathData by ID
+  // Path 1, 2, 4 have identical content, should share "__pd_0"
+  // Path 3 has different content, should get "__pd_1"
+
+  // Count occurrences of PathData references in Path elements
+  size_t pd0RefCount = 0;
+  size_t pd1RefCount = 0;
+  size_t pos = 0;
+  while ((pos = xml.find("data=\"@__pd_0\"", pos)) != std::string::npos) {
+    pd0RefCount++;
+    pos++;
+  }
+  pos = 0;
+  while ((pos = xml.find("data=\"@__pd_1\"", pos)) != std::string::npos) {
+    pd1RefCount++;
+    pos++;
+  }
+
+  // path1, path2, path4 should reference __pd_0 (3 references)
+  // path3 should reference __pd_1 (1 reference)
+  EXPECT_EQ(pd0RefCount, 3u) << "Triangle paths should share __pd_0";
+  EXPECT_EQ(pd1RefCount, 1u) << "Rectangle path should use __pd_1";
+
+  // Verify PathData resources are written only once each in Resources section
+  size_t pd0DefCount = 0;
+  size_t pd1DefCount = 0;
+  pos = 0;
+  while ((pos = xml.find("<PathData id=\"__pd_0\"", pos)) != std::string::npos) {
+    pd0DefCount++;
+    pos++;
+  }
+  pos = 0;
+  while ((pos = xml.find("<PathData id=\"__pd_1\"", pos)) != std::string::npos) {
+    pd1DefCount++;
+    pos++;
+  }
+
+  EXPECT_EQ(pd0DefCount, 1u) << "PathData __pd_0 should be defined exactly once";
+  EXPECT_EQ(pd1DefCount, 1u) << "PathData __pd_1 should be defined exactly once";
+
+  // Verify deterministic output: export again and compare
+  std::string xml2 = pagx::PAGXExporter::ToXML(*doc);
+  EXPECT_EQ(xml, xml2) << "Export should be deterministic";
+
+  // Verify round-trip: import and re-export should preserve structure
+  auto doc2 = pagx::PAGXImporter::FromXML(xml);
+  ASSERT_TRUE(doc2 != nullptr);
+  EXPECT_TRUE(doc2->errors.empty());
+  ASSERT_EQ(doc2->layers.size(), 1u);
+
+  // The imported document should have the same number of Path elements
+  auto* importedLayer = doc2->layers[0];
+  int pathCount = 0;
+  for (const auto* element : importedLayer->contents) {
+    if (element->nodeType() == pagx::NodeType::Path) {
+      pathCount++;
+    }
+  }
+  EXPECT_EQ(pathCount, 4) << "Should have 4 Path elements after import";
+}
+
+/**
+ * Test case: PathData deduplication with existing IDs
+ *
+ * Verifies that PathData with user-defined IDs are preserved and not deduplicated.
+ */
+PAGX_TEST(PAGXTest, PathDataDeduplicationWithExistingId) {
+  auto doc = pagx::PAGXDocument::Make(300, 200);
+
+  auto layer = doc->makeNode<pagx::Layer>();
+
+  // Create a PathData with explicit ID (makeNode already adds it to doc->nodes)
+  auto sharedPathData = doc->makeNode<pagx::PathData>("myTriangle");
+  sharedPathData->moveTo(0, 0);
+  sharedPathData->lineTo(40, 0);
+  sharedPathData->lineTo(20, 30);
+  sharedPathData->close();
+
+  // Path 1: Uses the shared PathData by reference
+  auto path1 = doc->makeNode<pagx::Path>();
+  path1->data = sharedPathData;
+  path1->position = {10, 10};
+  layer->contents.push_back(path1);
+
+  // Path 2: Uses the same shared PathData
+  auto path2 = doc->makeNode<pagx::Path>();
+  path2->data = sharedPathData;
+  path2->position = {100, 10};
+  layer->contents.push_back(path2);
+
+  // Path 3: Has identical content but created separately (no ID)
+  auto path3 = doc->makeNode<pagx::Path>();
+  path3->data = doc->makeNode<pagx::PathData>();
+  path3->data->moveTo(0, 0);
+  path3->data->lineTo(40, 0);
+  path3->data->lineTo(20, 30);
+  path3->data->close();
+  path3->position = {200, 10};
+  layer->contents.push_back(path3);
+
+  auto fill = doc->makeNode<pagx::Fill>();
+  auto solid = doc->makeNode<pagx::SolidColor>();
+  solid->color = {1, 0, 0, 1};
+  fill->color = solid;
+  layer->contents.push_back(fill);
+
+  doc->layers.push_back(layer);
+
+  std::string xml = pagx::PAGXExporter::ToXML(*doc);
+  ASSERT_FALSE(xml.empty());
+
+  // path1 and path2 should reference "@myTriangle" (the explicit ID)
+  size_t myTriangleRefCount = 0;
+  size_t pos = 0;
+  while ((pos = xml.find("data=\"@myTriangle\"", pos)) != std::string::npos) {
+    myTriangleRefCount++;
+    pos++;
+  }
+  EXPECT_EQ(myTriangleRefCount, 2u) << "Paths using shared PathData should reference @myTriangle";
+
+  // path3 should get a generated ID like "__pd_0"
+  EXPECT_NE(xml.find("data=\"@__pd_0\""), std::string::npos)
+      << "Path with unnamed PathData should get generated ID";
+
+  // Verify the explicit PathData resource exists
+  EXPECT_NE(xml.find("<PathData id=\"myTriangle\""), std::string::npos)
+      << "User-defined PathData should be in Resources";
+}
+
+/**
  * Test case: PAGXDocument creation and XML export
  */
 PAGX_TEST(PAGXTest, PAGXDocumentXMLExport) {

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -526,14 +526,15 @@ PAGX_TEST(PAGXTest, PathDataDeduplicationWithExistingId) {
   std::string xml = pagx::PAGXExporter::ToXML(*doc);
   ASSERT_FALSE(xml.empty());
 
-  // path1 and path2 should reference "@myTriangle" (the explicit ID)
+  // path1, path2, and path3 should all reference "@myTriangle": path1/path2 share the same
+  // PathData object, and path3 has identical content so it is merged to the named ID.
   size_t myTriangleRefCount = 0;
   size_t pos = 0;
   while ((pos = xml.find("data=\"@myTriangle\"", pos)) != std::string::npos) {
     myTriangleRefCount++;
     pos++;
   }
-  EXPECT_EQ(myTriangleRefCount, 2u) << "Paths using shared PathData should reference @myTriangle";
+  EXPECT_EQ(myTriangleRefCount, 3u) << "All three paths should reference @myTriangle";
 
   // path3 has identical content to sharedPathData -> should be merged and reference myTriangle.
   EXPECT_NE(xml.find("data=\"@myTriangle\""), std::string::npos)


### PR DESCRIPTION
在 PAGX 导出时实现 PathData 去重功能，并避免 ID 冲突。

主要变更：
- 新增 ExportContext 结构管理导出时的 PathData 映射状态
- 相同路径内容的 PathData 共享同一个生成的 ID（如 __pd_0、__pd_1）
- 用户定义的 PathData ID 保持不变
- 生成 ID 时自动跳过已被用户占用的 ID，避免冲突
- 输出按 ID 排序，确保确定性
- 使用 MD5 digest（16 字节）替代完整 SVG 字符串作为 pathDataContentToOutputId 的 map key，降低内存占用
- 引入 Phase 0 两阶段预收集：写入 XML 前先遍历 doc.nodes 注册所有具名 PathData，再遍历所有 Layer，确保 unnamed 与 named 同内容时优先使用 named ID
- 用 hasAnonymousPathData 标志精确控制是否需要写出去重段，修复 named-only 场景下误写空 Resources 的问题
- 新增测试：PathDataDeduplication、PathDataDeduplicationWithExistingId、PathDataDeduplicationIdCollision、PathDataDeduplicationUnnamedBeforeNamed