### PR TITLE
Fix OHOS Worker crash and harden JsHelper error handling

### DIFF
--- a/src/platform/ohos/JPAG.cpp
+++ b/src/platform/ohos/JPAG.cpp
@@ -72,6 +72,7 @@ static napi_value Init(napi_env env, napi_value exports) {
                 pag::NativeDisplayLink::InitThreadSafeFunction(env);
   if (!result) {
     LOGE("PAG InitFailed");
+    return nullptr;
   }
   return exports;
 }

--- a/src/platform/ohos/JsHelper.cpp
+++ b/src/platform/ohos/JsHelper.cpp
@@ -140,7 +140,10 @@ napi_status DefineClass(napi_env env, napi_value exports, const std::string& utf
     LOGE("DefineClass napi_set_named_property failed:%d", status);
     return status;
   }
-  SetConstructor(env, classConstructor, utf8name);
+  if (!SetConstructor(env, classConstructor, utf8name)) {
+    LOGE("DefineClass SetConstructor failed");
+    return napi_status::napi_generic_failure;
+  }
   if (parentName.empty()) {
     return status;
   }

--- a/src/platform/ohos/JsHelper.cpp
+++ b/src/platform/ohos/JsHelper.cpp
@@ -19,24 +19,35 @@
 #include "JsHelper.h"
 #include <multimedia/image_framework/image/pixelmap_native.h>
 #include <multimedia/image_framework/image_pixel_map_mdk.h>
+#include <mutex>
+#include <unordered_map>
 #include "base/utils/Log.h"
 #include "tgfx/core/ImageInfo.h"
 
 namespace pag {
 
-static std::unordered_map<std::string, napi_ref> ConstructorRefMap;
+// Constructor references are partitioned by napi_env, because each OHOS Worker has its own
+// EcmaVM. A napi_ref created with one env's EcmaVM cannot be safely released or accessed
+// from another env's thread. Using a process-wide map keyed only by name caused a fatal
+// "ecma_vm cannot run in multi-thread" abort when a Worker thread imported libpag and tried
+// to delete a reference that was created on the main thread's EcmaVM.
+static std::mutex ConstructorRefMapMutex;
+static std::unordered_map<napi_env, std::unordered_map<std::string, napi_ref>> ConstructorRefMap;
 
-bool SetConstructor(napi_env env, napi_value constructor, const std::string& name) {
+static bool SetConstructor(napi_env env, napi_value constructor, const std::string& name) {
   if (env == nullptr || constructor == nullptr || name.empty()) {
     return false;
   }
-  if (ConstructorRefMap.find(name) != ConstructorRefMap.end()) {
-    napi_delete_reference(env, ConstructorRefMap.at(name));
-    ConstructorRefMap.erase(name);
+  std::lock_guard<std::mutex> autoLock(ConstructorRefMapMutex);
+  auto& envMap = ConstructorRefMap[env];
+  auto it = envMap.find(name);
+  if (it != envMap.end()) {
+    napi_delete_reference(env, it->second);
+    envMap.erase(it);
   }
-  napi_ref ref;
+  napi_ref ref = nullptr;
   napi_create_reference(env, constructor, 1, &ref);
-  ConstructorRefMap[name] = ref;
+  envMap[name] = ref;
   return true;
 }
 
@@ -44,10 +55,21 @@ napi_value GetConstructor(napi_env env, const std::string& name) {
   if (env == nullptr || name.empty()) {
     return nullptr;
   }
-  napi_value result = nullptr;
-  if (ConstructorRefMap.find(name) != ConstructorRefMap.end()) {
-    napi_get_reference_value(env, ConstructorRefMap.at(name), &result);
+  napi_ref ref = nullptr;
+  {
+    std::lock_guard<std::mutex> autoLock(ConstructorRefMapMutex);
+    auto envIt = ConstructorRefMap.find(env);
+    if (envIt == ConstructorRefMap.end()) {
+      return nullptr;
+    }
+    auto refIt = envIt->second.find(name);
+    if (refIt == envIt->second.end()) {
+      return nullptr;
+    }
+    ref = refIt->second;
   }
+  napi_value result = nullptr;
+  napi_get_reference_value(env, ref, &result);
   return result;
 }
 

--- a/src/platform/ohos/JsHelper.cpp
+++ b/src/platform/ohos/JsHelper.cpp
@@ -60,7 +60,12 @@ static bool SetConstructor(napi_env env, napi_value constructor, const std::stri
   bool firstInsert = ConstructorRefMap.find(env) == ConstructorRefMap.end();
   auto& envMap = ConstructorRefMap[env];
   if (firstInsert) {
-    napi_add_env_cleanup_hook(env, CleanupConstructorRefs, env);
+    auto status = napi_add_env_cleanup_hook(env, CleanupConstructorRefs, env);
+    if (status != napi_ok) {
+      ConstructorRefMap.erase(env);
+      LOGE("SetConstructor napi_add_env_cleanup_hook failed :%d", status);
+      return false;
+    }
   }
   auto refIt = envMap.find(name);
   if (refIt != envMap.end()) {

--- a/src/platform/ohos/JsHelper.cpp
+++ b/src/platform/ohos/JsHelper.cpp
@@ -73,7 +73,11 @@ static bool SetConstructor(napi_env env, napi_value constructor, const std::stri
     envMap.erase(refIt);
   }
   napi_ref ref = nullptr;
-  napi_create_reference(env, constructor, 1, &ref);
+  auto refStatus = napi_create_reference(env, constructor, 1, &ref);
+  if (refStatus != napi_ok) {
+    LOGE("SetConstructor napi_create_reference failed :%d", refStatus);
+    return false;
+  }
   envMap[name] = ref;
   return true;
 }

--- a/src/platform/ohos/JsHelper.cpp
+++ b/src/platform/ohos/JsHelper.cpp
@@ -31,19 +31,41 @@ namespace pag {
 // from another env's thread. Using a process-wide map keyed only by name caused a fatal
 // "ecma_vm cannot run in multi-thread" abort when a Worker thread imported libpag and tried
 // to delete a reference that was created on the main thread's EcmaVM.
+//
+// We do NOT call napi_delete_reference for entries belonging to other envs from this map
+// (that was the original crash). Per-env cleanup is handled by CleanupConstructorRefs,
+// registered via napi_add_env_cleanup_hook on first insertion for each env. The hook runs
+// on the owning env's thread during teardown, where napi_delete_reference is safe.
 static std::mutex ConstructorRefMapMutex;
 static std::unordered_map<napi_env, std::unordered_map<std::string, napi_ref>> ConstructorRefMap;
+
+static void CleanupConstructorRefs(void* arg) {
+  auto env = static_cast<napi_env>(arg);
+  std::lock_guard<std::mutex> autoLock(ConstructorRefMapMutex);
+  auto envIt = ConstructorRefMap.find(env);
+  if (envIt == ConstructorRefMap.end()) {
+    return;
+  }
+  for (auto& entry : envIt->second) {
+    napi_delete_reference(env, entry.second);
+  }
+  ConstructorRefMap.erase(envIt);
+}
 
 static bool SetConstructor(napi_env env, napi_value constructor, const std::string& name) {
   if (env == nullptr || constructor == nullptr || name.empty()) {
     return false;
   }
   std::lock_guard<std::mutex> autoLock(ConstructorRefMapMutex);
+  bool firstInsert = ConstructorRefMap.find(env) == ConstructorRefMap.end();
   auto& envMap = ConstructorRefMap[env];
-  auto it = envMap.find(name);
-  if (it != envMap.end()) {
-    napi_delete_reference(env, it->second);
-    envMap.erase(it);
+  if (firstInsert) {
+    napi_add_env_cleanup_hook(env, CleanupConstructorRefs, env);
+  }
+  auto refIt = envMap.find(name);
+  if (refIt != envMap.end()) {
+    napi_delete_reference(env, refIt->second);
+    envMap.erase(refIt);
   }
   napi_ref ref = nullptr;
   napi_create_reference(env, constructor, 1, &ref);


### PR DESCRIPTION
当 OHOS 应用从 Worker 线程导入 libpag 时，会触发 "ecma_vm cannot run in multi-thread" 致命崩溃。

根因：JsHelper 里 ConstructorRefMap 是进程级全局表、仅以 class name 为 key 共享所有 napi_env。Worker 线程进入 SetConstructor 重复注册同名 class 时，会用 Worker 自己的 env 去调用 napi_delete_reference 释放主线程 env 创建的 napi_ref，跨 EcmaVM 访问触发 abort。

本 PR 的修复分两层：

一、核心修复
- 将 ConstructorRefMap 按 napi_env 分区，并加互斥锁保护所有读写。
- 新增 CleanupConstructorRefs，通过 napi_add_env_cleanup_hook 在每个 env 首次插入时注册；hook 在 env 自身线程上 teardown 期间执行，在该线程上 napi_delete_reference 是安全的。这样既避免了跨线程释放，又防止了 env 销毁后的 ref 泄漏。
- SetConstructor 改为文件内 static。

二、顺手把相关错误路径补齐（review 过程中发现的配套问题）
- napi_add_env_cleanup_hook 注册失败时，erase 刚插入的空 entry 并返回 false，避免残留项导致 firstInsert 再也不为 true。
- napi_create_reference 失败时不再把 nullptr 缓存进 map，避免后续 napi_delete_reference(nullptr) 和 napi_get_reference_value(nullptr) 的未定义行为。
- DefineClass 现在检查 SetConstructor 的返回值并以 napi_generic_failure 向上传播，避免出现 class 已导出但构造器未缓存的静默模块级故障。
- 顶层 Init 在任何子模块失败时返回 nullptr，让 import pag 在 JS 侧抛错，而非静默降级成一个残缺的模块。

改动仅限 src/platform/ohos/JsHelper.cpp 与 src/platform/ohos/JPAG.cpp，不影响其它平台。