### PR TITLE
Fix PAGImageView deadlock caused by animator update re-entering mutex

### DIFF
--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -378,32 +378,39 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
 - (void)setBounds:(CGRect)bounds {
   CGRect oldBounds = self.bounds;
   [super setBounds:bounds];
-  self.viewSize = CGSizeMake(bounds.size.width, bounds.size.height);
-  if (oldBounds.size.width != bounds.size.width || oldBounds.size.height != bounds.size.height) {
-    std::lock_guard<std::mutex> autoLock(imageViewLock);
-    if (pagComposition || filePath) {
-      [self reset];
-      [self updatePAGDecoder];
-      if (oldBounds.size.width == 0 || oldBounds.size.height == 0) {
-        [animator update];
-      }
-    }
-  }
+  [self handleSizeChanged:oldBounds.size newSize:bounds.size];
 }
 
 - (void)setFrame:(CGRect)frame {
   CGRect oldRect = self.frame;
   [super setFrame:frame];
-  self.viewSize = CGSizeMake(frame.size.width, frame.size.height);
-  if (oldRect.size.width != frame.size.width || oldRect.size.height != frame.size.height) {
+  [self handleSizeChanged:oldRect.size newSize:frame.size];
+}
+
+// Resets and rebuilds the decoder for a size change, then triggers a one-off
+// animator update so the first frame is rendered at the new size.
+//
+// Thread safety note: [animator update] can synchronously flow back into
+// -[PAGImageView flush], which also acquires imageViewLock. The critical
+// section here only mutates internal state, and the animator update is
+// deliberately scheduled after the lock is released to prevent the same
+// thread from attempting to re-enter a non-recursive mutex and deadlock.
+- (void)handleSizeChanged:(CGSize)oldSize newSize:(CGSize)newSize {
+  self.viewSize = newSize;
+  if (oldSize.width == newSize.width && oldSize.height == newSize.height) {
+    return;
+  }
+  BOOL shouldUpdateAnimator = NO;
+  {
     std::lock_guard<std::mutex> autoLock(imageViewLock);
     if (pagComposition || filePath) {
       [self reset];
       [self updatePAGDecoder];
-      if (oldRect.size.width == 0 || oldRect.size.height == 0) {
-        [animator update];
-      }
+      shouldUpdateAnimator = (oldSize.width == 0 || oldSize.height == 0);
     }
+  }
+  if (shouldUpdateAnimator) {
+    [animator update];
   }
 }
 

--- a/src/platform/ohos/JPAGImageView.cpp
+++ b/src/platform/ohos/JPAGImageView.cpp
@@ -586,14 +586,21 @@ void JPAGImageView::onAnimationUpdate(PAGAnimator* animator) {
 }
 
 void JPAGImageView::onSurfaceCreated(NativeWindow* window) {
-  std::lock_guard lock_guard(locker);
-  if (_animator == nullptr) {
-    return;
+  {
+    std::lock_guard lock_guard(locker);
+    if (_animator == nullptr) {
+      return;
+    }
+    _window = window;
+    targetWindow = tgfx::EGLWindow::MakeFrom(reinterpret_cast<EGLNativeWindowType>(_window));
+    invalidSize();
   }
-  _window = window;
-  targetWindow = tgfx::EGLWindow::MakeFrom(reinterpret_cast<EGLNativeWindowType>(_window));
-  invalidSize();
-  _animator->update();
+  // animator->update() can synchronously flow back into onAnimationUpdate,
+  // which also acquires `locker`. Call it outside the critical section to
+  // avoid re-entering the same non-recursive mutex on the caller thread.
+  if (_animator) {
+    _animator->update();
+  }
 }
 
 void JPAGImageView::onSurfaceSizeChanged() {


### PR DESCRIPTION
修复 iOS 和 OHOS 平台上 PAGImageView 因 animator update 回调重入 mutex 导致的死锁问题。

在 iOS 端，setBounds/setFrame 方法持有 imageViewLock 后调用 [animator update]，而 update 会同步回调 flush 再次尝试获取 imageViewLock，导致同一线程对非递归互斥锁的重入死锁。修复方式是将 [animator update] 调用移到锁作用域之外。

在 OHOS 端，onSurfaceCreated 同样存在持锁调用 _animator->update() 导致 onAnimationUpdate 回调重入 locker 的问题，采用相同策略修复。