### PR TITLE
Update tgfx dependency version

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,8 +11,8 @@
         "dir": "third_party/vendor_tools"
       },
       {
-        "url": "git@github.com:Tencent/tgfx.git",
-        "commit": "919ff33cfc4374d3ea0c614a7e168fadd646db4f",
+        "url": "${PAG_GROUP}/tgfx.git",
+        "commit": "ce05ab1456c5f9f4f1a264713e01da0bc8aaa7b4",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "7b69a2e2a449839a5de15ef5815240b88fea0254",
+        "commit": "02419909ae0b4af8e683876da55d463429499c00",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@
         "dir": "third_party/vendor_tools"
       },
       {
-        "url": "${PAG_GROUP}/tgfx.git",
+        "url": "git@github.com:Tencent/tgfx.git",
         "commit": "02419909ae0b4af8e683876da55d463429499c00",
         "dir": "third_party/tgfx"
       },

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "git@github.com:Tencent/tgfx.git",
-        "commit": "02419909ae0b4af8e683876da55d463429499c00",
+        "commit": "919ff33cfc4374d3ea0c614a7e168fadd646db4f",
         "dir": "third_party/tgfx"
       },
       {


### PR DESCRIPTION
更新 libpag 依赖的 tgfx 版本到 ce05ab1456c5f9f4f1a264713e01da0bc8aaa7b4。该版本包含 PDF 导出的图片去重和 JPEG 编码支持。已本地编译并执行 PAGFullTest，1151 个测试全部通过。