### PR TITLE
Add embed() and clearEmbed() methods to PAGXDocument.

### DIFF
--- a/include/pagx/PAGXDocument.h
+++ b/include/pagx/PAGXDocument.h
@@ -154,9 +154,9 @@ class PAGXDocument : public Node {
   bool embed();
 
   /**
-   * Clears existing embedded GlyphRuns from all Text nodes in the document. Call this before
-   * applyLayout() when re-embedding a file that already has embedded fonts, so that layout
-   * performs runtime shaping instead of using stale embedded data.
+   * Clears all embedded GlyphRuns from Text nodes in the document. Typically called before a
+   * subsequent applyLayout() when re-embedding a file that already has embedded fonts, so that
+   * layout performs runtime shaping instead of reusing stale embedded data.
    */
   void clearEmbed();
 

--- a/include/pagx/PAGXDocument.h
+++ b/include/pagx/PAGXDocument.h
@@ -145,6 +145,21 @@ class PAGXDocument : public Node {
     return layoutApplied;
   }
 
+  /**
+   * Embeds font data into the document by collecting layout glyph runs from all Text nodes.
+   * The document must have had applyLayout() called first so that Text nodes contain valid
+   * layout run data.
+   * @return true if embedding succeeded, false if layout has not been applied.
+   */
+  bool embed();
+
+  /**
+   * Clears existing embedded GlyphRuns from all Text nodes in the document. Call this before
+   * applyLayout() when re-embedding a file that already has embedded fonts, so that layout
+   * performs runtime shaping instead of using stale embedded data.
+   */
+  void clearEmbed();
+
   NodeType nodeType() const override {
     return NodeType::Document;
   }

--- a/src/pagx/PAGXDocument.cpp
+++ b/src/pagx/PAGXDocument.cpp
@@ -21,6 +21,8 @@
 #include "pagx/nodes/Composition.h"
 #include "pagx/nodes/Image.h"
 #include "pagx/nodes/LayoutNode.h"
+#include "renderer/FontEmbedder.h"
+#include "base/utils/Log.h"
 
 namespace pagx {
 
@@ -136,6 +138,19 @@ bool PAGXDocument::loadFileData(const std::string& filePath, std::shared_ptr<Dat
     found = true;
   }
   return found;
+}
+
+bool PAGXDocument::embed() {
+  if (!isLayoutApplied()) {
+    LOGE("PAGXDocument::embed() called before applyLayout(). Call applyLayout() first.");
+    return false;
+  }
+  FontEmbedder embedder;
+  return embedder.embed(this);
+}
+
+void PAGXDocument::clearEmbed() {
+  FontEmbedder::ClearEmbeddedGlyphRuns(this);
 }
 
 }  // namespace pagx

--- a/src/pagx/PAGXDocument.cpp
+++ b/src/pagx/PAGXDocument.cpp
@@ -18,11 +18,11 @@
 
 #include "pagx/PAGXDocument.h"
 #include "LayoutContext.h"
+#include "base/utils/Log.h"
 #include "pagx/nodes/Composition.h"
 #include "pagx/nodes/Image.h"
 #include "pagx/nodes/LayoutNode.h"
 #include "renderer/FontEmbedder.h"
-#include "base/utils/Log.h"
 
 namespace pagx {
 

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -5169,4 +5169,123 @@ PAGX_TEST(PAGXTest, HtmlFiles) {
   TestPAGXDirectory(context, ProjectPath::Absolute("resources/pagx_to_html"), "html_native_");
 }
 
+/**
+ * Test case: PAGXDocument::embed() returns false when layout is not applied.
+ */
+PAGX_TEST(PAGXTest, DocumentEmbedWithoutLayout) {
+  auto doc = pagx::PAGXDocument::Make(200, 100);
+  EXPECT_FALSE(doc->embed());
+}
+
+/**
+ * Test case: PAGXDocument::embed() succeeds when layout is applied.
+ */
+PAGX_TEST(PAGXTest, DocumentEmbedWithLayout) {
+  auto doc = pagx::PAGXDocument::Make(200, 100);
+  auto layer = doc->makeNode<pagx::Layer>();
+  doc->layers.push_back(layer);
+  layer->width = 200;
+  layer->height = 100;
+
+  auto typeface =
+      tgfx::Typeface::MakeFromPath(ProjectPath::Absolute("resources/font/NotoSansSC-Regular.otf"));
+  ASSERT_NE(typeface, nullptr);
+
+  auto text = doc->makeNode<pagx::Text>();
+  text->text = "Embed";
+  text->fontFamily = typeface->fontFamily();
+  text->fontStyle = typeface->fontStyle();
+  text->fontSize = 24;
+
+  auto fill = doc->makeNode<pagx::Fill>();
+  layer->contents = {text, fill};
+
+  pagx::FontConfig fontConfig;
+  fontConfig.registerTypeface(typeface);
+  doc->applyLayout(&fontConfig);
+
+  EXPECT_TRUE(doc->embed());
+  EXPECT_FALSE(text->glyphRuns.empty());
+}
+
+/**
+ * Test case: PAGXDocument::clearEmbed() clears embedded GlyphRuns.
+ */
+PAGX_TEST(PAGXTest, DocumentClearEmbed) {
+  auto doc = pagx::PAGXDocument::Make(200, 100);
+  auto layer = doc->makeNode<pagx::Layer>();
+  doc->layers.push_back(layer);
+  layer->width = 200;
+  layer->height = 100;
+
+  auto typeface =
+      tgfx::Typeface::MakeFromPath(ProjectPath::Absolute("resources/font/NotoSansSC-Regular.otf"));
+  ASSERT_NE(typeface, nullptr);
+
+  auto text = doc->makeNode<pagx::Text>();
+  text->text = "Embed";
+  text->fontFamily = typeface->fontFamily();
+  text->fontStyle = typeface->fontStyle();
+  text->fontSize = 24;
+
+  auto fill = doc->makeNode<pagx::Fill>();
+  layer->contents = {text, fill};
+
+  pagx::FontConfig fontConfig;
+  fontConfig.registerTypeface(typeface);
+  doc->applyLayout(&fontConfig);
+  doc->embed();
+
+  ASSERT_FALSE(text->glyphRuns.empty());
+
+  doc->clearEmbed();
+  EXPECT_TRUE(text->glyphRuns.empty());
+}
+
+/**
+ * Test case: PAGXDocument re-embedding after clearEmbed.
+ * Embeds fonts, clears, re-embeds, and verifies the result is consistent.
+ */
+PAGX_TEST(PAGXTest, DocumentReEmbed) {
+  auto doc = pagx::PAGXDocument::Make(200, 100);
+  auto layer = doc->makeNode<pagx::Layer>();
+  doc->layers.push_back(layer);
+  layer->width = 200;
+  layer->height = 100;
+
+  auto typeface =
+      tgfx::Typeface::MakeFromPath(ProjectPath::Absolute("resources/font/NotoSansSC-Regular.otf"));
+  ASSERT_NE(typeface, nullptr);
+
+  auto text = doc->makeNode<pagx::Text>();
+  text->text = "Embed";
+  text->fontFamily = typeface->fontFamily();
+  text->fontStyle = typeface->fontStyle();
+  text->fontSize = 24;
+
+  auto fill = doc->makeNode<pagx::Fill>();
+  layer->contents = {text, fill};
+
+  pagx::FontConfig fontConfig;
+  fontConfig.registerTypeface(typeface);
+  doc->applyLayout(&fontConfig);
+  doc->embed();
+
+  ASSERT_FALSE(text->glyphRuns.empty());
+  size_t firstGlyphCount = text->glyphRuns[0]->glyphs.size();
+  auto firstGlyphs = text->glyphRuns[0]->glyphs;
+
+  // Re-embed: clear existing glyphs, re-layout, re-embed.
+  doc->clearEmbed();
+  EXPECT_TRUE(text->glyphRuns.empty());
+
+  doc->applyLayout();
+  doc->embed();
+
+  ASSERT_FALSE(text->glyphRuns.empty());
+  // Glyph count and IDs should match after re-embedding.
+  EXPECT_EQ(text->glyphRuns[0]->glyphs.size(), firstGlyphCount);
+  EXPECT_EQ(text->glyphRuns[0]->glyphs, firstGlyphs);
+}
+
 }  // namespace pag


### PR DESCRIPTION
在 PAGXDocument 上新增 embed() 和 clearEmbed() 两个公共方法，将 FontEmbedder 的能力暴露到公开 API 层。

主要变更：
- include/pagx/PAGXDocument.h：新增 bool embed() 和 void clearEmbed() 接口及对应英文文档注释。
- src/pagx/PAGXDocument.cpp：实现两个方法，内部委托给 FontEmbedder。embed() 在未调用 applyLayout() 时打印 LOGE 并返回 false。
- test/src/PAGXTest.cpp：新增 4 个测试用例覆盖 无 layout 调用 embed、有 layout 调用 embed、clearEmbed 清空 GlyphRuns、clear 后重新 embed 的工作流。