### PR TITLE
Publish single-threaded pagx-viewer SDK alongside multi-threaded build

### DIFF
--- a/playground/pagx-viewer/.gitignore
+++ b/playground/pagx-viewer/.gitignore
@@ -1,5 +1,6 @@
 # Build outputs
 wasm-mt/
+wasm/
 
 # Build cache
 build-pagx-viewer/

--- a/playground/pagx-viewer/CMakeLists.txt
+++ b/playground/pagx-viewer/CMakeLists.txt
@@ -42,15 +42,26 @@ if (DEFINED EMSCRIPTEN)
                 -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency
                 -sEXIT_RUNTIME=0 -sINVOKE_RUN=0 -sMALLOC=dlmalloc)
         list(APPEND VIEWER_COMPILE_OPTIONS -fPIC -pthread)
+        set(VIEWER_OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/wasm-mt)
     else ()
         list(APPEND VIEWER_LINK_OPTIONS -sALLOW_MEMORY_GROWTH=1)
+        set(VIEWER_OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/wasm)
     endif ()
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         list(APPEND VIEWER_COMPILE_OPTIONS -O0 -g3)
         list(APPEND VIEWER_LINK_OPTIONS -O0 -g3 -sSAFE_HEAP=1 -Wno-limited-postlink-optimizations)
     else ()
         list(APPEND VIEWER_COMPILE_OPTIONS -Oz)
-        list(APPEND VIEWER_LINK_OPTIONS -Oz)
+        list(APPEND VIEWER_LINK_OPTIONS -Oz --emit-symbol-map)
+        # vendor_tools/lib-build wipes the intermediate build dir and only copies *.js / *.wasm
+        # to the arch output dir, so the emscripten-generated *.symbols would be lost. Copy it
+        # out manually right after link (POST_BUILD) so subsequent cleanup can't reach it.
+        add_custom_command(TARGET pagx-viewer POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${VIEWER_OUTPUT_DIR}
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        $<TARGET_FILE_DIR:pagx-viewer>/pagx-viewer.js.symbols
+                        ${VIEWER_OUTPUT_DIR}/pagx-viewer.wasm.symbols
+                COMMENT "Copying wasm symbol map to ${VIEWER_OUTPUT_DIR}/")
     endif ()
 else ()
     add_library(pagx-viewer SHARED ${VIEWER_FILES})

--- a/playground/pagx-viewer/CMakeLists.txt
+++ b/playground/pagx-viewer/CMakeLists.txt
@@ -56,6 +56,8 @@ if (DEFINED EMSCRIPTEN)
         # vendor_tools/lib-build wipes the intermediate build dir and only copies *.js / *.wasm
         # to the arch output dir, so the emscripten-generated *.symbols would be lost. Copy it
         # out manually right after link (POST_BUILD) so subsequent cleanup can't reach it.
+        # TODO(symbols): drop this workaround once vendor_tools exposes an extension point for
+        # extra artifacts (or once *.symbols is added to the web copy whitelist upstream).
         add_custom_command(TARGET pagx-viewer POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E make_directory ${VIEWER_OUTPUT_DIR}
                 COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/playground/pagx-viewer/README.md
+++ b/playground/pagx-viewer/README.md
@@ -104,18 +104,18 @@ npm run build:debug:st
 npm run build:release:st
 ```
 
-> Note: the multi-threaded (`wasm-mt`) and single-threaded (`wasm`) builds share the same output
-> files in `lib/`. Running a build of one flavor will overwrite the other's artifacts.
+> Note: both flavors coexist in `lib/`. The multi-threaded build keeps the canonical
+> filenames (`pagx-viewer.*`); the single-threaded build adds a `.st` infix (`pagx-viewer.st.*`).
 
 Both commands generate the following artifacts under `lib/`:
 
 | File | Format | Usage |
 |------|--------|-------|
-| `pagx-viewer.esm.js` | ESM | `import { PAGXInit } from 'pagx-viewer'` |
-| `pagx-viewer.cjs.js` | CJS | `const { PAGXInit } = require('pagx-viewer')` |
-| `pagx-viewer.umd.js` | UMD | Browser `<script>` tag |
-| `pagx-viewer.min.js` | UMD (minified) | Production use |
-| `pagx-viewer.wasm` | WebAssembly | Runtime dependency |
+| `pagx-viewer.esm.js` / `pagx-viewer.st.esm.js` | ESM | `import { PAGXInit } from 'pagx-viewer'` (mt) / `'pagx-viewer/st'` (st) |
+| `pagx-viewer.cjs.js` / `pagx-viewer.st.cjs.js` | CJS | `const { PAGXInit } = require('pagx-viewer')` (mt) / `require('pagx-viewer/st')` (st) |
+| `pagx-viewer.umd.js` / `pagx-viewer.st.umd.js` | UMD | Browser `<script>` tag |
+| `pagx-viewer.min.js` / `pagx-viewer.st.min.js` | UMD (minified) | Production use |
+| `pagx-viewer.wasm` / `pagx-viewer.st.wasm` | WebAssembly | Runtime dependency |
 
 To debug the C++ side, install the
 [C/C++ DevTools Support (DWARF)](https://chrome.google.com/webstore/detail/cc%20%20-devtools-support-dwa/pdcpmagijalfljmkmjngeonclgbbannb)

--- a/playground/pagx-viewer/README.md
+++ b/playground/pagx-viewer/README.md
@@ -97,7 +97,15 @@ npm run build:debug
 # Release build: minified JS, stripped WASM, optimized for production.
 # Use this when integrating the SDK into a shipping product.
 npm run build:release
+
+# Single-threaded variants (no pthread / SharedArrayBuffer requirement).
+# Useful when the hosting page cannot enable cross-origin isolation.
+npm run build:debug:st
+npm run build:release:st
 ```
+
+> Note: the multi-threaded (`wasm-mt`) and single-threaded (`wasm`) builds share the same output
+> files in `lib/`. Running a build of one flavor will overwrite the other's artifacts.
 
 Both commands generate the following artifacts under `lib/`:
 
@@ -122,10 +130,14 @@ bundles), you can invoke the individual steps:
 
 | Command | Description |
 |---------|-------------|
-| `npm run build:wasm` | Build only the WebAssembly binary (release) |
-| `npm run build:wasm:debug` | Build only the WebAssembly binary (debug) |
-| `npm run build:js` | Build only the JavaScript bundles (debug) |
-| `npm run build:js:release` | Build only the JavaScript bundles (release) |
+| `npm run build:wasm` | Build only the WebAssembly binary (multi-threaded, release) |
+| `npm run build:wasm:debug` | Build only the WebAssembly binary (multi-threaded, debug) |
+| `npm run build:wasm:st` | Build only the WebAssembly binary (single-threaded, release) |
+| `npm run build:wasm:st:debug` | Build only the WebAssembly binary (single-threaded, debug) |
+| `npm run build:js` | Build only the JavaScript bundles (multi-threaded, debug) |
+| `npm run build:js:release` | Build only the JavaScript bundles (multi-threaded, release) |
+| `npm run build:js:st` | Build only the JavaScript bundles (single-threaded, debug) |
+| `npm run build:js:st:release` | Build only the JavaScript bundles (single-threaded, release) |
 | `npm run build:types` | Emit TypeScript declaration files |
 | `npm run clean` | Remove build artifacts and caches |
 

--- a/playground/pagx-viewer/README.zh_CN.md
+++ b/playground/pagx-viewer/README.zh_CN.md
@@ -95,7 +95,15 @@ npm run build:debug
 # Release 构建：压缩 JS、剥离 WASM 调试信息，针对生产环境优化。
 # 适合将 SDK 集成到正式产品时使用。
 npm run build:release
+
+# 单线程版本（不依赖 pthread / SharedArrayBuffer）。
+# 适合宿主页面无法启用跨域隔离（COOP/COEP）的场景。
+npm run build:debug:st
+npm run build:release:st
 ```
+
+> 提示：多线程（`wasm-mt`）与单线程（`wasm`）构建共享 `lib/` 下的同一组产物文件，
+> 后构建的版本会覆盖前一次的产物。
 
 两个命令都会在 `lib/` 目录下生成以下产物：
 
@@ -118,10 +126,14 @@ Chrome 扩展，然后打开 DevTools → Settings → Experiments，勾选
 
 | 命令 | 说明 |
 |------|------|
-| `npm run build:wasm` | 仅构建 WebAssembly 二进制（release） |
-| `npm run build:wasm:debug` | 仅构建 WebAssembly 二进制（debug） |
-| `npm run build:js` | 仅构建 JavaScript 产物（debug） |
-| `npm run build:js:release` | 仅构建 JavaScript 产物（release） |
+| `npm run build:wasm` | 仅构建 WebAssembly 二进制（多线程，release） |
+| `npm run build:wasm:debug` | 仅构建 WebAssembly 二进制（多线程，debug） |
+| `npm run build:wasm:st` | 仅构建 WebAssembly 二进制（单线程，release） |
+| `npm run build:wasm:st:debug` | 仅构建 WebAssembly 二进制（单线程，debug） |
+| `npm run build:js` | 仅构建 JavaScript 产物（多线程，debug） |
+| `npm run build:js:release` | 仅构建 JavaScript 产物（多线程，release） |
+| `npm run build:js:st` | 仅构建 JavaScript 产物（单线程，debug） |
+| `npm run build:js:st:release` | 仅构建 JavaScript 产物（单线程，release） |
 | `npm run build:types` | 输出 TypeScript 声明文件 |
 | `npm run clean` | 清理构建产物和缓存 |
 

--- a/playground/pagx-viewer/README.zh_CN.md
+++ b/playground/pagx-viewer/README.zh_CN.md
@@ -102,18 +102,18 @@ npm run build:debug:st
 npm run build:release:st
 ```
 
-> 提示：多线程（`wasm-mt`）与单线程（`wasm`）构建共享 `lib/` 下的同一组产物文件，
-> 后构建的版本会覆盖前一次的产物。
+> 提示：两种构建产物共存于 `lib/`，多线程版本沿用 `pagx-viewer.*` 命名，单线程版本通过
+> `.st` 中缀（`pagx-viewer.st.*`）区分，互不覆盖。
 
 两个命令都会在 `lib/` 目录下生成以下产物：
 
 | 文件 | 格式 | 用途 |
 |------|------|------|
-| `pagx-viewer.esm.js` | ESM | `import { PAGXInit } from 'pagx-viewer'` |
-| `pagx-viewer.cjs.js` | CJS | `const { PAGXInit } = require('pagx-viewer')` |
-| `pagx-viewer.umd.js` | UMD | 浏览器 `<script>` 标签引入 |
-| `pagx-viewer.min.js` | UMD（已压缩） | 生产环境使用 |
-| `pagx-viewer.wasm` | WebAssembly | 运行时依赖 |
+| `pagx-viewer.esm.js` / `pagx-viewer.st.esm.js` | ESM | `import { PAGXInit } from 'pagx-viewer'`（mt）/ `'pagx-viewer/st'`（st）|
+| `pagx-viewer.cjs.js` / `pagx-viewer.st.cjs.js` | CJS | `const { PAGXInit } = require('pagx-viewer')`（mt）/ `require('pagx-viewer/st')`（st）|
+| `pagx-viewer.umd.js` / `pagx-viewer.st.umd.js` | UMD | 浏览器 `<script>` 标签引入 |
+| `pagx-viewer.min.js` / `pagx-viewer.st.min.js` | UMD（已压缩） | 生产环境使用 |
+| `pagx-viewer.wasm` / `pagx-viewer.st.wasm` | WebAssembly | 运行时依赖 |
 
 如需调试 C++ 端代码，请安装
 [C/C++ DevTools Support (DWARF)](https://chrome.google.com/webstore/detail/cc%20%20-devtools-support-dwa/pdcpmagijalfljmkmjngeonclgbbannb)

--- a/playground/pagx-viewer/package.json
+++ b/playground/pagx-viewer/package.json
@@ -12,6 +12,12 @@
       "import": "./lib/pagx-viewer.esm.js",
       "require": "./lib/pagx-viewer.cjs.js",
       "default": "./lib/pagx-viewer.umd.js"
+    },
+    "./st": {
+      "types": "./types/playground/pagx-viewer/src/ts/pagx.d.ts",
+      "import": "./lib/pagx-viewer.st.esm.js",
+      "require": "./lib/pagx-viewer.st.cjs.js",
+      "default": "./lib/pagx-viewer.st.umd.js"
     }
   },
   "files": [

--- a/playground/pagx-viewer/package.json
+++ b/playground/pagx-viewer/package.json
@@ -19,14 +19,20 @@
     "types"
   ],
   "scripts": {
-    "clean": "rimraf lib types wasm-mt build-pagx-viewer .*.md5",
+    "clean": "rimraf lib types wasm wasm-mt build-pagx-viewer .*.md5",
     "build:wasm": "node script/cmake.js -a wasm-mt",
     "build:wasm:debug": "node script/cmake.js -a wasm-mt --debug",
+    "build:wasm:st": "node script/cmake.js -a wasm",
+    "build:wasm:st:debug": "node script/cmake.js -a wasm --debug",
     "build:types": "tsc -p tsconfig.type.json",
-    "build:js": "rollup -c script/rollup.config.js && npm run build:types  && node script/fix-wasm-imports.js -a wasm-mt",
-    "build:js:release": "BUILD_MODE=release rollup -c script/rollup.config.js && npm run build:types && node script/fix-wasm-imports.js -a wasm-mt",
+    "build:js": "rollup -c script/rollup.config.js --environment ARCH:wasm-mt && npm run build:types && node script/fix-wasm-imports.js -a wasm-mt",
+    "build:js:release": "BUILD_MODE=release rollup -c script/rollup.config.js --environment ARCH:wasm-mt && npm run build:types && node script/fix-wasm-imports.js -a wasm-mt",
+    "build:js:st": "rollup -c script/rollup.config.js --environment ARCH:wasm && npm run build:types && node script/fix-wasm-imports.js -a wasm",
+    "build:js:st:release": "BUILD_MODE=release rollup -c script/rollup.config.js --environment ARCH:wasm && npm run build:types && node script/fix-wasm-imports.js -a wasm",
     "build:debug": "npm run build:wasm:debug && npm run build:js",
-    "build:release": "npm run build:wasm && npm run build:js:release"
+    "build:release": "npm run build:wasm && npm run build:js:release",
+    "build:debug:st": "npm run build:wasm:st:debug && npm run build:js:st",
+    "build:release:st": "npm run build:wasm:st && npm run build:js:st:release"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "~5.1.1",

--- a/playground/pagx-viewer/script/fix-wasm-imports.js
+++ b/playground/pagx-viewer/script/fix-wasm-imports.js
@@ -15,25 +15,6 @@ for (let i = 0; i < args.length; i++) {
     }
 }
 
-function getFilesInDir(dir, extension) {
-    let filesList = [];
-
-    const files = fs.readdirSync(dir);
-    files.forEach(file => {
-        const fullPath = path.join(dir, file);
-        const stat = fs.statSync(fullPath);
-
-        if (stat.isFile() && fullPath.endsWith(extension)) {
-            filesList.push(fullPath);
-        }
-        else if (stat.isDirectory()) {
-            filesList = filesList.concat(getFilesInDir(fullPath, extension));
-        }
-    });
-
-    return filesList;
-}
-
 function replaceInFile(filePath, searchString, replacement) {
     const data = fs.readFileSync(filePath, 'utf-8');
     if (data.includes(searchString)) {
@@ -43,18 +24,29 @@ function replaceInFile(filePath, searchString, replacement) {
     }
 }
 
-function replaceFileNameInFiles() {
-    const dir = path.resolve(__dirname, "../lib/");
-    const extension = '.js';
-    const searchString = 'pagx-viewer.js';
-    const files = getFilesInDir(dir, extension);
+// Multi-threaded build keeps canonical filenames (pagx-viewer.umd.js, pagx-viewer.wasm).
+// Single-threaded build adds a `.st` infix; the wasm reference baked into the emcc glue
+// must be rewritten so each bundle loads its matching wasm.
+const libDir = path.resolve(__dirname, '../lib');
+const isSt = argv.a === 'wasm';
+const nameInfix = isSt ? '.st' : '';
+const bundleNames = ['umd', 'esm', 'cjs', 'min'].map(
+    (kind) => `pagx-viewer${nameInfix}.${kind}.js`,
+);
 
-    files.forEach(file => {
-        const fileName = path.basename(file);
-        replaceInFile(file, searchString, fileName);
-    });
-}
-
-if(argv.a ==="wasm-mt"){
-    replaceFileNameInFiles();
+for (const bundleName of bundleNames) {
+    const filePath = path.join(libDir, bundleName);
+    if (!fs.existsSync(filePath)) {
+        continue;
+    }
+    if (isSt) {
+        // The emcc glue resolves `new URL("pagx-viewer.wasm", import.meta.url)`; redirect
+        // it to the renamed single-threaded wasm.
+        replaceInFile(filePath, 'pagx-viewer.wasm', 'pagx-viewer.st.wasm');
+    } else {
+        // The multi-threaded glue spawns pthread workers via
+        // `new URL("pagx-viewer.js", import.meta.url)`; redirect that to the actual bundle
+        // filename so the worker re-loads the same module.
+        replaceInFile(filePath, 'pagx-viewer.js', bundleName);
+    }
 }

--- a/playground/pagx-viewer/script/fix-wasm-imports.js
+++ b/playground/pagx-viewer/script/fix-wasm-imports.js
@@ -15,13 +15,20 @@ for (let i = 0; i < args.length; i++) {
     }
 }
 
+const SUPPORTED_ARCHS = ['wasm-mt', 'wasm'];
+if (!SUPPORTED_ARCHS.includes(argv.a)) {
+    console.error(`Unsupported -a ${argv.a}. Expected one of ${SUPPORTED_ARCHS.join(', ')}.`);
+    process.exit(1);
+}
+
 function replaceInFile(filePath, searchString, replacement) {
     const data = fs.readFileSync(filePath, 'utf-8');
-    if (data.includes(searchString)) {
-        const updatedData = data.replaceAll(searchString, replacement);
-        fs.writeFileSync(filePath, updatedData, 'utf-8');
-        console.log(`In file ${filePath}, "${searchString}" was replaced with "${replacement}"`);
+    if (!data.includes(searchString)) {
+        return false;
     }
+    fs.writeFileSync(filePath, data.replaceAll(searchString, replacement), 'utf-8');
+    console.log(`In ${filePath}: "${searchString}" -> "${replacement}"`);
+    return true;
 }
 
 // Multi-threaded build keeps canonical filenames (pagx-viewer.umd.js, pagx-viewer.wasm).
@@ -34,6 +41,7 @@ const bundleNames = ['umd', 'esm', 'cjs', 'min'].map(
     (kind) => `pagx-viewer${nameInfix}.${kind}.js`,
 );
 
+let replacedCount = 0;
 for (const bundleName of bundleNames) {
     const filePath = path.join(libDir, bundleName);
     if (!fs.existsSync(filePath)) {
@@ -42,11 +50,27 @@ for (const bundleName of bundleNames) {
     if (isSt) {
         // The emcc glue resolves `new URL("pagx-viewer.wasm", import.meta.url)`; redirect
         // it to the renamed single-threaded wasm.
-        replaceInFile(filePath, 'pagx-viewer.wasm', 'pagx-viewer.st.wasm');
+        if (replaceInFile(filePath, 'pagx-viewer.wasm', 'pagx-viewer.st.wasm')) {
+            replacedCount++;
+        }
     } else {
         // The multi-threaded glue spawns pthread workers via
         // `new URL("pagx-viewer.js", import.meta.url)`; redirect that to the actual bundle
         // filename so the worker re-loads the same module.
-        replaceInFile(filePath, 'pagx-viewer.js', bundleName);
+        if (replaceInFile(filePath, 'pagx-viewer.js', bundleName)) {
+            replacedCount++;
+        }
     }
+}
+
+if (replacedCount === 0) {
+    // No replacement means either the bundles were not built yet, or the emcc glue's
+    // hard-coded URL string changed (for example after an emscripten upgrade). Fail loudly
+    // so CI catches the regression instead of shipping bundles that 404 at runtime.
+    console.error(
+        `fix-wasm-imports: no occurrences rewritten in lib/. Expected to patch the ` +
+            `${isSt ? 'wasm URL ("pagx-viewer.wasm")' : 'pthread worker URL ("pagx-viewer.js")'} ` +
+            `inside ${bundleNames.join(', ')}.`,
+    );
+    process.exit(1);
 }

--- a/playground/pagx-viewer/script/rollup.config.js
+++ b/playground/pagx-viewer/script/rollup.config.js
@@ -35,7 +35,11 @@ const banner = readFileSync(fileHeaderPath, 'utf-8');
 // Both flavors publish to the same lib/ directory; the multi-threaded build keeps the
 // canonical filenames (pagx-viewer.umd.js, pagx-viewer.wasm), while the single-threaded
 // build adds a `.st` infix (pagx-viewer.st.umd.js, pagx-viewer.st.wasm) to disambiguate.
+const SUPPORTED_ARCHS = ['wasm-mt', 'wasm'];
 const arch = process.env.ARCH || 'wasm-mt';
+if (!SUPPORTED_ARCHS.includes(arch)) {
+  throw new Error(`Unsupported ARCH: ${arch}. Expected one of ${SUPPORTED_ARCHS.join(', ')}.`);
+}
 const nameInfix = arch === 'wasm-mt' ? '' : '.st';
 const libDir = path.resolve(__dirname, '../lib');
 
@@ -60,8 +64,9 @@ const copyWasmPlugin = {
 };
 
 const plugins = [
-  // alias must run before resolve/esbuild so the wasm glue path in pagx.ts is rewritten to
-  // the requested ARCH before it is resolved to a concrete file on disk.
+  // MUST stay before resolve()/esbuild() — see PR #3436. Otherwise node-resolve will
+  // resolve `../../wasm-mt/pagx-viewer` to a concrete file before alias rewrites it,
+  // and the single-threaded bundle will silently inline the multi-threaded glue.
   alias({
     entries: [
       { find: '@tgfx', replacement: path.resolve(__dirname, '../../../third_party/tgfx/web/src') },

--- a/playground/pagx-viewer/script/rollup.config.js
+++ b/playground/pagx-viewer/script/rollup.config.js
@@ -31,11 +31,14 @@ const __dirname = path.dirname(__filename);
 const fileHeaderPath = path.resolve(__dirname, '../../../.idea/fileTemplates/includes/PAG File Header.h');
 const banner = readFileSync(fileHeaderPath, 'utf-8');
 
+// ARCH selects the wasm output flavor: 'wasm-mt' (multi-threaded) or 'wasm' (single-threaded).
+const arch = process.env.ARCH || 'wasm-mt';
+
 // Copy WASM files to lib
 const copyWasmPlugin = {
   name: 'copy-wasm',
   writeBundle() {
-    const wasmDir = path.resolve(__dirname, '../wasm-mt');
+    const wasmDir = path.resolve(__dirname, `../${arch}`);
     const libDir = path.resolve(__dirname, '../lib');
 
     if (!existsSync(libDir)) {
@@ -57,6 +60,11 @@ const plugins = [
   alias({
     entries: [
       { find: '@tgfx', replacement: path.resolve(__dirname, '../../../third_party/tgfx/web/src') },
+      // Redirect the wasm glue import in pagx.ts to the requested arch's output directory.
+      {
+        find: '../../wasm-mt/pagx-viewer',
+        replacement: path.resolve(__dirname, `../${arch}/pagx-viewer`),
+      },
     ],
   }),
   {

--- a/playground/pagx-viewer/script/rollup.config.js
+++ b/playground/pagx-viewer/script/rollup.config.js
@@ -32,14 +32,20 @@ const fileHeaderPath = path.resolve(__dirname, '../../../.idea/fileTemplates/inc
 const banner = readFileSync(fileHeaderPath, 'utf-8');
 
 // ARCH selects the wasm output flavor: 'wasm-mt' (multi-threaded) or 'wasm' (single-threaded).
+// Both flavors publish to the same lib/ directory; the multi-threaded build keeps the
+// canonical filenames (pagx-viewer.umd.js, pagx-viewer.wasm), while the single-threaded
+// build adds a `.st` infix (pagx-viewer.st.umd.js, pagx-viewer.st.wasm) to disambiguate.
 const arch = process.env.ARCH || 'wasm-mt';
+const nameInfix = arch === 'wasm-mt' ? '' : '.st';
+const libDir = path.resolve(__dirname, '../lib');
 
-// Copy WASM files to lib
+// Copy the wasm next to the bundle. For the single-threaded build, the wasm is renamed
+// with the `.st` infix; the emcc glue's hard-coded `new URL("pagx-viewer.wasm", ...)` is
+// rewritten to the matching name later by script/fix-wasm-imports.js.
 const copyWasmPlugin = {
   name: 'copy-wasm',
   writeBundle() {
     const wasmDir = path.resolve(__dirname, `../${arch}`);
-    const libDir = path.resolve(__dirname, '../lib');
 
     if (!existsSync(libDir)) {
       mkdirSync(libDir, { recursive: true });
@@ -48,15 +54,14 @@ const copyWasmPlugin = {
     // Copy wasm file
     const wasmFile = path.join(wasmDir, 'pagx-viewer.wasm');
     if (existsSync(wasmFile)) {
-      copyFileSync(wasmFile, path.join(libDir, 'pagx-viewer.wasm'));
+      copyFileSync(wasmFile, path.join(libDir, `pagx-viewer${nameInfix}.wasm`));
     }
   },
 };
 
 const plugins = [
-  esbuild({ tsconfig: path.resolve(__dirname, '../tsconfig.json'), minify: false }),
-  resolve({ extensions: ['.ts', '.js'] }),
-  commonJs(),
+  // alias must run before resolve/esbuild so the wasm glue path in pagx.ts is rewritten to
+  // the requested ARCH before it is resolved to a concrete file on disk.
   alias({
     entries: [
       { find: '@tgfx', replacement: path.resolve(__dirname, '../../../third_party/tgfx/web/src') },
@@ -67,6 +72,9 @@ const plugins = [
       },
     ],
   }),
+  esbuild({ tsconfig: path.resolve(__dirname, '../tsconfig.json'), minify: false }),
+  resolve({ extensions: ['.ts', '.js'] }),
+  commonJs(),
   {
     name: 'preserve-import-meta-url',
     resolveImportMeta(property) {
@@ -79,7 +87,6 @@ const plugins = [
 ];
 
 const input = path.resolve(__dirname, '../src/ts/pagx.ts');
-const libDir = path.resolve(__dirname, '../lib');
 
 // UMD format (for script tag usage, mounts to window.pagxViewer)
 const umdConfig = {
@@ -90,7 +97,7 @@ const umdConfig = {
     format: 'umd',
     exports: 'named',
     sourcemap: true,
-    file: path.join(libDir, 'pagx-viewer.umd.js'),
+    file: path.join(libDir, `pagx-viewer${nameInfix}.umd.js`),
   },
   plugins: [...plugins],
 };
@@ -104,7 +111,7 @@ const umdMinConfig = {
     format: 'umd',
     exports: 'named',
     sourcemap: true,
-    file: path.join(libDir, 'pagx-viewer.min.js'),
+    file: path.join(libDir, `pagx-viewer${nameInfix}.min.js`),
   },
   plugins: [...plugins, terser()],
 };
@@ -113,8 +120,8 @@ const umdMinConfig = {
 const moduleConfig = {
   input,
   output: [
-    { banner, file: path.join(libDir, 'pagx-viewer.esm.js'), format: 'esm', sourcemap: true },
-    { banner, file: path.join(libDir, 'pagx-viewer.cjs.js'), format: 'cjs', exports: 'named', sourcemap: true },
+    { banner, file: path.join(libDir, `pagx-viewer${nameInfix}.esm.js`), format: 'esm', sourcemap: true },
+    { banner, file: path.join(libDir, `pagx-viewer${nameInfix}.cjs.js`), format: 'cjs', exports: 'named', sourcemap: true },
   ],
   plugins: [...plugins, copyWasmPlugin],
 };


### PR DESCRIPTION
## Summary

Make pagx-viewer publish two flavors from a single `lib/` directory:

- **Multi-threaded** (default) — `lib/pagx-viewer.{umd,esm,cjs,min}.js` + `lib/pagx-viewer.wasm`. Same names as before, fully backward compatible.
- **Single-threaded** (new) — `lib/pagx-viewer.st.{umd,esm,cjs,min}.js` + `lib/pagx-viewer.st.wasm`. Distinguished by an `.st` infix so all artifacts sit in the same directory without collision.

Downstream consumers select the flavor via the `exports` field:

\`\`\`js
import { PAGXInit } from 'pagx-viewer';      // multi-threaded (default)
import { PAGXInit } from 'pagx-viewer/st';   // single-threaded
\`\`\`

## What changed

- \`script/rollup.config.js\` — output filenames carry an \`.st\` infix when \`ARCH=wasm\` (no infix for \`wasm-mt\`, preserving existing names). The \`alias\` plugin is moved before \`node-resolve\` / \`esbuild\`; otherwise \`node-resolve\` would resolve \`'../../wasm-mt/pagx-viewer'\` to a concrete file before the alias rewrites it, causing the single-threaded bundle to silently inline the multi-threaded glue (a stale build had \`ENVIRONMENT_IS_PTHREAD\` and 69 \`PThread\` references in the single-threaded \`.cjs.js\`).
- \`script/fix-wasm-imports.js\` — rewritten to handle both flavors. For \`wasm-mt\`, it still rewrites the pthread-worker URL \`pagx-viewer.js\` to the actual bundle filename. For \`wasm\`, it rewrites the wasm URL \`pagx-viewer.wasm\` to \`pagx-viewer.st.wasm\` so each bundle loads its matching wasm.
- \`package.json\` — \`main\`/\`module\` continue pointing at \`lib/pagx-viewer.umd.js\` / \`.esm.js\`. \`exports\` adds a \`\"./st\"\` subpath for the single-threaded entry.
- \`.gitignore\` — ignore the new \`wasm/\` intermediate directory (single-threaded counterpart of \`wasm-mt/\`).

Earlier commits in this branch enable the single-threaded build pipeline itself:

- \`6e653627\` adds \`build:wasm:st\`, \`build:js:st\`, \`build:debug:st\`, \`build:release:st\` scripts and the rollup \`ARCH:wasm\` environment switch.
- \`91669f3a\` emits a wasm symbol map under release builds (\`pagx-viewer.wasm.symbols\` for stack-trace symbolization) and switches the CMake target output dir based on \`EMSCRIPTEN_PTHREADS\`.

## Verification

- \`rm -rf lib && npm run build:release && npm run build:release:st\` — both succeed; \`lib/\` ends up with both flavors.
- \`lib/pagx-viewer.cjs.js\`: \`new URL(\"pagx-viewer.wasm\", ...)\` plus worker URL rewritten to \`pagx-viewer.cjs.js\` — correct.
- \`lib/pagx-viewer.st.cjs.js\`: \`new URL(\"pagx-viewer.st.wasm\", ...)\`, no PThread code present — correct.
- \`playground/pagx-playground\` build still passes; \`prebuild.js\` continues consuming the unchanged \`lib/pagx-viewer.{esm.js,wasm}\` paths.