### PR TITLE
Fix NPE in PAGImageView.flush() by moving bitmapCache.put() inside the bitmapLock synchronized block.

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGImageView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageView.java
@@ -679,9 +679,9 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
                 flushBitmap.prepareToDraw();
             }
             renderBitmap = flushBitmap;
-        }
-        if (_cacheAllFramesInMemory && renderBitmap != null) {
-            bitmapCache.put(frame, renderBitmap);
+            if (_cacheAllFramesInMemory && flushBitmap != null) {
+                bitmapCache.put(frame, flushBitmap);
+            }
         }
         return true;
     }


### PR DESCRIPTION
修复 PAGImageView 在开启 cacheAllFramesInMemory 时的偶发 NPE。

问题：flush() 中 bitmapCache.put(frame, renderBitmap) 在 synchronized(bitmapLock) 块外执行，而 renderBitmap 是 volatile 字段，可能被 releaseBitmap() 并发置为 null，导致 ConcurrentHashMap.put 因 value 为 null 抛出 NullPointerException。原有的 renderBitmap != null 预检查仍存在 TOCTOU 窗口，无法防护。

修复：将 bitmapCache.put 调用移入 synchronized(bitmapLock) 块内，与 releaseBitmap() 互斥；同时改用局部变量 flushBitmap 作为写入值，避免读取可被其他线程置空的共享字段。