### PR TITLE
Fix HarmonyOS PAGView/PAGImageView callback leaks and OHOSVideoDecoder use-after-free

### DIFF
--- a/src/platform/ohos/JPAGImageView.cpp
+++ b/src/platform/ohos/JPAGImageView.cpp
@@ -335,12 +335,16 @@ static napi_value SetStateChangeCallback(napi_env env, napi_callback_info info) 
   }
   JPAGImageView* view = nullptr;
   napi_unwrap(env, jsView, reinterpret_cast<void**>(&view));
+  if (view == nullptr) {
+    return nullptr;
+  }
 
   napi_value resourceName = nullptr;
   napi_create_string_utf8(env, "PAGViewStateChangeCallback", NAPI_AUTO_LENGTH, &resourceName);
-
+  napi_threadsafe_function callback = nullptr;
   napi_create_threadsafe_function(env, args[0], nullptr, resourceName, 0, 1, nullptr, nullptr, view,
-                                  StateChangeCallback, &view->playingStateCallback);
+                                  StateChangeCallback, &callback);
+  view->setPlayingStateCallback(callback);
   return nullptr;
 }
 
@@ -360,10 +364,16 @@ static napi_value SetProgressUpdateCallback(napi_env env, napi_callback_info inf
   }
   JPAGImageView* view = nullptr;
   napi_unwrap(env, jsView, reinterpret_cast<void**>(&view));
+  if (view == nullptr) {
+    return nullptr;
+  }
+
   napi_value resourceName = nullptr;
   napi_create_string_utf8(env, "PAGViewProgressCallback", NAPI_AUTO_LENGTH, &resourceName);
+  napi_threadsafe_function callback = nullptr;
   napi_create_threadsafe_function(env, args[0], nullptr, resourceName, 0, 1, nullptr, nullptr,
-                                  nullptr, ProgressCallback, &view->progressCallback);
+                                  nullptr, ProgressCallback, &callback);
+  view->setProgressCallback(callback);
   return nullptr;
 }
 
@@ -883,6 +893,30 @@ void JPAGImageView::release() {
   }
 
   invalidDecoder();
+}
+
+void JPAGImageView::setProgressCallback(napi_threadsafe_function callback) {
+  napi_threadsafe_function previous = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    previous = progressCallback;
+    progressCallback = callback;
+  }
+  if (previous != nullptr) {
+    napi_release_threadsafe_function(previous, napi_tsfn_release);
+  }
+}
+
+void JPAGImageView::setPlayingStateCallback(napi_threadsafe_function callback) {
+  napi_threadsafe_function previous = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    previous = playingStateCallback;
+    playingStateCallback = callback;
+  }
+  if (previous != nullptr) {
+    napi_release_threadsafe_function(previous, napi_tsfn_release);
+  }
 }
 
 }  // namespace pag

--- a/src/platform/ohos/JPAGImageView.h
+++ b/src/platform/ohos/JPAGImageView.h
@@ -91,10 +91,11 @@ class JPAGImageView : public PAGAnimator::Listener, public XComponentListener {
 
   void release();
 
-  std::string id;
+  void setProgressCallback(napi_threadsafe_function callback);
 
-  napi_threadsafe_function progressCallback = nullptr;
-  napi_threadsafe_function playingStateCallback = nullptr;
+  void setPlayingStateCallback(napi_threadsafe_function callback);
+
+  std::string id;
 
  private:
   static napi_value Constructor(napi_env env, napi_callback_info info);
@@ -112,6 +113,9 @@ class JPAGImageView : public PAGAnimator::Listener, public XComponentListener {
   std::pair<tgfx::Bitmap, std::shared_ptr<tgfx::Image>> getImage(Frame frame);
 
   bool present(std::shared_ptr<tgfx::Image> image);
+
+  napi_threadsafe_function progressCallback = nullptr;
+  napi_threadsafe_function playingStateCallback = nullptr;
 
   std::mutex locker;
   int _width = 0;

--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -274,12 +274,16 @@ static napi_value SetStateChangeCallback(napi_env env, napi_callback_info info) 
   }
   JPAGView* view = nullptr;
   napi_unwrap(env, jsView, reinterpret_cast<void**>(&view));
+  if (view == nullptr) {
+    return nullptr;
+  }
 
   napi_value resourceName = nullptr;
   napi_create_string_utf8(env, "PAGViewStateChangeCallback", NAPI_AUTO_LENGTH, &resourceName);
-
+  napi_threadsafe_function callback = nullptr;
   napi_create_threadsafe_function(env, args[0], nullptr, resourceName, 0, 1, nullptr, nullptr, view,
-                                  StateChangeCallback, &view->playingStateCallback);
+                                  StateChangeCallback, &callback);
+  view->setPlayingStateCallback(callback);
   return nullptr;
 }
 
@@ -299,10 +303,16 @@ static napi_value SetProgressUpdateCallback(napi_env env, napi_callback_info inf
   }
   JPAGView* view = nullptr;
   napi_unwrap(env, jsView, reinterpret_cast<void**>(&view));
+  if (view == nullptr) {
+    return nullptr;
+  }
+
   napi_value resourceName = nullptr;
   napi_create_string_utf8(env, "PAGViewProgressCallback", NAPI_AUTO_LENGTH, &resourceName);
+  napi_threadsafe_function callback = nullptr;
   napi_create_threadsafe_function(env, args[0], nullptr, resourceName, 0, 1, nullptr, nullptr,
-                                  nullptr, ProgressCallback, &view->progressCallback);
+                                  nullptr, ProgressCallback, &callback);
+  view->setProgressCallback(callback);
   return nullptr;
 }
 
@@ -934,5 +944,29 @@ std::shared_ptr<PAGAnimator> JPAGView::getAnimator() {
 std::shared_ptr<PAGPlayer> JPAGView::getPlayer() {
   std::lock_guard lock_guard(locker);
   return player;
+}
+
+void JPAGView::setProgressCallback(napi_threadsafe_function callback) {
+  napi_threadsafe_function previous = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    previous = progressCallback;
+    progressCallback = callback;
+  }
+  if (previous != nullptr) {
+    napi_release_threadsafe_function(previous, napi_tsfn_release);
+  }
+}
+
+void JPAGView::setPlayingStateCallback(napi_threadsafe_function callback) {
+  napi_threadsafe_function previous = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    previous = playingStateCallback;
+    playingStateCallback = callback;
+  }
+  if (previous != nullptr) {
+    napi_release_threadsafe_function(previous, napi_tsfn_release);
+  }
 }
 }  // namespace pag

--- a/src/platform/ohos/JPAGView.h
+++ b/src/platform/ohos/JPAGView.h
@@ -57,15 +57,18 @@ class JPAGView : public PAGAnimator::Listener, public XComponentListener {
 
   std::shared_ptr<PAGAnimator> getAnimator();
 
-  std::string id;
+  void setProgressCallback(napi_threadsafe_function callback);
 
-  napi_threadsafe_function progressCallback = nullptr;
-  napi_threadsafe_function playingStateCallback = nullptr;
+  void setPlayingStateCallback(napi_threadsafe_function callback);
+
+  std::string id;
 
  private:
   static napi_value Constructor(napi_env env, napi_callback_info info);
   std::shared_ptr<PAGPlayer> player;
   std::shared_ptr<PAGAnimator> animator = nullptr;
+  napi_threadsafe_function progressCallback = nullptr;
+  napi_threadsafe_function playingStateCallback = nullptr;
   std::mutex locker;
 };
 }  // namespace pag

--- a/src/platform/ohos/OHOSVideoDecoder.cpp
+++ b/src/platform/ohos/OHOSVideoDecoder.cpp
@@ -24,6 +24,7 @@
 #include <native_buffer/native_buffer.h>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <mutex>
 #include "base/utils/Log.h"
 #include "rendering/video/SoftwareData.h"
@@ -31,6 +32,26 @@
 
 namespace pag {
 #define NV12_PLANE_COUNT 2
+
+namespace {
+// RAII wrapper for per-frame NV12 CPU buffers. The lifetime is owned by the SoftwareData
+// attached to the ImageBuffer, so the memory stays alive until the asynchronous GPU upload
+// task finishes, even if the decoder has been destroyed in the meantime.
+struct NV12FrameBuffer {
+  uint8_t* data[2] = {nullptr, nullptr};
+  int lineSize[2] = {0, 0};
+
+  NV12FrameBuffer() = default;
+
+  ~NV12FrameBuffer() {
+    delete[] data[0];
+    delete[] data[1];
+  }
+
+  NV12FrameBuffer(const NV12FrameBuffer&) = delete;
+  NV12FrameBuffer& operator=(const NV12FrameBuffer&) = delete;
+};
+}  // namespace
 
 void OH_AVCodecOnError(OH_AVCodec*, int32_t index, void* userData) {
   if (userData == nullptr) {
@@ -80,7 +101,6 @@ std::shared_ptr<OHOSVideoDecoder> OHOSVideoDecoder::MakeSoftwareDecoder(const Vi
   if (!decoder->isValid) {
     return nullptr;
   }
-  decoder->weakThis = decoder;
   return decoder;
 }
 
@@ -91,14 +111,6 @@ OHOSVideoDecoder::OHOSVideoDecoder(const VideoFormat& format, bool hardware) {
 }
 
 OHOSVideoDecoder::~OHOSVideoDecoder() {
-  if (yuvBuffer) {
-    if (yuvBuffer->data[0]) {
-      delete[] yuvBuffer->data[0];
-    }
-    if (yuvBuffer->data[1]) {
-      delete[] yuvBuffer->data[1];
-    }
-  }
   if (videoCodec != nullptr) {
     releaseOutputBuffer();
     OH_VideoDecoder_Flush(videoCodec);
@@ -278,34 +290,46 @@ std::shared_ptr<tgfx::ImageBuffer> OHOSVideoDecoder::onRenderFrame() {
       if (videoStride == 0 || videoSliceHeight == 0) {
         return nullptr;
       }
-      yBufferSize = videoStride * videoSliceHeight;
-      uvBufferSize = codecBufferInfo.attr.size - yBufferSize;
-      yuvBuffer = std::make_shared<pag::YUVBuffer>();
-      yuvBuffer->data[0] = new (std::nothrow) uint8_t[yBufferSize];
-      if (yuvBuffer->data[0] == nullptr) {
-        videoStride = 0;
-        return nullptr;
-      }
-      yuvBuffer->data[1] = new (std::nothrow) uint8_t[uvBufferSize];
-      if (yuvBuffer->data[1] == nullptr) {
-        delete[] yuvBuffer->data[0];
-        videoStride = 0;
-        return nullptr;
-      }
-      yuvBuffer->lineSize[0] = videoStride;
-      yuvBuffer->lineSize[1] = videoStride;
     }
     auto capacity = OH_AVBuffer_GetCapacity(codecBufferInfo.buffer);
     if (capacity <= 0) {
       return nullptr;
     }
     uint8_t* yuvAddress = OH_AVBuffer_GetAddr(codecBufferInfo.buffer);
-    memcpy(yuvBuffer->data[0], yuvAddress, yBufferSize);
-    memcpy(yuvBuffer->data[1], yuvAddress + yBufferSize, uvBufferSize);
+    if (yuvAddress == nullptr) {
+      return nullptr;
+    }
+    size_t yBufferSize = static_cast<size_t>(videoStride) * static_cast<size_t>(videoSliceHeight);
+    size_t uvBufferSize = codecBufferInfo.attr.size > static_cast<int32_t>(yBufferSize)
+                              ? static_cast<size_t>(codecBufferInfo.attr.size) - yBufferSize
+                              : 0;
+    if (uvBufferSize == 0) {
+      return nullptr;
+    }
 
-    auto yuvData = SoftwareData<OHOSVideoDecoder>::Make(videoFormat.width, videoFormat.height,
-                                                        yuvBuffer->data, yuvBuffer->lineSize,
-                                                        NV12_PLANE_COUNT, weakThis.lock());
+    // Allocate a fresh frame buffer for every decoded frame. SoftwareData keeps a
+    // shared_ptr to the NV12FrameBuffer, so the memory stays alive until the asynchronous
+    // GPU upload task consumes it, even if the decoder is destroyed in the meantime.
+    auto frameBuffer = std::make_shared<NV12FrameBuffer>();
+    frameBuffer->data[0] = new (std::nothrow) uint8_t[yBufferSize];
+    if (frameBuffer->data[0] == nullptr) {
+      return nullptr;
+    }
+    frameBuffer->lineSize[0] = videoStride;
+    frameBuffer->data[1] = new (std::nothrow) uint8_t[uvBufferSize];
+    if (frameBuffer->data[1] == nullptr) {
+      return nullptr;
+    }
+    frameBuffer->lineSize[1] = videoStride;
+
+    memcpy(frameBuffer->data[0], yuvAddress, yBufferSize);
+    memcpy(frameBuffer->data[1], yuvAddress + yBufferSize, uvBufferSize);
+
+    uint8_t* planes[3] = {frameBuffer->data[0], frameBuffer->data[1], nullptr};
+    int lineSizes[3] = {frameBuffer->lineSize[0], frameBuffer->lineSize[1], 0};
+    auto yuvData =
+        SoftwareData<NV12FrameBuffer>::Make(videoFormat.width, videoFormat.height, planes,
+                                            lineSizes, NV12_PLANE_COUNT, std::move(frameBuffer));
     imageBuffer = tgfx::ImageBuffer::MakeNV12(yuvData, videoFormat.colorSpace);
   }
   return imageBuffer;

--- a/src/platform/ohos/OHOSVideoDecoder.h
+++ b/src/platform/ohos/OHOSVideoDecoder.h
@@ -93,10 +93,6 @@ class OHOSVideoDecoder : public VideoDecoder {
   OH_AVCodecCategory codecCategory = HARDWARE;
   int videoStride = 0;
   int videoSliceHeight = 0;
-  std::shared_ptr<pag::YUVBuffer> yuvBuffer = nullptr;
-  int64_t yBufferSize = 0;
-  int64_t uvBufferSize = 0;
-  std::weak_ptr<OHOSVideoDecoder> weakThis;
   size_t maxPendingFramesCount = 0;
 
   explicit OHOSVideoDecoder(const VideoFormat& format, bool hardware);


### PR DESCRIPTION
修复 HarmonyOS 平台两类问题：

1. PAGView 和 PAGImageView 的 napi_threadsafe_function 回调泄漏与竞态：原实现将 callback 指针作为 public 成员直接赋值，重复设置时不释放旧回调导致泄漏，且与动画回调线程存在竞态。改为通过加锁的 setter 方法管理，替换前释放旧 callback，同时增加 napi_unwrap 后的空指针检查。

2. OHOSVideoDecoder NV12 软件解码路径的 use-after-free：原实现复用同一块 YUV 缓冲区并通过 weak_ptr 续命，但 decoder 销毁后 SoftwareData 异步上传 GPU 时访问已释放内存。改为每帧独立分配 NV12FrameBuffer，生命周期由 SoftwareData 的 shared_ptr 持有，确保异步上传完成前内存有效。