### PR TITLE
Make pagx spec self-contained by removing xsd reference.

### DIFF
--- a/spec/pagx_spec.md
+++ b/spec/pagx_spec.md
@@ -97,7 +97,7 @@ The following attributes are available on any element and are not repeated in in
 | `string` | String | `"Arial"`, `"myLayer"` |
 | `enum` | Enumeration value | `normal`, `multiply` |
 | `idref` | ID reference | `@gradientId`, `@maskLayer` |
-| `Dimension` | A non-negative floating-point number in pixels, or the same number followed by `%` to denote a percentage of the parent container's corresponding axis (inside padding). Grammar matches the xsd `DimensionType` pattern `[0-9]*\.?[0-9]+%?` | `100`, `0.5`, `50%`, `100%` |
+| `Dimension` | A non-negative floating-point number in pixels, or the same number followed by `%` to denote a percentage of the parent container's corresponding axis (inside padding). Grammar matches the pattern `[0-9]*\.?[0-9]+%?` | `100`, `0.5`, `50%`, `100%` |
 
 ### 2.5 Point
 

--- a/spec/pagx_spec.md
+++ b/spec/pagx_spec.md
@@ -97,7 +97,7 @@ The following attributes are available on any element and are not repeated in in
 | `string` | String | `"Arial"`, `"myLayer"` |
 | `enum` | Enumeration value | `normal`, `multiply` |
 | `idref` | ID reference | `@gradientId`, `@maskLayer` |
-| `Dimension` | A non-negative floating-point number in pixels, or the same number followed by `%` to denote a percentage of the parent container's corresponding axis (inside padding). Grammar matches the pattern `[0-9]*\.?[0-9]+%?` | `100`, `0.5`, `50%`, `100%` |
+| `Dimension` | A non-negative floating-point number in pixels, or the same number followed by `%` to denote a percentage of the parent container's corresponding axis (inside padding). | `100`, `0.5`, `50%`, `100%` |
 
 ### 2.5 Point
 

--- a/spec/pagx_spec.zh_CN.md
+++ b/spec/pagx_spec.zh_CN.md
@@ -97,7 +97,7 @@ PAGX 是纯 XML 文件（`.pagx`），可引用外部资源文件（图片、视
 | `string` | 字符串 | `"Arial"`、`"myLayer"` |
 | `enum` | 枚举值 | `normal`、`multiply` |
 | `idref` | ID 引用 | `@gradientId`、`@maskLayer` |
-| `Dimension` | 非负浮点数（像素），或其后跟 `%` 表示相对父容器对应轴（内缩 padding 后）的百分比。语法匹配 xsd `DimensionType` 模式 `[0-9]*\.?[0-9]+%?` | `100`、`0.5`、`50%`、`100%` |
+| `Dimension` | 非负浮点数（像素），或其后跟 `%` 表示相对父容器对应轴（内缩 padding 后）的百分比。语法匹配模式 `[0-9]*\.?[0-9]+%?` | `100`、`0.5`、`50%`、`100%` |
 
 ### 2.5 点（Point）
 

--- a/spec/pagx_spec.zh_CN.md
+++ b/spec/pagx_spec.zh_CN.md
@@ -97,7 +97,7 @@ PAGX 是纯 XML 文件（`.pagx`），可引用外部资源文件（图片、视
 | `string` | 字符串 | `"Arial"`、`"myLayer"` |
 | `enum` | 枚举值 | `normal`、`multiply` |
 | `idref` | ID 引用 | `@gradientId`、`@maskLayer` |
-| `Dimension` | 非负浮点数（像素），或其后跟 `%` 表示相对父容器对应轴（内缩 padding 后）的百分比。语法匹配模式 `[0-9]*\.?[0-9]+%?` | `100`、`0.5`、`50%`、`100%` |
+| `Dimension` | 非负浮点数（像素），或其后跟 `%` 表示相对父容器对应轴（内缩 padding 后）的百分比。 | `100`、`0.5`、`50%`、`100%` |
 
 ### 2.5 点（Point）
 


### PR DESCRIPTION
移除 pagx 中英文规范中对 xsd DimensionType 的引用，使规范保持独立、不依赖外部定义。同时删除原来与自然语言描述重复的正则模式片段，简化 Dimension 类型的说明。