### PR TITLE
Auto-install puppeteer on first run if node_modules is missing

### DIFF
--- a/test/screenshot.js
+++ b/test/screenshot.js
@@ -15,12 +15,21 @@
  * launching per task, while the periodic roll absorbs the "Connection closed" bursts that
  * used to sink the second half of the suite on macOS.
  *
- * Prerequisites: npx puppeteer browsers install chrome
+ * Dependencies are auto-installed on first run via `npm ci`.
  */
 
-const puppeteer = require('puppeteer');
 const path = require('path');
 const fs = require('fs');
+const { execSync } = require('child_process');
+
+// Auto-install puppeteer if node_modules is missing (fresh clone without manual npm ci).
+const nodeModulesDir = path.join(__dirname, 'node_modules', 'puppeteer');
+if (!fs.existsSync(nodeModulesDir)) {
+  console.log('puppeteer not found, running npm ci...');
+  execSync('npm ci', { cwd: __dirname, stdio: 'inherit' });
+}
+
+const puppeteer = require('puppeteer');
 
 const SINGLE_TASK_TIMEOUT_MS = 60000;
 const PROTOCOL_TIMEOUT_MS = 180000;


### PR DESCRIPTION
## Problem

On a fresh Mac clone, running `PAGFullTest` fails at `PAGXHtmlTest.HtmlScreenshotCompare` with:

```
Error: Cannot find module 'puppeteer'
```

This is because `test/node_modules/` is gitignored and the local build flow (CMake) does not auto-install npm dependencies. GitHub CI handles this via an explicit `cd test && npm ci` step in `autotest.yml`, but local developers must remember to run it manually.

## Solution

Add a self-bootstrapping check at the top of `test/screenshot.js`: if `test/node_modules/puppeteer` does not exist, automatically run `npm ci` (using the committed `package-lock.json`) before requiring puppeteer.

- Zero overhead when already installed (`fs.existsSync` check only)
- Uses `npm ci` for deterministic, lock-file-pinned installation
- Consistent with CI behavior (`autotest.yml:51-53`)
- No CMake or C++ changes needed

## Testing

- Fresh environment: puppeteer gets installed automatically, test passes
- Existing environment: no-op, 1151 tests pass as before
