### PR TITLE
Add startup check to prompt installing or updating the AE plugin.

### DIFF
--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -273,6 +273,7 @@ PAGWindow {
             if (settings.isAutoCheckUpdate) {
                 checkForUpdates(true);
             }
+            pluginInstaller.checkPluginOnStartup();
         }
     }
 

--- a/viewer/assets/translation/Chinese.ts
+++ b/viewer/assets/translation/Chinese.ts
@@ -80,41 +80,41 @@
         <translation>选择保存路径</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="362"/>
+        <location filename="../qml/Main.qml" line="363"/>
         <source>Performance Benchmark Test</source>
         <translation>性能基准测试</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="363"/>
+        <location filename="../qml/Main.qml" line="364"/>
         <source>Performance Benchmark Test Complete</source>
         <translation>性能基准测试已完成</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="385"/>
+        <location filename="../qml/Main.qml" line="386"/>
         <source>Export failed, error code: </source>
         <translation>导出错误，错误码：</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="539"/>
+        <location filename="../qml/Main.qml" line="540"/>
         <source>Open PAG File</source>
         <translation>打开PAG文件</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="614"/>
-        <location filename="../qml/Main.qml" line="639"/>
-        <location filename="../qml/Main.qml" line="662"/>
+        <location filename="../qml/Main.qml" line="615"/>
+        <location filename="../qml/Main.qml" line="640"/>
+        <location filename="../qml/Main.qml" line="663"/>
         <source>Select save path</source>
         <translation>选择保存路径</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="625"/>
-        <location filename="../qml/Main.qml" line="646"/>
-        <location filename="../qml/Main.qml" line="671"/>
+        <location filename="../qml/Main.qml" line="626"/>
+        <location filename="../qml/Main.qml" line="647"/>
+        <location filename="../qml/Main.qml" line="672"/>
         <source>Exporting</source>
         <translation>正在导出</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="689"/>
+        <location filename="../qml/Main.qml" line="690"/>
         <source>Profiling</source>
         <translation>分析</translation>
     </message>
@@ -602,27 +602,27 @@
 <context>
     <name>pag::PAGXViewModel</name>
     <message>
-        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="312"/>
+        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="315"/>
         <source>Failed to parse XML: invalid syntax or structure</source>
         <translation>解析 XML 失败：语法或结构无效</translation>
     </message>
     <message>
-        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="318"/>
+        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="321"/>
         <source>Failed to build layer from XML document</source>
         <translation>从 XML 文档构建图层失败</translation>
     </message>
     <message>
-        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="349"/>
+        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="352"/>
         <source>No file path specified</source>
         <translation>未指定文件路径</translation>
     </message>
     <message>
-        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="353"/>
+        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="356"/>
         <source>Failed to open file for writing: %1</source>
         <translation>无法打开文件进行写入：%1</translation>
     </message>
     <message>
-        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="358"/>
+        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="361"/>
         <source>Failed to write all data to file</source>
         <translation>写入文件数据不完整</translation>
     </message>
@@ -630,122 +630,126 @@
 <context>
     <name>pag::PluginInstaller</name>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="58"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="127"/>
         <source>Install Adobe After Effects Plug-in</source>
         <translation>安装 Adobe After Effects 插件</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="59"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="131"/>
         <source>Do you want to install the Adobe After Effects plugins?</source>
         <translation>是否要安装 Adobe After Effects 插件？</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="66"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="135"/>
         <source>Update Adobe After Effects Plug-in</source>
         <translation>更新 Adobe After Effects 插件</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="67"/>
         <source>New plugin versions are available. Do you want to install them?</source>
-        <translation>有新版本的插件可用。是否要安装？</translation>
+        <translation type="vanished">有新版本的插件可用。是否要安装？</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="71"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="73"/>
         <source>Reinstall Adobe After Effects Plug-in</source>
         <translation>重新安装 Adobe After Effects 插件</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="72"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="74"/>
         <source>The plugins are already installed with the latest version. Do you want to reinstall them?</source>
         <translation>插件已是最新版本。是否要重新安装？</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="79"/>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="122"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="145"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="188"/>
         <source>Please close Adobe After Effects</source>
         <translation>请关闭 Adobe After Effects</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="80"/>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="123"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="146"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="189"/>
         <source>Adobe After Effects is currently running. Please close it and click OK to continue, or Cancel to abort.</source>
         <translation>Adobe After Effects 正在运行。请关闭它并点击确定继续，或点击取消中止。</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="90"/>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="105"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="156"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="171"/>
         <source>Installation Failed</source>
         <translation>安装失败</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="90"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="156"/>
         <source>Plugin source not found: %1</source>
         <translation>未找到插件源：%1</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="99"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="165"/>
         <source>Installation Complete</source>
         <translation>安装完成</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="100"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="166"/>
         <source>Adobe After Effects plugins have been successfully installed!</source>
         <translation>Adobe After Effects 插件已成功安装！</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="102"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="168"/>
         <source>Adobe After Effects plug-in installed successfully.</source>
         <translation>Adobe After Effects 插件安装成功。</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="106"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="172"/>
         <source>Failed to install Adobe After Effects plugins. Please check permissions.</source>
         <translation>安装 Adobe After Effects 插件失败。请检查权限。</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="110"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="176"/>
         <source>Failed to install Adobe After Effects plug-in due to permission issues.</source>
         <translation>由于权限问题，安装 Adobe After Effects 插件失败。</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="116"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="182"/>
         <source>Uninstall Plugins</source>
         <translation>卸载插件</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="117"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="183"/>
         <source>Are you sure you want to uninstall the selected plugins?</source>
         <translation>确定要卸载选中的插件吗？</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="133"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="199"/>
         <source>Uninstallation Complete</source>
         <translation>卸载完成</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="133"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="199"/>
         <source>Plugins have been successfully removed!</source>
         <translation>插件已成功移除！</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="134"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="200"/>
         <source>Uninstalled AE Plug-in Successfully</source>
         <translation>AE 插件卸载成功</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="137"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="203"/>
         <source>Uninstallation Failed</source>
         <translation>卸载失败</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="138"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="204"/>
         <source>Failed to uninstall plugins. Please check permissions.</source>
         <translation>卸载插件失败。请检查权限。</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="140"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="206"/>
         <source>Failed to uninstall AE Plug-in due to permission issues.</source>
         <translation>由于权限问题，卸载 AE 插件失败。</translation>
+    </message>
+    <message>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="139"/>
+        <source>A new version of the Adobe After Effects plugin is available. Would you like to update it now?</source>
+        <translation>Adobe After Effects 插件有新版本可用，是否立即更新？</translation>
     </message>
 </context>
 </TS>

--- a/viewer/assets/translation/Chinese.ts
+++ b/viewer/assets/translation/Chinese.ts
@@ -659,90 +659,90 @@
         <translation>插件已是最新版本。是否要重新安装？</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="145"/>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="188"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="146"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="189"/>
         <source>Please close Adobe After Effects</source>
         <translation>请关闭 Adobe After Effects</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="146"/>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="189"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="147"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="190"/>
         <source>Adobe After Effects is currently running. Please close it and click OK to continue, or Cancel to abort.</source>
         <translation>Adobe After Effects 正在运行。请关闭它并点击确定继续，或点击取消中止。</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="156"/>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="171"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="157"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="172"/>
         <source>Installation Failed</source>
         <translation>安装失败</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="156"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="157"/>
         <source>Plugin source not found: %1</source>
         <translation>未找到插件源：%1</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="165"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="166"/>
         <source>Installation Complete</source>
         <translation>安装完成</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="166"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="167"/>
         <source>Adobe After Effects plugins have been successfully installed!</source>
         <translation>Adobe After Effects 插件已成功安装！</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="168"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="169"/>
         <source>Adobe After Effects plug-in installed successfully.</source>
         <translation>Adobe After Effects 插件安装成功。</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="172"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="173"/>
         <source>Failed to install Adobe After Effects plugins. Please check permissions.</source>
         <translation>安装 Adobe After Effects 插件失败。请检查权限。</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="176"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="177"/>
         <source>Failed to install Adobe After Effects plug-in due to permission issues.</source>
         <translation>由于权限问题，安装 Adobe After Effects 插件失败。</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="182"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="183"/>
         <source>Uninstall Plugins</source>
         <translation>卸载插件</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="183"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="184"/>
         <source>Are you sure you want to uninstall the selected plugins?</source>
         <translation>确定要卸载选中的插件吗？</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="199"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="200"/>
         <source>Uninstallation Complete</source>
         <translation>卸载完成</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="199"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="200"/>
         <source>Plugins have been successfully removed!</source>
         <translation>插件已成功移除！</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="200"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="201"/>
         <source>Uninstalled AE Plug-in Successfully</source>
         <translation>AE 插件卸载成功</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="203"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="204"/>
         <source>Uninstallation Failed</source>
         <translation>卸载失败</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="204"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="205"/>
         <source>Failed to uninstall plugins. Please check permissions.</source>
         <translation>卸载插件失败。请检查权限。</translation>
     </message>
     <message>
-        <location filename="../../src/platform/PluginInstaller.cpp" line="206"/>
+        <location filename="../../src/platform/PluginInstaller.cpp" line="207"/>
         <source>Failed to uninstall AE Plug-in due to permission issues.</source>
         <translation>由于权限问题，卸载 AE 插件失败。</translation>
     </message>

--- a/viewer/src/maintenance/PluginInstallerModel.cpp
+++ b/viewer/src/maintenance/PluginInstallerModel.cpp
@@ -52,4 +52,8 @@ bool PluginInstallerModel::isPluginInstalled() const {
   return installer->isPluginInstalled();
 }
 
+void PluginInstallerModel::checkPluginOnStartup() {
+  installer->checkPluginOnStartup();
+}
+
 }  // namespace pag

--- a/viewer/src/maintenance/PluginInstallerModel.h
+++ b/viewer/src/maintenance/PluginInstallerModel.h
@@ -41,6 +41,11 @@ class PluginInstallerModel : public QObject {
 
   Q_INVOKABLE bool isPluginInstalled() const;
 
+  /// Run once at app startup to keep the AE plugin in sync with the bundled version.
+  /// Prompts the user to install (if missing) or update (if version differs); no-op when
+  /// already up to date. Idempotent within a session.
+  Q_INVOKABLE void checkPluginOnStartup();
+
  Q_SIGNALS:
   void updateCheckCompleted(bool hasUpdate);
   void installationCompleted(InstallResult result, const QString& message);

--- a/viewer/src/platform/PluginInstaller.cpp
+++ b/viewer/src/platform/PluginInstaller.cpp
@@ -62,11 +62,11 @@ InstallResult PluginInstaller::installPlugin() {
   bool hasUpdateAvailable = hasUpdate();
 
   if (!pluginInstalled) {
-    if (!requestConfirmation(installPromptTitle(), installPromptMessage())) {
+    if (!requestConfirmation(InstallPromptTitle(), InstallPromptMessage())) {
       return InstallResult::UserCancelled;
     }
   } else if (hasUpdateAvailable) {
-    if (!requestConfirmation(updatePromptTitle(), updatePromptMessage())) {
+    if (!requestConfirmation(UpdatePromptTitle(), UpdatePromptMessage())) {
       return InstallResult::UserCancelled;
     }
   } else {
@@ -101,14 +101,14 @@ void PluginInstaller::checkPluginOnStartup() {
       return;
     }
     qDebug() << "[PluginInstaller] startup: plugin not installed, sourceVersion=" << sourceVersion;
-    promptAndInstall(installPromptTitle(), installPromptMessage());
+    promptAndInstall(InstallPromptTitle(), InstallPromptMessage());
     return;
   }
 
   if (hasUpdate()) {
     qDebug() << "[PluginInstaller] startup: update available, source=" << sourceVersion
              << "installed=" << installedVersion;
-    promptAndInstall(updatePromptTitle(), updatePromptMessage());
+    promptAndInstall(UpdatePromptTitle(), UpdatePromptMessage());
     return;
   }
 
@@ -123,19 +123,19 @@ void PluginInstaller::promptAndInstall(const QString& title, const QString& mess
   performInstall();
 }
 
-QString PluginInstaller::installPromptTitle() {
+QString PluginInstaller::InstallPromptTitle() {
   return tr("Install Adobe After Effects Plug-in");
 }
 
-QString PluginInstaller::installPromptMessage() {
+QString PluginInstaller::InstallPromptMessage() {
   return tr("Do you want to install the Adobe After Effects plugins?");
 }
 
-QString PluginInstaller::updatePromptTitle() {
+QString PluginInstaller::UpdatePromptTitle() {
   return tr("Update Adobe After Effects Plug-in");
 }
 
-QString PluginInstaller::updatePromptMessage() {
+QString PluginInstaller::UpdatePromptMessage() {
   return tr(
       "A new version of the Adobe After Effects plugin is available. "
       "Would you like to update it now?");

--- a/viewer/src/platform/PluginInstaller.cpp
+++ b/viewer/src/platform/PluginInstaller.cpp
@@ -40,9 +40,16 @@ bool PluginInstaller::hasUpdate() const {
       continue;
     }
 
+    // Only flag an update when we can actually compare versions and the source is strictly
+    // newer. A zero result from getPluginVersion() means either the file is missing or the
+    // version string is unparseable (e.g. dev builds that ship a placeholder like ".." in
+    // Info.plist) — in both cases we skip rather than risk spamming the user.
     auto sourceVersion = getPluginVersion(sourcePath);
     auto installedVersion = getPluginVersion(installPath);
-    if (installedVersion == 0 || sourceVersion > installedVersion) {
+    if (sourceVersion == 0 || installedVersion == 0) {
+      continue;
+    }
+    if (sourceVersion > installedVersion) {
       return true;
     }
   }
@@ -55,26 +62,86 @@ InstallResult PluginInstaller::installPlugin() {
   bool hasUpdateAvailable = hasUpdate();
 
   if (!pluginInstalled) {
-    if (!requestConfirmation(tr("Install Adobe After Effects Plug-in"),
-                             tr("Do you want to install the Adobe After Effects plugins?"))) {
-      return InstallResult::UnknownError;
+    if (!requestConfirmation(installPromptTitle(), installPromptMessage())) {
+      return InstallResult::UserCancelled;
     }
-  }
-
-  else if (hasUpdateAvailable) {
-    if (!requestConfirmation(
-            tr("Update Adobe After Effects Plug-in"),
-            tr("New plugin versions are available. Do you want to install them?"))) {
-      return InstallResult::UnknownError;
+  } else if (hasUpdateAvailable) {
+    if (!requestConfirmation(updatePromptTitle(), updatePromptMessage())) {
+      return InstallResult::UserCancelled;
     }
   } else {
     if (!requestConfirmation(tr("Reinstall Adobe After Effects Plug-in"),
                              tr("The plugins are already installed with the latest version. "
                                 "Do you want to reinstall them?"))) {
-      return InstallResult::UnknownError;
+      return InstallResult::UserCancelled;
     }
   }
 
+  return performInstall();
+}
+
+void PluginInstaller::checkPluginOnStartup() {
+  // Idempotent: only run on the first call per session. Each call shows a modal, so allowing
+  // repeated calls would let any unintended QML re-trigger spam the user.
+  if (startupCheckTriggered) {
+    return;
+  }
+  startupCheckTriggered = true;
+
+  // Read versions only for diagnostic logging — install/update decisions go through
+  // isPluginInstalled() and hasUpdate() so the startup path stays consistent with
+  // installPlugin() and automatically covers any plugin in pluginInfoList().
+  QString sourceVersion = getPluginVersionAt(getPluginSourcePath(PrimaryPluginName));
+  QString installedVersion = getPluginVersionAt(getPluginInstallPath(PrimaryPluginName));
+
+  if (!isPluginInstalled()) {
+    if (sourceVersion.isEmpty()) {
+      // No bundled plugin to install — nothing we can do.
+      qDebug() << "[PluginInstaller] startup: plugin not installed and no bundled source";
+      return;
+    }
+    qDebug() << "[PluginInstaller] startup: plugin not installed, sourceVersion=" << sourceVersion;
+    promptAndInstall(installPromptTitle(), installPromptMessage());
+    return;
+  }
+
+  if (hasUpdate()) {
+    qDebug() << "[PluginInstaller] startup: update available, source=" << sourceVersion
+             << "installed=" << installedVersion;
+    promptAndInstall(updatePromptTitle(), updatePromptMessage());
+    return;
+  }
+
+  qDebug() << "[PluginInstaller] startup: plugin up to date, version=" << installedVersion;
+}
+
+void PluginInstaller::promptAndInstall(const QString& title, const QString& message) {
+  if (!requestConfirmation(title, message)) {
+    qDebug() << "[PluginInstaller] user declined prompt";
+    return;
+  }
+  performInstall();
+}
+
+QString PluginInstaller::installPromptTitle() {
+  return tr("Install Adobe After Effects Plug-in");
+}
+
+QString PluginInstaller::installPromptMessage() {
+  return tr("Do you want to install the Adobe After Effects plugins?");
+}
+
+QString PluginInstaller::updatePromptTitle() {
+  return tr("Update Adobe After Effects Plug-in");
+}
+
+QString PluginInstaller::updatePromptMessage() {
+  return tr(
+      "A new version of the Adobe After Effects plugin is available. "
+      "Would you like to update it now?");
+}
+
+InstallResult PluginInstaller::performInstall() {
   while (checkAeRunning()) {
     if (!requestConfirmation(tr("Please close Adobe After Effects"),
                              tr("Adobe After Effects is currently running. Please close it and "
@@ -115,7 +182,7 @@ InstallResult PluginInstaller::installPlugin() {
 InstallResult PluginInstaller::uninstallPlugin() {
   if (!requestConfirmation(tr("Uninstall Plugins"),
                            tr("Are you sure you want to uninstall the selected plugins?"))) {
-    return InstallResult::UnknownError;
+    return InstallResult::UserCancelled;
   }
 
   while (checkAeRunning()) {
@@ -143,24 +210,27 @@ InstallResult PluginInstaller::uninstallPlugin() {
 }
 
 QString PluginInstaller::getInstalledVersion() const {
-  QString pluginName = "PAGExporter";
-  QString installPath = getPluginInstallPath(pluginName);
-  if (!QFile::exists(installPath)) {
+  return getPluginVersionAt(getPluginInstallPath(PrimaryPluginName));
+}
+
+QString PluginInstaller::getPluginVersionAt(const QString& path) const {
+  if (!QFile::exists(path)) {
     return QString();
   }
   QString version;
-  if (getPluginVersionString(installPath, version) == VersionResult::Success) {
+  if (getPluginVersionString(path, version) == VersionResult::Success) {
     return version;
   }
   return QString();
 }
 
 bool PluginInstaller::isPluginInstalled() const {
-  QString pluginName = "PAGExporter";
-  return QFile::exists(getPluginInstallPath(pluginName));
+  return QFile::exists(getPluginInstallPath(PrimaryPluginName));
 }
 
 const QList<PluginInfo>& PluginInstaller::pluginInfoList() {
+  // The "PAGExporter" entry must stay in sync with PluginInstaller::PrimaryPluginName,
+  // which is the plugin used for startup install/update detection.
   static const QList<PluginInfo> list = {
       {"PAGExporter", PluginPermission::Admin},
       {"H264EncoderTools", PluginPermission::User},

--- a/viewer/src/platform/PluginInstaller.h
+++ b/viewer/src/platform/PluginInstaller.h
@@ -104,10 +104,10 @@ class PluginInstaller : public QObject {
   /// Single source of truth for the install/update prompts. Shared between the manual
   /// installPlugin() path and the startup checkPluginOnStartup() path so wording stays in
   /// sync — keep this list aligned with the matching messages in Chinese.ts.
-  static QString installPromptTitle();
-  static QString installPromptMessage();
-  static QString updatePromptTitle();
-  static QString updatePromptMessage();
+  static QString InstallPromptTitle();
+  static QString InstallPromptMessage();
+  static QString UpdatePromptTitle();
+  static QString UpdatePromptMessage();
 
   QStringList getAeInstallPaths();
   QString getPluginSourcePath(const QString& pluginName) const;

--- a/viewer/src/platform/PluginInstaller.h
+++ b/viewer/src/platform/PluginInstaller.h
@@ -24,7 +24,14 @@
 
 namespace pag {
 
-enum class InstallResult { Success, SourceNotFound, PermissionDenied, AeRunning, UnknownError };
+enum class InstallResult {
+  Success,
+  SourceNotFound,
+  PermissionDenied,
+  AeRunning,
+  UserCancelled,
+  UnknownError
+};
 
 enum class VersionResult {
   Success,
@@ -62,6 +69,14 @@ class PluginInstaller : public QObject {
   InstallResult installPlugin();
   InstallResult uninstallPlugin();
 
+  /// Run once at app startup to keep the AE plugin in sync with the bundled version.
+  /// Behavior depends on the installed state:
+  ///   - Not installed: prompts the user to install.
+  ///   - Installed but version differs: prompts the user to update.
+  ///   - Installed and versions match: no-op.
+  /// Idempotent: subsequent calls within the same session are silent.
+  void checkPluginOnStartup();
+
   QString getInstalledVersion() const;
   bool isPluginInstalled() const;
 
@@ -75,9 +90,24 @@ class PluginInstaller : public QObject {
   void uninstallCompleted(InstallResult result, const QString& message);
 
  private:
+  /// The plugin used as the source of truth for "is anything installed?" and version
+  /// comparison during startup checks. Must be present in pluginInfoList().
+  static constexpr const char* PrimaryPluginName = "PAGExporter";
+
+  InstallResult performInstall();
+  void promptAndInstall(const QString& title, const QString& message);
+  QString getPluginVersionAt(const QString& path) const;
   bool checkAeRunning();
   bool requestConfirmation(const QString& title, const QString& message);
   void showMessage(const QString& title, const QString& message, bool isWarning = false);
+
+  /// Single source of truth for the install/update prompts. Shared between the manual
+  /// installPlugin() path and the startup checkPluginOnStartup() path so wording stays in
+  /// sync — keep this list aligned with the matching messages in Chinese.ts.
+  static QString installPromptTitle();
+  static QString installPromptMessage();
+  static QString updatePromptTitle();
+  static QString updatePromptMessage();
 
   QStringList getAeInstallPaths();
   QString getPluginSourcePath(const QString& pluginName) const;
@@ -125,6 +155,7 @@ class PluginInstaller : public QObject {
 
   int minSupportedYear = DefaultMinYear;
   int maxSupportedYear = DefaultMaxYear;
+  bool startupCheckTriggered = false;
 };
 
 }  // namespace pag


### PR DESCRIPTION
### 背景
PAGViewer 内置的 AE 插件在版本更新时，用户需要手动进入维护页才能更新；首次使用时也没有引导安装。

### 改动
- 启动时调用 `PluginInstaller::checkPluginOnStartup()`，根据当前状态分三种行为：
  - 未安装且有内置 source → 弹窗引导安装
  - 已安装但版本与内置 source 不一致 → 弹窗引导更新
  - 已是最新 → 无动作
- 单次会话内幂等，避免重复弹窗。
- 抽出 install/update 文案 helper，让手动安装路径与启动检查路径共用同一份措辞。
- `InstallResult` 新增 `UserCancelled`，把"用户主动取消"从 `UnknownError` 中拆分出来。
- 加固 `hasUpdate()`：版本号无法解析时跳过，避免 dev build 占位符 `..` 触发死循环弹窗。
- 同步 `Chinese.ts` 翻译。

### 测试
- 本地手动验证：未安装 / 旧版本 / 最新版本三种状态下的启动行为均符合预期。