### PR TITLE
Update tgfx dependency.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "db519bd2e916aaf92560e7acc5d494f1866cdfd9",
+        "commit": "5342bbae5a2a297b8b1e23935f7f0b87cac39345",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "e465de2b9be5e2e18c70819ba18e4789692d2a66",
+        "commit": "db519bd2e916aaf92560e7acc5d494f1866cdfd9",
         "dir": "third_party/tgfx"
       },
       {

--- a/src/base/utils/TGFXCast.cpp
+++ b/src/base/utils/TGFXCast.cpp
@@ -182,12 +182,11 @@ tgfx::BackendRenderTarget ToTGFX(const BackendRenderTarget& renderTarget) {
   tgfx::GLFrameBufferInfo frameBuffer = {};
   frameBuffer.id = glInfo.id;
   frameBuffer.format = glInfo.format;
-  return {frameBuffer, renderTarget.width(), renderTarget.height()};
+  return tgfx::BackendRenderTarget(frameBuffer, renderTarget.width(), renderTarget.height());
 }
 
 tgfx::BackendSemaphore ToTGFX(const BackendSemaphore& semaphore) {
   tgfx::GLSyncInfo syncInfo = {semaphore.glSync()};
-  tgfx::BackendSemaphore glSemaphore = {syncInfo};
-  return glSemaphore;
+  return tgfx::BackendSemaphore(syncInfo);
 }
 }  // namespace pag


### PR DESCRIPTION
升级 tgfx 依赖版本，并修复 TGFXCast.cpp 中因 BackendRenderTarget 和 BackendSemaphore 构造函数被标记为 explicit 导致的 copy-initialization 编译错误，改为显式构造调用。