### PR TITLE
Add single-threaded PAGX Viewer builds

### DIFF
--- a/playground/pagx-viewer/CMakeLists.txt
+++ b/playground/pagx-viewer/CMakeLists.txt
@@ -42,15 +42,26 @@ if (DEFINED EMSCRIPTEN)
                 -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency
                 -sEXIT_RUNTIME=0 -sINVOKE_RUN=0 -sMALLOC=dlmalloc)
         list(APPEND VIEWER_COMPILE_OPTIONS -fPIC -pthread)
+        set(VIEWER_OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/wasm-mt)
     else ()
         list(APPEND VIEWER_LINK_OPTIONS -sALLOW_MEMORY_GROWTH=1)
+        set(VIEWER_OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/wasm)
     endif ()
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         list(APPEND VIEWER_COMPILE_OPTIONS -O0 -g3)
         list(APPEND VIEWER_LINK_OPTIONS -O0 -g3 -sSAFE_HEAP=1 -Wno-limited-postlink-optimizations)
     else ()
         list(APPEND VIEWER_COMPILE_OPTIONS -Oz)
-        list(APPEND VIEWER_LINK_OPTIONS -Oz)
+        list(APPEND VIEWER_LINK_OPTIONS -Oz --emit-symbol-map)
+        # vendor_tools/lib-build wipes the intermediate build dir and only copies *.js / *.wasm
+        # to the arch output dir, so the emscripten-generated *.symbols would be lost. Copy it
+        # out manually right after link (POST_BUILD) so subsequent cleanup can't reach it.
+        add_custom_command(TARGET pagx-viewer POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${VIEWER_OUTPUT_DIR}
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        $<TARGET_FILE_DIR:pagx-viewer>/pagx-viewer.js.symbols
+                        ${VIEWER_OUTPUT_DIR}/pagx-viewer.wasm.symbols
+                COMMENT "Copying wasm symbol map to ${VIEWER_OUTPUT_DIR}/")
     endif ()
 else ()
     add_library(pagx-viewer SHARED ${VIEWER_FILES})

--- a/playground/pagx-viewer/README.md
+++ b/playground/pagx-viewer/README.md
@@ -97,7 +97,15 @@ npm run build:debug
 # Release build: minified JS, stripped WASM, optimized for production.
 # Use this when integrating the SDK into a shipping product.
 npm run build:release
+
+# Single-threaded variants (no pthread / SharedArrayBuffer requirement).
+# Useful when the hosting page cannot enable cross-origin isolation.
+npm run build:debug:st
+npm run build:release:st
 ```
+
+> Note: the multi-threaded (`wasm-mt`) and single-threaded (`wasm`) builds share the same output
+> files in `lib/`. Running a build of one flavor will overwrite the other's artifacts.
 
 Both commands generate the following artifacts under `lib/`:
 
@@ -122,10 +130,14 @@ bundles), you can invoke the individual steps:
 
 | Command | Description |
 |---------|-------------|
-| `npm run build:wasm` | Build only the WebAssembly binary (release) |
-| `npm run build:wasm:debug` | Build only the WebAssembly binary (debug) |
-| `npm run build:js` | Build only the JavaScript bundles (debug) |
-| `npm run build:js:release` | Build only the JavaScript bundles (release) |
+| `npm run build:wasm` | Build only the WebAssembly binary (multi-threaded, release) |
+| `npm run build:wasm:debug` | Build only the WebAssembly binary (multi-threaded, debug) |
+| `npm run build:wasm:st` | Build only the WebAssembly binary (single-threaded, release) |
+| `npm run build:wasm:st:debug` | Build only the WebAssembly binary (single-threaded, debug) |
+| `npm run build:js` | Build only the JavaScript bundles (multi-threaded, debug) |
+| `npm run build:js:release` | Build only the JavaScript bundles (multi-threaded, release) |
+| `npm run build:js:st` | Build only the JavaScript bundles (single-threaded, debug) |
+| `npm run build:js:st:release` | Build only the JavaScript bundles (single-threaded, release) |
 | `npm run build:types` | Emit TypeScript declaration files |
 | `npm run clean` | Remove build artifacts and caches |
 

--- a/playground/pagx-viewer/README.zh_CN.md
+++ b/playground/pagx-viewer/README.zh_CN.md
@@ -95,7 +95,15 @@ npm run build:debug
 # Release 构建：压缩 JS、剥离 WASM 调试信息，针对生产环境优化。
 # 适合将 SDK 集成到正式产品时使用。
 npm run build:release
+
+# 单线程版本（不依赖 pthread / SharedArrayBuffer）。
+# 适合宿主页面无法启用跨域隔离（COOP/COEP）的场景。
+npm run build:debug:st
+npm run build:release:st
 ```
+
+> 提示：多线程（`wasm-mt`）与单线程（`wasm`）构建共享 `lib/` 下的同一组产物文件，
+> 后构建的版本会覆盖前一次的产物。
 
 两个命令都会在 `lib/` 目录下生成以下产物：
 
@@ -118,10 +126,14 @@ Chrome 扩展，然后打开 DevTools → Settings → Experiments，勾选
 
 | 命令 | 说明 |
 |------|------|
-| `npm run build:wasm` | 仅构建 WebAssembly 二进制（release） |
-| `npm run build:wasm:debug` | 仅构建 WebAssembly 二进制（debug） |
-| `npm run build:js` | 仅构建 JavaScript 产物（debug） |
-| `npm run build:js:release` | 仅构建 JavaScript 产物（release） |
+| `npm run build:wasm` | 仅构建 WebAssembly 二进制（多线程，release） |
+| `npm run build:wasm:debug` | 仅构建 WebAssembly 二进制（多线程，debug） |
+| `npm run build:wasm:st` | 仅构建 WebAssembly 二进制（单线程，release） |
+| `npm run build:wasm:st:debug` | 仅构建 WebAssembly 二进制（单线程，debug） |
+| `npm run build:js` | 仅构建 JavaScript 产物（多线程，debug） |
+| `npm run build:js:release` | 仅构建 JavaScript 产物（多线程，release） |
+| `npm run build:js:st` | 仅构建 JavaScript 产物（单线程，debug） |
+| `npm run build:js:st:release` | 仅构建 JavaScript 产物（单线程，release） |
 | `npm run build:types` | 输出 TypeScript 声明文件 |
 | `npm run clean` | 清理构建产物和缓存 |
 

--- a/playground/pagx-viewer/package.json
+++ b/playground/pagx-viewer/package.json
@@ -19,14 +19,20 @@
     "types"
   ],
   "scripts": {
-    "clean": "rimraf lib types wasm-mt build-pagx-viewer .*.md5",
+    "clean": "rimraf lib types wasm wasm-mt build-pagx-viewer .*.md5",
     "build:wasm": "node script/cmake.js -a wasm-mt",
     "build:wasm:debug": "node script/cmake.js -a wasm-mt --debug",
+    "build:wasm:st": "node script/cmake.js -a wasm",
+    "build:wasm:st:debug": "node script/cmake.js -a wasm --debug",
     "build:types": "tsc -p tsconfig.type.json",
-    "build:js": "rollup -c script/rollup.config.js && npm run build:types  && node script/fix-wasm-imports.js -a wasm-mt",
-    "build:js:release": "BUILD_MODE=release rollup -c script/rollup.config.js && npm run build:types && node script/fix-wasm-imports.js -a wasm-mt",
+    "build:js": "rollup -c script/rollup.config.js --environment ARCH:wasm-mt && npm run build:types && node script/fix-wasm-imports.js -a wasm-mt",
+    "build:js:release": "BUILD_MODE=release rollup -c script/rollup.config.js --environment ARCH:wasm-mt && npm run build:types && node script/fix-wasm-imports.js -a wasm-mt",
+    "build:js:st": "rollup -c script/rollup.config.js --environment ARCH:wasm && npm run build:types && node script/fix-wasm-imports.js -a wasm",
+    "build:js:st:release": "BUILD_MODE=release rollup -c script/rollup.config.js --environment ARCH:wasm && npm run build:types && node script/fix-wasm-imports.js -a wasm",
     "build:debug": "npm run build:wasm:debug && npm run build:js",
-    "build:release": "npm run build:wasm && npm run build:js:release"
+    "build:release": "npm run build:wasm && npm run build:js:release",
+    "build:debug:st": "npm run build:wasm:st:debug && npm run build:js:st",
+    "build:release:st": "npm run build:wasm:st && npm run build:js:st:release"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "~5.1.1",

--- a/playground/pagx-viewer/script/rollup.config.js
+++ b/playground/pagx-viewer/script/rollup.config.js
@@ -31,11 +31,14 @@ const __dirname = path.dirname(__filename);
 const fileHeaderPath = path.resolve(__dirname, '../../../.idea/fileTemplates/includes/PAG File Header.h');
 const banner = readFileSync(fileHeaderPath, 'utf-8');
 
+// ARCH selects the wasm output flavor: 'wasm-mt' (multi-threaded) or 'wasm' (single-threaded).
+const arch = process.env.ARCH || 'wasm-mt';
+
 // Copy WASM files to lib
 const copyWasmPlugin = {
   name: 'copy-wasm',
   writeBundle() {
-    const wasmDir = path.resolve(__dirname, '../wasm-mt');
+    const wasmDir = path.resolve(__dirname, `../${arch}`);
     const libDir = path.resolve(__dirname, '../lib');
 
     if (!existsSync(libDir)) {
@@ -57,6 +60,11 @@ const plugins = [
   alias({
     entries: [
       { find: '@tgfx', replacement: path.resolve(__dirname, '../../../third_party/tgfx/web/src') },
+      // Redirect the wasm glue import in pagx.ts to the requested arch's output directory.
+      {
+        find: '../../wasm-mt/pagx-viewer',
+        replacement: path.resolve(__dirname, `../${arch}/pagx-viewer`),
+      },
     ],
   }),
   {


### PR DESCRIPTION
## Summary

- Add single-threaded PAGX Viewer build scripts alongside the existing multi-threaded builds.
- Let Rollup select the wasm output flavor through ARCH and copy artifacts from the matching directory.
- Preserve release wasm symbol maps from the CMake build output.
- Document the new single-threaded build commands and output overwrite behavior.

## Testing

- Not run in this session.