### PR TITLE
Optimize macOS and Windows packaging scripts with structured logging and robustness improvements

### DIFF
--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -1,14 +1,112 @@
 #!/bin/bash
 
-function print() {
-    local text="$1"
-    local width=${2:-40}
-    local textLength=${#text}
-    local padingLength=$(((width - textLength) / 2))
-    local padding=$(printf '%*s' $padingLength '')
-    padding=${padding// /=}
+# Color definitions
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+NC='\033[0m'
 
-    echo "${padding}${text}${padding}"
+SECTION_WIDTH=60
+TOTAL_SECTIONS=5
+
+function printSection() {
+    local index="$1"
+    local title="$2"
+    local header="  ▶ [${index}/${TOTAL_SECTIONS}] ${title}"
+    local line=$(printf '═%.0s' $(seq 1 ${SECTION_WIDTH}))
+    echo ""
+    echo -e "${BOLD}${BLUE}${line}${NC}"
+    echo -e "${BOLD}${BLUE}${header}${NC}"
+    echo -e "${BOLD}${BLUE}${line}${NC}"
+}
+
+function printStep() {
+    echo -e "${BLUE}  → $1${NC}"
+}
+
+function logInfo() {
+    echo -e "${BLUE}    [INFO] $1${NC}"
+}
+
+function logSuccess() {
+    echo -e "${GREEN}    [OK] $1${NC}"
+}
+
+function logWarning() {
+    echo -e "${YELLOW}    [WARN] $1${NC}"
+}
+
+function logError() {
+    echo -e "${RED}    [ERROR] $1${NC}"
+}
+
+function exitWithError() {
+    logError "$1"
+    exit 1
+}
+
+function cmakeConfigure() {
+    local sourceDir="$1"
+    local buildDir="$2"
+    local target="$3"
+    shift 3
+    cmake -S "${sourceDir}" -B "${buildDir}" "$@"
+    if [ $? -ne 0 ];
+    then
+        exitWithError "CMake configure failed for ${target}"
+    fi
+}
+
+function cmakeBuild() {
+    local buildDir="$1"
+    local target="$2"
+    cmake --build "${buildDir}" --target "${target}" -j 8
+    if [ $? -ne 0 ];
+    then
+        exitWithError "CMake build failed for ${target}"
+    fi
+}
+
+function generateUniversalDsym() {
+    local binaryName="$1"
+    local x86Dir="$2"
+    local armDir="$3"
+    local outputDir="$4"
+    local x86Exe="$5"
+    local armExe="$6"
+
+    local x86Dsym="${x86Dir}/${binaryName}.dSYM"
+    local armDsym="${armDir}/${binaryName}.dSYM"
+    local universalDsym="${outputDir}/${binaryName}.dSYM"
+
+    dsymutil "${x86Exe}" -o "${x86Dsym}"
+    if [ $? -ne 0 ];
+    then
+        exitWithError "Generate ${binaryName} x86_64 dSYM failed"
+    fi
+
+    dsymutil "${armExe}" -o "${armDsym}"
+    if [ $? -ne 0 ];
+    then
+        exitWithError "Generate ${binaryName} arm64 dSYM failed"
+    fi
+
+    cp -R "${x86Dsym}" "${universalDsym}"
+    lipo -create \
+        "${x86Dsym}/Contents/Resources/DWARF/${binaryName}" \
+        "${armDsym}/Contents/Resources/DWARF/${binaryName}" \
+        -output "${universalDsym}/Contents/Resources/DWARF/${binaryName}"
+    if [ $? -ne 0 ];
+    then
+        exitWithError "Merge ${binaryName} dSYM failed"
+    fi
+
+    logSuccess "${binaryName} dSYM files generated:"
+    logInfo "  Universal: ${universalDsym}"
+    logInfo "  x86_64: ${x86Dsym}"
+    logInfo "  arm64: ${armDsym}"
 }
 
 function createDmg()
@@ -34,19 +132,24 @@ function createDmg()
 }
 
 # 1 Initialize variables
-print "[ Initialize variables ]"
+BUILD_START_TIME=$(date +%s)
+printSection 1 "Initialize variables"
+# Default to 1.0.0 when version env vars are not provided (e.g. local dev builds).
+# CI populates MajorVersion / MinorVersion / BuildNumber from the release pipeline.
+MajorVersion=${MajorVersion:-1}
+MinorVersion=${MinorVersion:-0}
+BuildNumber=${BuildNumber:-0}
 AppVersion=${MajorVersion}.${MinorVersion}.${BuildNumber}
 CurrentTime=$(date +"%Y-%m-%d %H:%M:%S")
 RFCTime=$(date -R)
 SourceDir=$(dirname "$(dirname "$(realpath "$0")")")
 BuildDir="${SourceDir}/build_viewer"
 
-echo "Build Time: ${CurrentTime}"
+logInfo "Build Time: ${CurrentTime}"
 
 if [ -z "${PAG_DeployQt_Path}" ] || [ -z "${PAG_Qt_Path}" ] || [ -z "${PAG_AE_SDK_Path}" ];
 then
-  echo "Please set [PAG_DeployQt_Path], [PAG_Qt_Path] and [PAG_AE_SDK_Path] before build on mac"
-  exit 1
+    exitWithError "Please set [PAG_DeployQt_Path], [PAG_Qt_Path] and [PAG_AE_SDK_Path] before build on mac"
 fi
 
 Deployqt="${PAG_DeployQt_Path}"
@@ -55,99 +158,62 @@ QtCMakePath="${QtPath}/lib/cmake"
 AESDKPath="${PAG_AE_SDK_Path}"
 
 # 2 Compile
-print "[ Compile ]"
+printSection 2 "Compile"
 PAGPath=""
 if declare -F GetPAGPath > /dev/null;
 then
     PAGPath=$(GetPAGPath)
-    echo "Get PAGPath: ${PAGPath}"
+    logInfo "Get PAGPath: ${PAGPath}"
 fi
 
 PAGOptions=""
 if declare -F GetPAGOptions > /dev/null;
 then
     PAGOptions=$(GetPAGOptions)
-    echo "Get PAGOptions: ${PAGOptions}"
+    logInfo "Get PAGOptions: ${PAGOptions}"
 fi
 
 x86_64BuildDir="${BuildDir}/build_x86_64"
 arm64BuildDir="${BuildDir}/build_arm64"
 
 # 2.1 Compile PAGExporter-x86_64
-print "[ Compile PAGExporter-x86_64 ]"
+printStep "PAGExporter-x86_64"
 PluginSourceDir="$(dirname "${SourceDir}")/exporter"
 x86_64BuildDirForPlugin="${x86_64BuildDir}/Plugin"
 
-cmake -S ${PluginSourceDir} -B ${x86_64BuildDirForPlugin} -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_PREFIX_PATH="${QtCMakePath}" -DAE_SDK_PATH="${AESDKPath}"
-if [ $? -ne 0 ];
-then
-    echo "Build PAGExporter-x86_64 failed"
-    exit 1
-fi
-
-cmake --build ${x86_64BuildDirForPlugin} --target PAGExporter -j 8
-if [ $? -ne 0 ];
-then
-    echo "Compile PAGExporter-x86_64 failed"
-    exit 1
-fi
+cmakeConfigure "${PluginSourceDir}" "${x86_64BuildDirForPlugin}" "PAGExporter-x86_64" \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+    -DCMAKE_PREFIX_PATH="${QtCMakePath}" -DAE_SDK_PATH="${AESDKPath}"
+cmakeBuild "${x86_64BuildDirForPlugin}" "PAGExporter"
 
 # 2.2 Compile PAGExporter-arm64
-print "[ Compile PAGExporter-arm64 ]"
+printStep "PAGExporter-arm64"
 arm64BuildDirForPlugin="${arm64BuildDir}/Plugin"
 
-cmake -S ${PluginSourceDir} -B ${arm64BuildDirForPlugin} -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_PREFIX_PATH="${QtCMakePath}" -DAE_SDK_PATH="${AESDKPath}"
-if [ $? -ne 0 ];
-then
-    echo "Build PAGExporter-arm64 failed"
-    exit 1
-fi
-
-cmake --build ${arm64BuildDirForPlugin} --target PAGExporter -j 8
-if [ $? -ne 0 ];
-then
-    echo "Compile PAGExporter-arm64 failed"
-    exit 1
-fi
+cmakeConfigure "${PluginSourceDir}" "${arm64BuildDirForPlugin}" "PAGExporter-arm64" \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 \
+    -DCMAKE_PREFIX_PATH="${QtCMakePath}" -DAE_SDK_PATH="${AESDKPath}"
+cmakeBuild "${arm64BuildDirForPlugin}" "PAGExporter"
 
 # 2.3 Compile PAGViewer-x86_64
-print "[ Compile x86_64 ]"
-x86_64BuildDir="${BuildDir}/build_x86_64"
+printStep "PAGViewer-x86_64"
 
-cmake -S ${SourceDir} -B ${x86_64BuildDir} -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_PREFIX_PATH="${QtCMakePath}" -DPAG_PATH="${PAGPath}" -DPAG_OPTIONS="${PAGOptions}"
-if [ $? -ne 0 ];
-then
-    echo "Build PAGViewer-x86_64 failed"
-    exit 1
-fi
+cmakeConfigure "${SourceDir}" "${x86_64BuildDir}" "PAGViewer-x86_64" \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+    -DCMAKE_PREFIX_PATH="${QtCMakePath}" -DPAG_PATH="${PAGPath}" -DPAG_OPTIONS="${PAGOptions}"
+cmakeBuild "${x86_64BuildDir}" "PAGViewer"
 
-cmake --build ${x86_64BuildDir} --target PAGViewer -j 8
-if [ $? -ne 0 ];
-then
-    echo "Compile PAGViewer-x86_64 failed"
-    exit 1
-fi
-
-# 2.4 Compile PAGViewer-arm
-print "[ Compile arm64 ]"
+# 2.4 Compile PAGViewer-arm64
+printStep "PAGViewer-arm64"
 arm64BuildDir="${BuildDir}/build_arm64"
 
-cmake -S ${SourceDir} -B ${arm64BuildDir} -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_PREFIX_PATH="${QtCMakePath}" -DPAG_PATH="${PAGPath}" -DPAG_OPTIONS="${PAGOptions}"
-if [ $? -ne 0 ];
-then
-    echo "Build PAGViewer-arm64 failed"
-    exit 1
-fi
-
-cmake --build ${arm64BuildDir} --target PAGViewer -j 8
-if [ $? -ne 0 ];
-then
-    echo "Compile PAGViewer-arm64 failed"
-    exit 1
-fi
+cmakeConfigure "${SourceDir}" "${arm64BuildDir}" "PAGViewer-arm64" \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 \
+    -DCMAKE_PREFIX_PATH="${QtCMakePath}" -DPAG_PATH="${PAGPath}" -DPAG_OPTIONS="${PAGOptions}"
+cmakeBuild "${arm64BuildDir}" "PAGViewer"
 
 # 2.5 Compile H264EncoderTools
-print "[ Compile H264EncoderTools ]"
+printStep "H264EncoderTools"
 EncoderToolSourceDir="${SourceDir}/third_party/H264EncoderTools"
 EncoderToolBuildDir="${BuildDir}/EncoderTools"
 
@@ -155,122 +221,90 @@ xcodebuild clean -project "${EncoderToolSourceDir}/H264EncoderTools.xcodeproj" -
 xcodebuild -project "${EncoderToolSourceDir}/H264EncoderTools.xcodeproj" -scheme H264EncoderTools -configuration Release SYMROOT="${EncoderToolBuildDir}" CODE_SIGN_IDENTITY="" ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_ALLOWED=NO -quiet > /dev/null 2>&1
 if [ $? -ne 0 ];
 then
-    echo "Build H264EncoderTools failed"
-    exit 1
+    exitWithError "Build H264EncoderTools failed"
 fi
 
 # 3 Organize resources
 # 3.1 Merge PAGViewer
-print "[ Merge PAGViewer ]"
+printSection 3 "Organize resources"
+printStep "Merge PAGViewer"
 AppDir="${BuildDir}/PAGViewer.app"
 ExeDir="${AppDir}/Contents/MacOS"
 ExePath="${ExeDir}/PAGViewer"
 x86_64ExePath="${x86_64BuildDir}/PAGViewer"
 arm64ExePath="${arm64BuildDir}/PAGViewer"
 
-install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/x64" ${x86_64ExePath}
-install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/arm64" ${arm64ExePath}
+# Clean previous app bundle to avoid incremental build issues
+rm -rf "${AppDir}"
+
+install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/x64" ${x86_64ExePath} 2>/dev/null || true
+install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/arm64" ${arm64ExePath} 2>/dev/null || true
 
 mkdir -p ${ExeDir}
 lipo -create ${x86_64ExePath} ${arm64ExePath} -output ${ExePath}
 
 # 3.1.1 Generate dSYM files for PAGViewer
-print "[ Generate dSYM files for PAGViewer ]"
-
-# Generate dSYM for each architecture in their respective build directories
-x86_64DsymPath="${x86_64BuildDir}/PAGViewer.dSYM"
-arm64DsymPath="${arm64BuildDir}/PAGViewer.dSYM"
-UniversalDsymPath="${BuildDir}/PAGViewer.dSYM"
-
-dsymutil ${x86_64ExePath} -o ${x86_64DsymPath}
-if [ $? -ne 0 ];
-then
-    echo "Generate PAGViewer x86_64 dSYM failed"
-    exit 1
-fi
-
-dsymutil ${arm64ExePath} -o ${arm64DsymPath}
-if [ $? -ne 0 ];
-then
-    echo "Generate PAGViewer arm64 dSYM failed"
-    exit 1
-fi
-
-# Create universal dSYM by copying structure and merging DWARF
-cp -R ${x86_64DsymPath} ${UniversalDsymPath}
-lipo -create \
-    ${x86_64DsymPath}/Contents/Resources/DWARF/PAGViewer \
-    ${arm64DsymPath}/Contents/Resources/DWARF/PAGViewer \
-    -output ${UniversalDsymPath}/Contents/Resources/DWARF/PAGViewer
-
-if [ $? -ne 0 ];
-then
-    echo "Merge PAGViewer dSYM failed"
-    exit 1
-fi
-
-echo "PAGViewer dSYM files generated:"
-echo "  Universal: ${UniversalDsymPath}"
-echo "  x86_64: ${x86_64DsymPath}"
-echo "  arm64: ${arm64DsymPath}"
+printStep "Generate dSYM for PAGViewer"
+generateUniversalDsym "PAGViewer" "${x86_64BuildDir}" "${arm64BuildDir}" "${BuildDir}" "${x86_64ExePath}" "${arm64ExePath}"
 
 # 3.2 Obtain the dependencies of PAGViewer
-print "[ Obtain the dependencies of PAGViewer ]"
+printStep "Deploy Qt dependencies"
 ${Deployqt} ${AppDir} -qmldir=${SourceDir}/assets/qml
+if [ $? -ne 0 ];
+then
+    exitWithError "Deploy Qt dependencies (viewer qml) failed"
+fi
 ${Deployqt} ${AppDir} -qmldir=${PluginSourceDir}/assets/qml
 if [ $? -ne 0 ];
 then
-    echo "Obtain the dependencies of PAGViewer failed"
-    exit 1
+    exitWithError "Deploy Qt dependencies (exporter qml) failed"
 fi
 
 # 3.2.1 Copy Sparkle
-print "[ Copy Sparkle.framework ]"
+printStep "Copy Sparkle.framework"
 FrameworkDir="${AppDir}/Contents/Frameworks"
 SparklePath="${SourceDir}/vendor/sparkle/mac/Sparkle.framework"
 cp -f -R -P ${SparklePath} ${FrameworkDir}
 
 # 3.2.2 Merge and copy ffmovie
-print "[ Merge and copy ffmovie.dylib ]"
+printStep "Merge ffmovie.dylib"
 x64FfmoviePath="${SourceDir}/vendor/ffmovie/mac/x64/libffmovie.dylib"
 arm64FfmoviePath="${SourceDir}/vendor/ffmovie/mac/arm64/libffmovie.dylib"
 FfmoviePath="${FrameworkDir}/libffmovie.dylib"
 lipo -create ${x64FfmoviePath} ${arm64FfmoviePath} -output ${FfmoviePath}
 
 # 3.3 Obtain public and private keys
-print "[ Obtain public and private keys ]"
+printStep "Obtain signing keys"
 
 # 3.3.1 Obtain DSA public and private keys
-print "[ Obtain DSA public and private keys ]"
 SignForUpdate=false
 DSAPublicKey=""
 DSAPrivateKey=""
 if declare -F GetDSAPublicKeyPath > /dev/null;
 then
     DSAPublicKey=$(GetDSAPublicKeyPath)
-    print "Get DSAPublicKey: ${DSAPublicKey}"
+    logInfo "Get DSAPublicKey: ${DSAPublicKey}"
 fi
 
 if declare -F GetDSAPrivateKeyPath > /dev/null;
 then
     DSAPrivateKey=$(GetDSAPrivateKeyPath)
-    print "Get DSAPrivateKey: ${DSAPrivateKey}"
+    logInfo "Get DSAPrivateKey: ${DSAPrivateKey}"
 fi
 
 # 3.3.2 Obtain EDDSA public and private keys
-print "[ Obtain EDDSA public and private keys ]"
 EDDSAPublicKey=""
 EDDSAPrivateKey=""
 if declare -F GetEDDSAPublicKeyPath > /dev/null;
 then
     EDDSAPublicKey=$(GetEDDSAPublicKeyPath)
-    print "Get EDDSAPublicKey: ${EDDSAPublicKey}"
+    logInfo "Get EDDSAPublicKey: ${EDDSAPublicKey}"
 fi
 
 if declare -F GetEDDSAPrivateKeyPath > /dev/null;
 then
     EDDSAPrivateKey=$(GetEDDSAPrivateKeyPath)
-    print "Get EDDSAPrivateKey: ${EDDSAPrivateKey}"
+    logInfo "Get EDDSAPrivateKey: ${EDDSAPrivateKey}"
 fi
 
 if [ -n "${DSAPublicKey}" ] && [ -n "${DSAPrivateKey}" ] && [ -n "${EDDSAPublicKey}" ] && [ -n "${EDDSAPrivateKey}" ];
@@ -279,7 +313,7 @@ then
 fi
 
 # 3.4 Copy resources
-print "[ Copy resources ]"
+printStep "Copy resources"
 ContentsDir="${AppDir}/Contents"
 PlistPath=${SourceDir}/package/templates/Info.plist
 cp -f ${PlistPath} ${ContentsDir}
@@ -293,10 +327,9 @@ then
 fi
 
 # 3.5 Merge PAGExporter and copy related tools
-print "[ Merge PAGExporter and copy related tools ]"
+printStep "Merge PAGExporter"
 
 # 3.5.1 Merge PAGExporter
-print "[ Merge PAGExporter ]"
 PluginPath="${ResourcesDir}/PAGExporter.plugin"
 PluginExePath="${PluginPath}/Contents/MacOS/PAGExporter"
 x86_64PluginPath="${x86_64BuildDirForPlugin}/PAGExporter.plugin"
@@ -304,82 +337,62 @@ arm64PluginPath="${arm64BuildDirForPlugin}/PAGExporter.plugin"
 x86_64PluginExePath="${x86_64PluginPath}/Contents/MacOS/PAGExporter"
 arm64PluginExePath="${arm64PluginPath}/Contents/MacOS/PAGExporter"
 
-install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/x64" ${x86_64PluginExePath}
-install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/arm64" ${arm64PluginExePath}
+# Remove absolute build rpaths from each architecture before merging
+otool -l "${x86_64PluginExePath}" | grep -A2 "LC_RPATH" | grep "path " | sed 's/.*path \(.*\) (offset.*/\1/' | while IFS= read -r rpath; do
+    case "${rpath}" in
+        @*|/Library/*) ;;
+        *) install_name_tool -delete_rpath "${rpath}" "${x86_64PluginExePath}" 2>/dev/null || true ;;
+    esac
+done
+otool -l "${arm64PluginExePath}" | grep -A2 "LC_RPATH" | grep "path " | sed 's/.*path \(.*\) (offset.*/\1/' | while IFS= read -r rpath; do
+    case "${rpath}" in
+        @*|/Library/*) ;;
+        *) install_name_tool -delete_rpath "${rpath}" "${arm64PluginExePath}" 2>/dev/null || true ;;
+    esac
+done
 
 cp -fr ${x86_64PluginPath} ${PluginPath}
 lipo -create ${x86_64PluginExePath} ${arm64PluginExePath} -output ${PluginExePath}
 
 # 3.5.1.1 Generate dSYM files for PAGExporter
-print "[ Generate dSYM files for PAGExporter ]"
-
-# Generate dSYM for each architecture in their respective build directories
-x86_64PluginDsymPath="${x86_64BuildDirForPlugin}/PAGExporter.dSYM"
-arm64PluginDsymPath="${arm64BuildDirForPlugin}/PAGExporter.dSYM"
-UniversalPluginDsymPath="${BuildDir}/PAGExporter.dSYM"
-
-dsymutil ${x86_64PluginExePath} -o ${x86_64PluginDsymPath}
-if [ $? -ne 0 ];
-then
-    echo "Generate PAGExporter x86_64 dSYM failed"
-    exit 1
-fi
-
-dsymutil ${arm64PluginExePath} -o ${arm64PluginDsymPath}
-if [ $? -ne 0 ];
-then
-    echo "Generate PAGExporter arm64 dSYM failed"
-    exit 1
-fi
-
-# Create universal dSYM by copying structure and merging DWARF
-cp -R ${x86_64PluginDsymPath} ${UniversalPluginDsymPath}
-lipo -create \
-    ${x86_64PluginDsymPath}/Contents/Resources/DWARF/PAGExporter \
-    ${arm64PluginDsymPath}/Contents/Resources/DWARF/PAGExporter \
-    -output ${UniversalPluginDsymPath}/Contents/Resources/DWARF/PAGExporter
-
-if [ $? -ne 0 ];
-then
-    echo "Merge PAGExporter dSYM failed"
-    exit 1
-fi
-
-echo "PAGExporter dSYM files generated:"
-echo "  Universal: ${UniversalPluginDsymPath}"
-echo "  x86_64: ${x86_64PluginDsymPath}"
-echo "  arm64: ${arm64PluginDsymPath}"
+printStep "Generate dSYM for PAGExporter"
+generateUniversalDsym "PAGExporter" "${x86_64BuildDirForPlugin}" "${arm64BuildDirForPlugin}" "${BuildDir}" "${x86_64PluginExePath}" "${arm64PluginExePath}"
 
 # 3.5.2 Obtain the dependencies of PAGExporter
-print "[ Obtain the dependencies of PAGExporter ]"
+printStep "Deploy PAGExporter Qt dependencies"
 ${Deployqt} ${PluginPath} -qmldir=${PluginSourceDir}/assets/qml
 if [ $? -ne 0 ];
 then
-    echo "Obtain the dependencies of PAGExporter failed"
-    exit 1
+    exitWithError "Obtain the dependencies of PAGExporter failed"
 fi
-cp -fRP "${PluginPath}/Contents/Frameworks/*" "${AppDir}/Contents/Frameworks/"
-cp -fRP "${PluginPath}/Contents/Plugins/*" "${AppDir}/Contents/Plugins/"
+# Remove libraries from plugin that already exist in the main app (to avoid overwriting universal with single-arch)
+if [ -d "${PluginPath}/Contents/Frameworks" ];
+then
+    for existingLib in "${FrameworkDir}"/*.dylib; do
+        libName=$(basename "${existingLib}")
+        rm -f "${PluginPath}/Contents/Frameworks/${libName}"
+    done
+    # Copy remaining plugin Frameworks into the main app
+    find "${PluginPath}/Contents/Frameworks" -mindepth 1 -maxdepth 1 -exec cp -fRP {} "${AppDir}/Contents/Frameworks/" \;
+fi
+if [ -d "${PluginPath}/Contents/Plugins" ];
+then
+    cp -fRP "${PluginPath}/Contents/Plugins/"* "${AppDir}/Contents/Plugins/"
+fi
 rm -rf "${PluginPath}/Contents/Frameworks"
 rm -rf "${PluginPath}/Contents/Plugins"
 rm -rf "${PluginPath}/Contents/Resources/qml"
 
 # 3.5.3 Copy related tools
-print "[ Copy related tools ]"
+printStep "Copy tools and scripts"
 EncoderToolsPath="${EncoderToolBuildDir}/Release/H264EncoderTools"
 cp -f ${EncoderToolsPath} ${ResourcesDir}
-
-# 3.5.4 Copy Qt deployment scripts
-print "[ Copy Qt deployment scripts ]"
 cp -f "${SourceDir}/qttools/copy_qt_resource.sh" "${ResourcesDir}/"
 cp -f "${SourceDir}/qttools/delete_qt_resource.sh" "${ResourcesDir}/"
 cp -f "${SourceDir}/qttools/replace_qt_path.sh" "${ResourcesDir}/"
 
 # 3.5.5 Generate qt.conf for PAGExporter plugin
-# Use absolute path to load Qt resources from external shared directory
-# This avoids modifying plugin bundle contents which would break code signature
-# Note: qt.conf in Resources/ has higher priority than MacOS/ on macOS
-print "[ Generate qt.conf for PAGExporter ]"
+printStep "Generate qt.conf for PAGExporter"
 PLUGIN_RESOURCES_DIR="${ResourcesDir}/PAGExporter.plugin/Contents/Resources"
 PLUGIN_QT_CONF="${PLUGIN_RESOURCES_DIR}/qt.conf"
 mkdir -p "${PLUGIN_RESOURCES_DIR}"
@@ -392,7 +405,7 @@ QmlImports = Resources/qml
 EOF
 
 # 3.6 Update plist
-print "[ Update plist ]"
+printStep "Update plist"
 DSAPublicKeyName=$(basename "${DSAPublicKey}")
 SUPublicEDKey=""
 if [ -n "${EDDSAPublicKey}" ] && [ -f "${EDDSAPublicKey}" ];
@@ -409,134 +422,174 @@ fi
 /usr/libexec/Plistbuddy -c "Set CFBundleIdentifier im.pag.exporter" "${PluginPath}/Contents/Info.plist"
 
 # 3.7 Set rpath
-print "[ Set rpath ]"
-# todo delete redundant paths
-install_name_tool -delete_rpath "${QtPath}/lib" ${ExePath}
-install_name_tool -delete_rpath "${SourceDir}/vendor/sparkle/mac" ${ExePath}
-install_name_tool -add_rpath "@executable_path/../Frameworks" ${ExePath}
+printStep "Set rpath"
+install_name_tool -delete_rpath "${QtPath}/lib" ${ExePath} 2>/dev/null || true
+install_name_tool -delete_rpath "${SourceDir}/vendor/sparkle/mac" ${ExePath} 2>/dev/null || true
+install_name_tool -add_rpath "@executable_path/../Frameworks" ${ExePath} 2>/dev/null || true
 
-install_name_tool -delete_rpath "${QtPath}/lib" ${PluginExePath}
-install_name_tool -add_rpath "@executable_path/../Frameworks" ${PluginExePath}
-install_name_tool -add_rpath "@loader_path/../Frameworks" ${PluginExePath}
-# Add rpath to load Qt frameworks from external shared directory
-install_name_tool -add_rpath "/Library/Application Support/PAGExporter/Frameworks" ${PluginExePath}
+install_name_tool -delete_rpath "${QtPath}/lib" ${PluginExePath} 2>/dev/null || true
+install_name_tool -add_rpath "@executable_path/../Frameworks" ${PluginExePath} 2>/dev/null || true
+install_name_tool -add_rpath "@loader_path/../Frameworks" ${PluginExePath} 2>/dev/null || true
+install_name_tool -add_rpath "/Library/Application Support/PAGExporter/Frameworks" ${PluginExePath} 2>/dev/null || true
 
-# 4 Sign
-print "[ Sign ]"
-SignCertName=""
+# 4 Sign & Notarize
+printSection 4 "Sign & Notarize"
+SignCertName="Developer ID Application: Tencent Technology (Shanghai) Company Limited (FN2V63AD2J)"
 if declare -F GetSignCertName > /dev/null;
 then
     SignCertName=$(GetSignCertName)
-    echo "Get SignCertName: ${SignCertName}"
+    logInfo "Get SignCertName: ${SignCertName}"
 fi
 
 if security find-certificate -c "${SignCertName}" >/dev/null 2>&1;
 then
     # 4.1 Sign PAGViewer.app
-    print "[ Sign PAGViewer.app ]"
+    printStep "Sign PAGViewer.app"
     EntitlementsPath="${SourceDir}/package/templates/PAGViewer.entitlements"
-    NeedSignFiles=(
-        "${ExePath}"
-        "${ResourcesDir}/H264EncoderTools"
-        "${ResourcesDir}/PAGExporter.plugin/Contents/MacOS/PAGExporter"
-        "${ResourcesDir}/PAGExporter.plugin"
-        "${FrameworkDir}/Sparkle.framework/Versions/Current/Autoupdate"
-        "${FrameworkDir}/Sparkle.framework/Versions/Current/Sparkle"
+
+    xattr -rc "${AppDir}"
+    xattr -rc "${PluginPath}"
+
+    # Sign all dylibs in Frameworks/ directory first
+    logInfo "Signing all libraries in Frameworks/..."
+    find "${FrameworkDir}" -name "*.dylib" -type f | while IFS= read -r dylib; do
+        codesign --force --timestamp --options "runtime" --sign "${SignCertName}" "${dylib}" 2>/dev/null
+    done
+
+    # Sign standalone executables not inside a bundle
+    logInfo "Signing: ${ResourcesDir}/H264EncoderTools"
+    SIGN_OUTPUT=$(codesign --force --entitlements "${EntitlementsPath}" --timestamp --options "runtime" --sign "${SignCertName}" "${ResourcesDir}/H264EncoderTools" 2>&1)
+    SIGN_STATUS=$?
+    if [ ${SIGN_STATUS} -ne 0 ];
+    then
+        echo "${SIGN_OUTPUT}"
+        exitWithError "Failed to sign: H264EncoderTools"
+    fi
+
+    # Sign bundles with --deep (from inner to outer)
+    # --deep recursively signs all executables and frameworks inside the bundle
+    NeedSignBundles=(
         "${FrameworkDir}/Sparkle.framework/Versions/Current/XPCServices/Downloader.xpc"
         "${FrameworkDir}/Sparkle.framework/Versions/Current/XPCServices/Installer.xpc"
-        "${FrameworkDir}/Sparkle.framework/Versions/Current/Updater.app/Contents/MacOS/Updater"
+        "${FrameworkDir}/Sparkle.framework/Versions/Current/Updater.app"
+        "${FrameworkDir}/Sparkle.framework"
+        "${ResourcesDir}/PAGExporter.plugin"
         "${AppDir}"
     )
 
-    xattr -rc ${AppDir}
-    xattr -rc ${PluginPath}
-
-    for NeedSignFile in ${NeedSignFiles[@]};
+    for NeedSignFile in "${NeedSignBundles[@]}";
     do
-        codesign --deep --force --entitlements ${EntitlementsPath} --timestamp --options "runtime" --sign "${SignCertName}" "${NeedSignFile}"
+        logInfo "Signing bundle: ${NeedSignFile}"
+        SIGN_OUTPUT=$(codesign --deep --force --entitlements "${EntitlementsPath}" --timestamp --options "runtime" --sign "${SignCertName}" "${NeedSignFile}" 2>&1)
+        SIGN_STATUS=$?
+        if [ ${SIGN_STATUS} -ne 0 ];
+        then
+            echo "${SIGN_OUTPUT}"
+            exitWithError "Failed to sign: ${NeedSignFile}"
+        fi
+        if echo "${SIGN_OUTPUT}" | grep -qi "ambiguous\|error\|invalid";
+        then
+            echo "${SIGN_OUTPUT}"
+            exitWithError "Signing issue detected for: ${NeedSignFile}"
+        fi
+        if [ -n "${SIGN_OUTPUT}" ];
+        then
+            logWarning "${SIGN_OUTPUT}"
+        fi
     done
 
     # 4.2 Verify signature
-    print "[ Verify signature ]"
+    printStep "Verify signature"
     codesign -vvv --deep "${AppDir}"
+    if [ $? -ne 0 ];
+    then
+        exitWithError "Signature verification failed"
+    fi
+    logSuccess "Signature verification passed"
 
     # 4.3 Notarize PAGViewer.app
-    (
-        print "[ Notarize PAGViewer ]"
+    printStep "Notarize"
 
-        # 4.3.1 Compress PAGViewer.app
-        print "[ Compress PAGViewer ]"
-        cd "${BuildDir}"
-        KeychainProfile="AC_PASSWORD"
-        TempDir="Applications"
-        TempZip="Applications.zip"
+    # 4.3.1 Compress PAGViewer.app for notarization
+    pushd "${BuildDir}" > /dev/null
+    KeychainProfile="AC_PASSWORD"
+    TempDir="Applications"
+    TempZip="Applications.zip"
 
-        if [ -f "${TempZip}" ];
-        then
-            rm -f "${TempZip}"
-        fi
+    rm -f "${TempZip}"
+    rm -rf "${TempDir}"
 
-        if [ -d "${TempDir}" ];
-        then
-            rm -rf "${TempDir}"
-        fi
+    mkdir -p "${TempDir}"
+    cp -fRP "${AppDir}" "${TempDir}"
+    zip --symlinks -r -q -X "${TempZip}" "${TempDir}"
 
-        mkdir -p "${TempDir}"
-        cp -fRP "${AppDir}" "${TempDir}"
-        zip --symlinks -r -q -X "${TempZip}" "${TempDir}"
+    # 4.3.2 Submit PAGViewer.app for notarization
+    # Use --wait to block until notarization completes, no need for manual polling
+    xcrun notarytool submit --keychain-profile "${KeychainProfile}" --wait "${TempZip}" 2>&1 | tee notarize.log
+    SUBMIT_STATUS=${PIPESTATUS[0]}
 
-        # 4.3.2 Submit PAGViewer.app
-        print "[ Submit PAGViewer ]"
-        xcrun notarytool submit --keychain-profile "${KeychainProfile}" --wait "${TempZip}" 2>&1 | tee notarize.log
+    if [ ${SUBMIT_STATUS} -ne 0 ];
+    then
+        logError "Notarization submission failed. Log output:"
         cat notarize.log
-        if [ $? -ne 0 ];
+        exitWithError "Failed to submit app for notarization."
+    fi
+
+    # Check the notarization result from the log
+    NOTARIZE_STATUS=$(grep -i "status:" notarize.log | tail -1 | awk '{print $2}')
+    logInfo "Notarization status: ${NOTARIZE_STATUS}"
+
+    if [ "$(echo "${NOTARIZE_STATUS}" | tr '[:upper:]' '[:lower:]')" != "accepted" ];
+    then
+        logError "Notarization was not accepted. Status: ${NOTARIZE_STATUS}"
+        # Retrieve the submission ID to fetch the log for debugging
+        UUID=$(grep -Eo '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' notarize.log | head -n 1)
+        if [ -n "${UUID}" ];
         then
-            echo "Failed to submit app for notarization."
-            exit 1
-        fi
-
-        UUID=$(cat notarize.log | grep -Eo '\w{8}-(\w{4}-){3}\w{12}' | head -n 1)
-        echo "Submit app successfully. UUID: ${UUID}"
-
-        # 4.3.3 Verify notarization
-        print "[ Verify notarization ]"
-        while true;
-        do
-            xcrun notarytool info "${UUID}" --keychain-profile "${KeychainProfile}"  2>&1 | tee validate_notarize.log
-            Status=$(cat validate_notarize.log | grep "status" | awk '{print $2}' | tr -d '"')
-            echo "Current notarization[${UUID}] status: ${Status}"
-            Status=$(echo "$Status" | tr '[:lower:]' '[:upper:]')
-            if [ "${Status}" == "ACCEPTED" ];
+            logInfo "Fetching notarization log for UUID: ${UUID}"
+            xcrun notarytool log "${UUID}" --keychain-profile "${KeychainProfile}" notarize_detail.json 2>/dev/null
+            if [ -f notarize_detail.json ];
             then
-                echo "Succeeded to notarize app."
-                break;
-            elif [ "${Status}" == "INVALID" ];
-            then
-                echo "Failed to notarize app."
-                cat validate_notarize.log
-                exit 1
-            else
-                echo "Notarization is not completed yet. Wait for 20 seconds..."
-                sleep 20
+                cat notarize_detail.json
             fi
-        done
+        fi
+        exitWithError "Notarization failed."
+    fi
 
-        # 4.3.4 Attach notarize ticket
-        print "[ Add notarize ticket ]"
-        xcrun stapler staple "${AppDir}"
+    logSuccess "Notarization accepted."
 
-        # 4.3.5 Ensure ticket is attached
-        print "[ Ensure ticket is attached ]"
-        xcrun stapler validate "${AppDir}"
-    )
+    # 4.3.3 Attach notarization ticket to the app bundle
+    printStep "Staple ticket"
+    xcrun stapler staple "${AppDir}"
+    if [ $? -ne 0 ];
+    then
+        exitWithError "Failed to staple notarization ticket to ${AppDir}"
+    fi
+    logSuccess "Notarization ticket stapled successfully."
+
+    # 4.3.4 Validate the stapled ticket
+    printStep "Validate ticket"
+    xcrun stapler validate "${AppDir}"
+    if [ $? -ne 0 ];
+    then
+        exitWithError "Stapler validation failed for ${AppDir}"
+    fi
+    logSuccess "Stapler validation passed."
+
+    # Clean up temp files
+    rm -f "${TempZip}"
+    rm -rf "${TempDir}"
+    rm -f notarize.log
+    popd > /dev/null
+else
+    logWarning "Certificate '${SignCertName}' not found in keychain, skipping code signing and notarization."
 fi
 
-
 # 5 Package PAGViewer.dmg
-print "[ Package PAGViewer.dmg ]"
+printSection 5 "Package"
 
 # 5.1 Update Appcast.xml
-print "[ Update Appcast.xml ]"
+printStep "Update Appcast.xml"
 if [ "${SignForUpdate}" == true ];
 then
     (
@@ -548,18 +601,18 @@ then
             rm -f "${ZipFile}"
         fi
 
-        zip --symlinks -r -q -X "${ZipFile}" "${AppDir}"
+        zip --symlinks -r -q -X "${ZipFile}" "PAGViewer.app"
 
         SignScript="${SourceDir}/package/sign_update.sh"
         chmod +x "${SignScript}"
 
         ${SignScript} ${BuildDir}/${ZipFile} ${DSAPrivateKey} > DSASignHash.txt
         ZipDSAHash=$(tr '\n' ' ' < DSASignHash.txt | sed '$s/ //g')
-        echo "Get Zip DSA Hash: ${ZipDSAHash}"
+        logInfo "Get Zip DSA Hash: ${ZipDSAHash}"
 
         ${SignScript} ${BuildDir}/${ZipFile} ${EDDSAPrivateKey} > EDDSASignHash.txt
         ZipEDDSAHash=$(tr '\n' ' ' < EDDSASignHash.txt | sed '$s/ //g')
-        echo "Get Zip EDDSA Hash: ${ZipEDDSAHash}"
+        logInfo "Get Zip EDDSA Hash: ${ZipEDDSAHash}"
 
         ZipLength=$(stat -f%z ${BuildDir}/${ZipFile})
 
@@ -582,7 +635,21 @@ then
 fi
 
 # 5.2 Generate dmg
-print "[ Generate dmg ]"
+printStep "Generate DMG"
+
+# Remove existing DMG to avoid create-dmg failure
+rm -f "${BuildDir}/PAGViewer.dmg"
+
+# Detach any previously mounted PAGViewer volumes to avoid conflicts
+for vol in /Volumes/PAGViewer*; do
+    if [ -d "$vol" ];
+    then
+        logWarning "Found mounted volume: $vol, detaching..."
+        hdiutil detach "$vol" -force 2>/dev/null || true
+    fi
+done
+sleep 1
+
 if [ -d "${BuildDir}/dmg_content" ];
 then
     rm -rf "${BuildDir}/dmg_content"
@@ -593,11 +660,43 @@ cp -R -P "${AppDir}" "${BuildDir}/dmg_content"
 CreateDmgTool="${SourceDir}/tools/create-dmg/create-dmg"
 
 createDmg "${CreateDmgTool}" "${BuildDir}/dmg_content" "${BuildDir}/PAGViewer.dmg" "${SourceDir}/assets/images/dmgIcon.icns" "${SourceDir}/assets/images/dmg-background.png"
-if [  $? -eq 0 ];
+if [ $? -eq 0 ];
 then
-    echo "create dmg success"
+    logSuccess "DMG created successfully: ${BuildDir}/PAGViewer.dmg"
 else
-    echo "create dmg failed"
-    exit 1
+    exitWithError "Failed to create DMG"
 fi
 
+# Summary
+BUILD_END_TIME=$(date +%s)
+BUILD_DURATION=$((BUILD_END_TIME - BUILD_START_TIME))
+BUILD_MINUTES=$((BUILD_DURATION / 60))
+BUILD_SECONDS=$((BUILD_DURATION % 60))
+
+DMG_PATH="${BuildDir}/PAGViewer.dmg"
+DMG_SIZE=""
+if [ -f "${DMG_PATH}" ];
+then
+    DMG_SIZE=$(du -h "${DMG_PATH}" | awk '{print $1}')
+fi
+
+SIGNED="No"
+NOTARIZED="No"
+if security find-certificate -c "${SignCertName}" >/dev/null 2>&1;
+then
+    SIGNED="Yes (${SignCertName})"
+    NOTARIZED="Yes (stapled)"
+fi
+
+LINE=$(printf '═%.0s' $(seq 1 ${SECTION_WIDTH}))
+echo ""
+echo -e "${BOLD}${GREEN}${LINE}${NC}"
+echo -e "${BOLD}${GREEN}  ✔ Build Complete — ${BUILD_MINUTES}m ${BUILD_SECONDS}s${NC}"
+echo -e "${BOLD}${GREEN}${LINE}${NC}"
+logInfo "  Version:    ${AppVersion}"
+logInfo "  DMG:        ${DMG_PATH} (${DMG_SIZE})"
+logInfo "  dSYM:       ${BuildDir}/PAGViewer.dSYM"
+logInfo "              ${BuildDir}/PAGExporter.dSYM"
+logInfo "  Signed:     ${SIGNED}"
+logInfo "  Notarized:  ${NOTARIZED}"
+echo ""

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -457,7 +457,13 @@ then
     logInfo "Get SignCertName: ${SignCertName}"
 fi
 
+HasSignCert=false
 if security find-certificate -c "${SignCertName}" >/dev/null 2>&1;
+then
+    HasSignCert=true
+fi
+
+if [ "${HasSignCert}" = true ];
 then
     # 4.1 Sign PAGViewer.app
     printStep "Sign PAGViewer.app"
@@ -704,7 +710,7 @@ fi
 
 SIGNED="No"
 NOTARIZED="No"
-if security find-certificate -c "${SignCertName}" >/dev/null 2>&1;
+if [ "${HasSignCert}" = true ];
 then
     SIGNED="Yes (${SignCertName})"
     NOTARIZED="Yes (stapled)"

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -536,6 +536,13 @@ then
     rm -rf "${TempDir}"
 
     mkdir -p "${TempDir}"
+    # Ensure notarization temp artifacts are removed even if a later step fails.
+    # Use absolute paths so the trap works regardless of the cwd at exit time.
+    NotarizeTempDir="${BuildDir}/${TempDir}"
+    NotarizeTempZip="${BuildDir}/${TempZip}"
+    NotarizeLog="${BuildDir}/notarize.log"
+    NotarizeDetail="${BuildDir}/notarize_detail.json"
+    trap 'rm -rf "${NotarizeTempDir}" "${NotarizeTempZip}" "${NotarizeLog}" "${NotarizeDetail}" 2>/dev/null || true' EXIT
     cp -fRP "${AppDir}" "${TempDir}"
     zip --symlinks -r -q -X "${TempZip}" "${TempDir}"
 
@@ -592,11 +599,10 @@ then
     fi
     logSuccess "Stapler validation passed."
 
-    # Clean up temp files
-    rm -f "${TempZip}"
-    rm -rf "${TempDir}"
-    rm -f notarize.log
     popd > /dev/null
+    # Notarization succeeded; run cleanup explicitly and disarm the EXIT trap
+    rm -rf "${NotarizeTempDir}" "${NotarizeTempZip}" "${NotarizeLog}" "${NotarizeDetail}" 2>/dev/null || true
+    trap - EXIT
 else
     logWarning "Certificate '${SignCertName}' not found in keychain, skipping code signing and notarization."
 fi

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -665,7 +665,11 @@ then
 
         ZipLength=$(stat -f%z "${BuildDir}/${ZipFile}")
 
-        URL=$(curl -s https://pag.io/server.html)
+        URL=$(curl -fsS --retry 3 --connect-timeout 10 https://pag.io/server.html)
+        if [ -z "${URL}" ];
+        then
+            exitWithError "Failed to fetch update URL from pag.io/server.html"
+        fi
         if [ "${IsBetaVersion}" == true ];
         then
             URL="${URL}beta/"

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -258,6 +258,10 @@ install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/arm64" "${arm64
 
 mkdir -p "${ExeDir}"
 lipo -create "${x86_64ExePath}" "${arm64ExePath}" -output "${ExePath}"
+if [ $? -ne 0 ];
+then
+    exitWithError "Failed to merge PAGViewer universal binary at ${ExePath}"
+fi
 
 # 3.1.1 Generate dSYM files for PAGViewer
 printStep "Generate dSYM for PAGViewer"
@@ -288,6 +292,10 @@ x64FfmoviePath="${SourceDir}/vendor/ffmovie/mac/x64/libffmovie.dylib"
 arm64FfmoviePath="${SourceDir}/vendor/ffmovie/mac/arm64/libffmovie.dylib"
 FfmoviePath="${FrameworkDir}/libffmovie.dylib"
 lipo -create "${x64FfmoviePath}" "${arm64FfmoviePath}" -output "${FfmoviePath}"
+if [ $? -ne 0 ];
+then
+    exitWithError "Failed to merge ffmovie universal dylib at ${FfmoviePath}"
+fi
 
 # 3.3 Obtain public and private keys
 printStep "Obtain signing keys"

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -410,18 +410,25 @@ if [ -n "${EDDSAPublicKey}" ] && [ -f "${EDDSAPublicKey}" ];
 then
     SUPublicEDKey=$(awk '/-----BEGIN PUBLIC KEY-----/{flag=1; next} /-----END PUBLIC KEY-----/{flag=0} flag' "${EDDSAPublicKey}")
 fi
-/usr/libexec/Plistbuddy -c "Set CFBundleVersion ${AppVersion}" "${ContentsDir}/Info.plist"
-/usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString ${AppVersion}" "${ContentsDir}/Info.plist"
+/usr/libexec/Plistbuddy -c "Set CFBundleVersion ${AppVersion}" "${ContentsDir}/Info.plist" \
+    || exitWithError "Failed to update CFBundleVersion in ${ContentsDir}/Info.plist"
+/usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString ${AppVersion}" "${ContentsDir}/Info.plist" \
+    || exitWithError "Failed to update CFBundleShortVersionString in ${ContentsDir}/Info.plist"
 if [ -n "${DSAPublicKey}" ];
 then
     DSAPublicKeyName=$(basename "${DSAPublicKey}")
-    /usr/libexec/Plistbuddy -c "Set SUPublicDSAKeyFile ${DSAPublicKeyName}" "${ContentsDir}/Info.plist"
+    /usr/libexec/Plistbuddy -c "Set SUPublicDSAKeyFile ${DSAPublicKeyName}" "${ContentsDir}/Info.plist" \
+        || exitWithError "Failed to update SUPublicDSAKeyFile in ${ContentsDir}/Info.plist"
 fi
-/usr/libexec/Plistbuddy -c "Set SUPublicEDKey ${SUPublicEDKey}" "${ContentsDir}/Info.plist"
+/usr/libexec/Plistbuddy -c "Set SUPublicEDKey ${SUPublicEDKey}" "${ContentsDir}/Info.plist" \
+    || exitWithError "Failed to update SUPublicEDKey in ${ContentsDir}/Info.plist"
 
-/usr/libexec/Plistbuddy -c "Set CFBundleVersion ${AppVersion}" "${PluginPath}/Contents/Info.plist"
-/usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString ${AppVersion}" "${PluginPath}/Contents/Info.plist"
-/usr/libexec/Plistbuddy -c "Set CFBundleIdentifier im.pag.exporter" "${PluginPath}/Contents/Info.plist"
+/usr/libexec/Plistbuddy -c "Set CFBundleVersion ${AppVersion}" "${PluginPath}/Contents/Info.plist" \
+    || exitWithError "Failed to update CFBundleVersion in ${PluginPath}/Contents/Info.plist"
+/usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString ${AppVersion}" "${PluginPath}/Contents/Info.plist" \
+    || exitWithError "Failed to update CFBundleShortVersionString in ${PluginPath}/Contents/Info.plist"
+/usr/libexec/Plistbuddy -c "Set CFBundleIdentifier im.pag.exporter" "${PluginPath}/Contents/Info.plist" \
+    || exitWithError "Failed to update CFBundleIdentifier in ${PluginPath}/Contents/Info.plist"
 
 # 3.7 Set rpath
 printStep "Set rpath"

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -109,6 +109,16 @@ function generateUniversalDsym() {
     logInfo "  arm64: ${armDsym}"
 }
 
+function cleanAbsoluteRpaths() {
+    local binary="$1"
+    otool -l "${binary}" | grep -A2 "LC_RPATH" | grep "path " | sed 's/.*path \(.*\) (offset.*/\1/' | while IFS= read -r rpath; do
+        case "${rpath}" in
+            @*|/Library/*) ;;
+            *) install_name_tool -delete_rpath "${rpath}" "${binary}" 2>/dev/null || true ;;
+        esac
+    done
+}
+
 function createDmg()
 {
     local creatDmg="${1}"
@@ -344,18 +354,8 @@ x86_64PluginExePath="${x86_64PluginPath}/Contents/MacOS/PAGExporter"
 arm64PluginExePath="${arm64PluginPath}/Contents/MacOS/PAGExporter"
 
 # Remove absolute build rpaths from each architecture before merging
-otool -l "${x86_64PluginExePath}" | grep -A2 "LC_RPATH" | grep "path " | sed 's/.*path \(.*\) (offset.*/\1/' | while IFS= read -r rpath; do
-    case "${rpath}" in
-        @*|/Library/*) ;;
-        *) install_name_tool -delete_rpath "${rpath}" "${x86_64PluginExePath}" 2>/dev/null || true ;;
-    esac
-done
-otool -l "${arm64PluginExePath}" | grep -A2 "LC_RPATH" | grep "path " | sed 's/.*path \(.*\) (offset.*/\1/' | while IFS= read -r rpath; do
-    case "${rpath}" in
-        @*|/Library/*) ;;
-        *) install_name_tool -delete_rpath "${rpath}" "${arm64PluginExePath}" 2>/dev/null || true ;;
-    esac
-done
+cleanAbsoluteRpaths "${x86_64PluginExePath}"
+cleanAbsoluteRpaths "${arm64PluginExePath}"
 
 cp -fr "${x86_64PluginPath}" "${PluginPath}"
 lipo -create "${x86_64PluginExePath}" "${arm64PluginExePath}" -output "${PluginExePath}"

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -150,6 +150,11 @@ MajorVersion=${MajorVersion:-1}
 MinorVersion=${MinorVersion:-0}
 BuildNumber=${BuildNumber:-0}
 AppVersion=${MajorVersion}.${MinorVersion}.${BuildNumber}
+# Normalize isBetaVersion to a strict lowercase "true" so later string compares are predictable.
+case "${isBetaVersion:-}" in
+    [Tt][Rr][Uu][Ee]|1) IsBetaVersion="true" ;;
+    *)                  IsBetaVersion="false" ;;
+esac
 CurrentTime=$(date +"%Y-%m-%d %H:%M:%S")
 RFCTime=$(date -R)
 SourceDir=$(dirname "$(dirname "$(realpath "$0")")")
@@ -661,7 +666,7 @@ then
         ZipLength=$(stat -f%z "${BuildDir}/${ZipFile}")
 
         URL=$(curl -s https://pag.io/server.html)
-        if [ "${isBetaVersion}" == true ];
+        if [ "${IsBetaVersion}" == true ];
         then
             URL="${URL}beta/"
         fi

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -111,13 +111,13 @@ function generateUniversalDsym() {
 
 function createDmg()
 {
-    local creatDmg=${1}
-    local sourcePath=${2}
-    local dmgPath=${3}
-    local iconPath=${4}
-    local backgroundPath=${5}
+    local creatDmg="${1}"
+    local sourcePath="${2}"
+    local dmgPath="${3}"
+    local iconPath="${4}"
+    local backgroundPath="${5}"
 
-    ${creatDmg} \
+    "${creatDmg}" \
     --volname "PAGViewer" \
     --volicon "${iconPath}" \
     --background "${backgroundPath}" \
@@ -243,11 +243,11 @@ arm64ExePath="${arm64BuildDir}/PAGViewer"
 # Clean previous app bundle to avoid incremental build issues
 rm -rf "${AppDir}"
 
-install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/x64" ${x86_64ExePath} 2>/dev/null || true
-install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/arm64" ${arm64ExePath} 2>/dev/null || true
+install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/x64" "${x86_64ExePath}" 2>/dev/null || true
+install_name_tool -delete_rpath "${SourceDir}/vendor/ffmovie/mac/arm64" "${arm64ExePath}" 2>/dev/null || true
 
-mkdir -p ${ExeDir}
-lipo -create ${x86_64ExePath} ${arm64ExePath} -output ${ExePath}
+mkdir -p "${ExeDir}"
+lipo -create "${x86_64ExePath}" "${arm64ExePath}" -output "${ExePath}"
 
 # 3.1.1 Generate dSYM files for PAGViewer
 printStep "Generate dSYM for PAGViewer"
@@ -255,12 +255,12 @@ generateUniversalDsym "PAGViewer" "${x86_64BuildDir}" "${arm64BuildDir}" "${Buil
 
 # 3.2 Obtain the dependencies of PAGViewer
 printStep "Deploy Qt dependencies"
-${Deployqt} ${AppDir} -qmldir=${SourceDir}/assets/qml
+"${Deployqt}" "${AppDir}" -qmldir="${SourceDir}/assets/qml"
 if [ $? -ne 0 ];
 then
     exitWithError "Deploy Qt dependencies (viewer qml) failed"
 fi
-${Deployqt} ${AppDir} -qmldir=${PluginSourceDir}/assets/qml
+"${Deployqt}" "${AppDir}" -qmldir="${PluginSourceDir}/assets/qml"
 if [ $? -ne 0 ];
 then
     exitWithError "Deploy Qt dependencies (exporter qml) failed"
@@ -270,14 +270,14 @@ fi
 printStep "Copy Sparkle.framework"
 FrameworkDir="${AppDir}/Contents/Frameworks"
 SparklePath="${SourceDir}/vendor/sparkle/mac/Sparkle.framework"
-cp -f -R -P ${SparklePath} ${FrameworkDir}
+cp -f -R -P "${SparklePath}" "${FrameworkDir}"
 
 # 3.2.2 Merge and copy ffmovie
 printStep "Merge ffmovie.dylib"
 x64FfmoviePath="${SourceDir}/vendor/ffmovie/mac/x64/libffmovie.dylib"
 arm64FfmoviePath="${SourceDir}/vendor/ffmovie/mac/arm64/libffmovie.dylib"
 FfmoviePath="${FrameworkDir}/libffmovie.dylib"
-lipo -create ${x64FfmoviePath} ${arm64FfmoviePath} -output ${FfmoviePath}
+lipo -create "${x64FfmoviePath}" "${arm64FfmoviePath}" -output "${FfmoviePath}"
 
 # 3.3 Obtain public and private keys
 printStep "Obtain signing keys"
@@ -321,15 +321,15 @@ fi
 # 3.4 Copy resources
 printStep "Copy resources"
 ContentsDir="${AppDir}/Contents"
-PlistPath=${SourceDir}/package/templates/Info.plist
-cp -f ${PlistPath} ${ContentsDir}
+PlistPath="${SourceDir}/package/templates/Info.plist"
+cp -f "${PlistPath}" "${ContentsDir}"
 
 ResourcesDir="${AppDir}/Contents/Resources"
-cp -f ${SourceDir}/assets/images/appIcon.icns ${ResourcesDir}
-cp -f ${SourceDir}/assets/images/pagIcon.icns ${ResourcesDir}
+cp -f "${SourceDir}/assets/images/appIcon.icns" "${ResourcesDir}"
+cp -f "${SourceDir}/assets/images/pagIcon.icns" "${ResourcesDir}"
 if [ -n "${DSAPublicKey}" ] && [ -f "${DSAPublicKey}" ];
 then
-    cp -f ${DSAPublicKey} ${ResourcesDir}
+    cp -f "${DSAPublicKey}" "${ResourcesDir}"
 fi
 
 # 3.5 Merge PAGExporter and copy related tools
@@ -357,8 +357,8 @@ otool -l "${arm64PluginExePath}" | grep -A2 "LC_RPATH" | grep "path " | sed 's/.
     esac
 done
 
-cp -fr ${x86_64PluginPath} ${PluginPath}
-lipo -create ${x86_64PluginExePath} ${arm64PluginExePath} -output ${PluginExePath}
+cp -fr "${x86_64PluginPath}" "${PluginPath}"
+lipo -create "${x86_64PluginExePath}" "${arm64PluginExePath}" -output "${PluginExePath}"
 
 # 3.5.1.1 Generate dSYM files for PAGExporter
 printStep "Generate dSYM for PAGExporter"
@@ -366,7 +366,7 @@ generateUniversalDsym "PAGExporter" "${x86_64BuildDirForPlugin}" "${arm64BuildDi
 
 # 3.5.2 Obtain the dependencies of PAGExporter
 printStep "Deploy PAGExporter Qt dependencies"
-${Deployqt} ${PluginPath} -qmldir=${PluginSourceDir}/assets/qml
+"${Deployqt}" "${PluginPath}" -qmldir="${PluginSourceDir}/assets/qml"
 if [ $? -ne 0 ];
 then
     exitWithError "Obtain the dependencies of PAGExporter failed"
@@ -392,7 +392,7 @@ rm -rf "${PluginPath}/Contents/Resources/qml"
 # 3.5.3 Copy related tools
 printStep "Copy tools and scripts"
 EncoderToolsPath="${EncoderToolBuildDir}/Release/H264EncoderTools"
-cp -f ${EncoderToolsPath} ${ResourcesDir}
+cp -f "${EncoderToolsPath}" "${ResourcesDir}"
 cp -f "${SourceDir}/qttools/copy_qt_resource.sh" "${ResourcesDir}/"
 cp -f "${SourceDir}/qttools/delete_qt_resource.sh" "${ResourcesDir}/"
 cp -f "${SourceDir}/qttools/replace_qt_path.sh" "${ResourcesDir}/"
@@ -439,14 +439,14 @@ fi
 
 # 3.7 Set rpath
 printStep "Set rpath"
-install_name_tool -delete_rpath "${QtPath}/lib" ${ExePath} 2>/dev/null || true
-install_name_tool -delete_rpath "${SourceDir}/vendor/sparkle/mac" ${ExePath} 2>/dev/null || true
-install_name_tool -add_rpath "@executable_path/../Frameworks" ${ExePath} 2>/dev/null || true
+install_name_tool -delete_rpath "${QtPath}/lib" "${ExePath}" 2>/dev/null || true
+install_name_tool -delete_rpath "${SourceDir}/vendor/sparkle/mac" "${ExePath}" 2>/dev/null || true
+install_name_tool -add_rpath "@executable_path/../Frameworks" "${ExePath}" 2>/dev/null || true
 
-install_name_tool -delete_rpath "${QtPath}/lib" ${PluginExePath} 2>/dev/null || true
-install_name_tool -add_rpath "@executable_path/../Frameworks" ${PluginExePath} 2>/dev/null || true
-install_name_tool -add_rpath "@loader_path/../Frameworks" ${PluginExePath} 2>/dev/null || true
-install_name_tool -add_rpath "/Library/Application Support/PAGExporter/Frameworks" ${PluginExePath} 2>/dev/null || true
+install_name_tool -delete_rpath "${QtPath}/lib" "${PluginExePath}" 2>/dev/null || true
+install_name_tool -add_rpath "@executable_path/../Frameworks" "${PluginExePath}" 2>/dev/null || true
+install_name_tool -add_rpath "@loader_path/../Frameworks" "${PluginExePath}" 2>/dev/null || true
+install_name_tool -add_rpath "/Library/Application Support/PAGExporter/Frameworks" "${PluginExePath}" 2>/dev/null || true
 
 # 4 Sign & Notarize
 printSection 4 "Sign & Notarize"
@@ -622,15 +622,15 @@ then
         SignScript="${SourceDir}/package/sign_update.sh"
         chmod +x "${SignScript}"
 
-        ${SignScript} ${BuildDir}/${ZipFile} ${DSAPrivateKey} > DSASignHash.txt
+        "${SignScript}" "${BuildDir}/${ZipFile}" "${DSAPrivateKey}" > DSASignHash.txt
         ZipDSAHash=$(tr '\n' ' ' < DSASignHash.txt | sed '$s/ //g')
         logInfo "Get Zip DSA Hash: ${ZipDSAHash}"
 
-        ${SignScript} ${BuildDir}/${ZipFile} ${EDDSAPrivateKey} > EDDSASignHash.txt
+        "${SignScript}" "${BuildDir}/${ZipFile}" "${EDDSAPrivateKey}" > EDDSASignHash.txt
         ZipEDDSAHash=$(tr '\n' ' ' < EDDSASignHash.txt | sed '$s/ //g')
         logInfo "Get Zip EDDSA Hash: ${ZipEDDSAHash}"
 
-        ZipLength=$(stat -f%z ${BuildDir}/${ZipFile})
+        ZipLength=$(stat -f%z "${BuildDir}/${ZipFile}")
 
         URL=$(curl -s https://pag.io/server.html)
         if [ "${isBetaVersion}" == true ];

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -391,8 +391,15 @@ then
         libName=$(basename "${existingLib}")
         rm -f "${PluginPath}/Contents/Frameworks/${libName}"
     done
-    # Copy remaining plugin Frameworks into the main app
-    find "${PluginPath}/Contents/Frameworks" -mindepth 1 -maxdepth 1 -exec cp -fRP {} "${AppDir}/Contents/Frameworks/" \;
+    # Copy remaining plugin Frameworks into the main app.
+    # Use process substitution so exitWithError aborts the whole script;
+    # find -exec swallows cp failures and a piped while runs in a subshell.
+    while IFS= read -r -d '' Item; do
+        if ! cp -fRP "${Item}" "${AppDir}/Contents/Frameworks/";
+        then
+            exitWithError "Failed to copy plugin framework item: ${Item}"
+        fi
+    done < <(find "${PluginPath}/Contents/Frameworks" -mindepth 1 -maxdepth 1 -print0)
 fi
 if [ -d "${PluginPath}/Contents/Plugins" ];
 then

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -205,7 +205,6 @@ cmakeBuild "${x86_64BuildDir}" "PAGViewer"
 
 # 2.4 Compile PAGViewer-arm64
 printStep "PAGViewer-arm64"
-arm64BuildDir="${BuildDir}/build_arm64"
 
 cmakeConfigure "${SourceDir}" "${arm64BuildDir}" "PAGViewer-arm64" \
     -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64 \

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -472,11 +472,19 @@ then
     xattr -rc "${AppDir}"
     xattr -rc "${PluginPath}"
 
-    # Sign all dylibs in Frameworks/ directory first
+    # Sign all dylibs in Frameworks/ directory first.
+    # Use process substitution so exitWithError aborts the whole script;
+    # a piped `while` would only exit the subshell.
     logInfo "Signing all libraries in Frameworks/..."
-    find "${FrameworkDir}" -name "*.dylib" -type f | while IFS= read -r dylib; do
-        codesign --force --timestamp --options "runtime" --sign "${SignCertName}" "${dylib}" 2>/dev/null
-    done
+    while IFS= read -r dylib; do
+        SIGN_OUTPUT=$(codesign --force --timestamp --options "runtime" --sign "${SignCertName}" "${dylib}" 2>&1)
+        SIGN_STATUS=$?
+        if [ ${SIGN_STATUS} -ne 0 ];
+        then
+            echo "${SIGN_OUTPUT}"
+            exitWithError "Failed to sign dylib: ${dylib}"
+        fi
+    done < <(find "${FrameworkDir}" -name "*.dylib" -type f)
 
     # Sign standalone executables not inside a bundle
     logInfo "Signing: ${ResourcesDir}/H264EncoderTools"

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -217,9 +217,16 @@ EncoderToolSourceDir="${SourceDir}/third_party/H264EncoderTools"
 EncoderToolBuildDir="${BuildDir}/EncoderTools"
 
 xcodebuild clean -project "${EncoderToolSourceDir}/H264EncoderTools.xcodeproj" -scheme H264EncoderTools -configuration Release -quiet > /dev/null 2>&1
-xcodebuild -project "${EncoderToolSourceDir}/H264EncoderTools.xcodeproj" -scheme H264EncoderTools -configuration Release SYMROOT="${EncoderToolBuildDir}" CODE_SIGN_IDENTITY="" ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_ALLOWED=NO -quiet > /dev/null 2>&1
 if [ $? -ne 0 ];
 then
+    exitWithError "Clean H264EncoderTools failed"
+fi
+
+BUILD_OUTPUT=$(xcodebuild -project "${EncoderToolSourceDir}/H264EncoderTools.xcodeproj" -scheme H264EncoderTools -configuration Release SYMROOT="${EncoderToolBuildDir}" CODE_SIGN_IDENTITY="" ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_ALLOWED=NO -quiet 2>&1)
+BUILD_STATUS=$?
+if [ ${BUILD_STATUS} -ne 0 ];
+then
+    echo "${BUILD_OUTPUT}"
     exitWithError "Build H264EncoderTools failed"
 fi
 

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -676,7 +676,6 @@ for vol in /Volumes/PAGViewer*; do
         hdiutil detach "$vol" -force 2>/dev/null || true
     fi
 done
-sleep 1
 
 if [ -d "${BuildDir}/dmg_content" ];
 then

--- a/viewer/package/build_mac.sh
+++ b/viewer/package/build_mac.sh
@@ -405,7 +405,6 @@ EOF
 
 # 3.6 Update plist
 printStep "Update plist"
-DSAPublicKeyName=$(basename "${DSAPublicKey}")
 SUPublicEDKey=""
 if [ -n "${EDDSAPublicKey}" ] && [ -f "${EDDSAPublicKey}" ];
 then
@@ -413,7 +412,11 @@ then
 fi
 /usr/libexec/Plistbuddy -c "Set CFBundleVersion ${AppVersion}" "${ContentsDir}/Info.plist"
 /usr/libexec/Plistbuddy -c "Set CFBundleShortVersionString ${AppVersion}" "${ContentsDir}/Info.plist"
-/usr/libexec/Plistbuddy -c "Set SUPublicDSAKeyFile ${DSAPublicKeyName}" "${ContentsDir}/Info.plist"
+if [ -n "${DSAPublicKey}" ];
+then
+    DSAPublicKeyName=$(basename "${DSAPublicKey}")
+    /usr/libexec/Plistbuddy -c "Set SUPublicDSAKeyFile ${DSAPublicKeyName}" "${ContentsDir}/Info.plist"
+fi
 /usr/libexec/Plistbuddy -c "Set SUPublicEDKey ${SUPublicEDKey}" "${ContentsDir}/Info.plist"
 
 /usr/libexec/Plistbuddy -c "Set CFBundleVersion ${AppVersion}" "${PluginPath}/Contents/Info.plist"

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -280,7 +280,7 @@ if ([string]::IsNullOrEmpty($DSAPrivateKey) -eq $false) {
     Print-Step "Sign installer"
     $SignScript = Join-Path $SourceDir "package\sign_update.bat"
     $Base64Code = cmd /c $SignScript $OpenSSL $PAGViewerInstallerPath $DSAPrivateKey
-    if (-not $?) { Exit-WithError "Signing installer failed" }
+    if ($LASTEXITCODE -ne 0) { Exit-WithError "Signing installer failed" }
     Log-Success "Installer signed"
 
     Print-Step "Update Appcast"

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -86,7 +86,7 @@ $RFCTime = Get-Date -Format "r"
 $SourceDir = Split-Path $PSScriptRoot -Parent
 $LibpagDir = Split-Path $SourceDir -Parent
 $BuildDir = Join-Path $SourceDir "build_viewer"
-$IsBetaVersion = if ($env:isBetaVersion) { $env:isBetaVersion } else { $false }
+$IsBetaVersion = if ($env:isBetaVersion -eq "true") { $true } else { $false }
 
 Log-Info "Build Time: $CurrentTime"
 Log-Info "Version: $AppVersion"

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -143,8 +143,12 @@ Print-Step "H264EncoderTools"
 $EncoderToolsSourceDir = Join-Path $SourceDir "third_party\H264EncoderTools"
 $EncoderToolsSlnPath = Join-Path $EncoderToolsSourceDir "H264EncoderTools.sln"
 $EncoderToolsVcxprojPath = Join-Path $EncoderToolsSourceDir "H264EncoderTools.vcxproj"
-(Get-Content "$EncoderToolsVcxprojPath" -Raw) -replace "<PlatformToolset>v142</PlatformToolset>", "<PlatformToolset>$LatestMSVCToolSet</PlatformToolset>" | Set-Content "$EncoderToolsVcxprojPath"
-if (-not $?) { Exit-WithError "Failed to update H264EncoderTools toolset" }
+(Get-Content $EncoderToolsVcxprojPath -Raw) -replace '<PlatformToolset>v14\d</PlatformToolset>', "<PlatformToolset>$LatestMSVCToolSet</PlatformToolset>" | Set-Content $EncoderToolsVcxprojPath
+# Verify the substitution actually took effect; the regex above only matches v14x toolsets
+$ToolsetCheck = Get-Content $EncoderToolsVcxprojPath -Raw
+if ($ToolsetCheck -notmatch "<PlatformToolset>$([regex]::Escape($LatestMSVCToolSet))</PlatformToolset>") {
+    Exit-WithError "Failed to set PlatformToolset to $LatestMSVCToolSet in vcxproj"
+}
 
 $process = Start-Process -FilePath $VSDevEnv -ArgumentList "`"$EncoderToolsSlnPath`" /Rebuild `"Release|x64`"" -Wait -PassThru
 if ($process.ExitCode -ne 0) { Exit-WithError "Build H264EncoderTools failed" }

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -251,7 +251,9 @@ if (-not (Test-Path $ISCCPath)) {
     $Installer = "$env:TEMP\innosetup.exe"
     Invoke-WebRequest -Uri "https://www.jrsoftware.org/download.php/is.exe" -OutFile $Installer
     Start-Process -Wait -FilePath $Installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=$InnoSetupDir"
-    if (-not $?) { Exit-WithError "Install InnoSetup failed" }
+    $InstallStatus = $?
+    Remove-Item -Path $Installer -Force -ErrorAction SilentlyContinue
+    if (-not $InstallStatus) { Exit-WithError "Install InnoSetup failed" }
     $UninstallInnoSetup = $true
     Log-Success "InnoSetup installed"
 } else {

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -55,6 +55,21 @@ function Exit-WithError {
     exit 1
 }
 
+function Invoke-CMakeBuild {
+    param(
+        [string]$SourceDir,
+        [string]$BuildDir,
+        [string]$Target,
+        [string[]]$ConfigureArgs,
+        [int]$Jobs = 16
+    )
+    & cmake -S $SourceDir -B $BuildDir @ConfigureArgs
+    if ($LASTEXITCODE -ne 0) { Exit-WithError "CMake configure $Target failed" }
+
+    & cmake --build $BuildDir --config Release -j $Jobs
+    if ($LASTEXITCODE -ne 0) { Exit-WithError "CMake build $Target failed" }
+}
+
 # ═══════════════════════════════════════════════════════════
 # 1 Initialize variables
 # ═══════════════════════════════════════════════════════════
@@ -127,19 +142,13 @@ Print-Step "PAGExporter"
 $PluginSourceDir = Join-Path $LibpagDir "exporter"
 $x64BuildDirForPlugin = Join-Path $x64BuildDir "Plugin"
 
-cmake -S $PluginSourceDir -B $x64BuildDirForPlugin -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$QtCMakePath" -DAE_SDK_PATH="$AESDKPath"
-if (-not $?) { Exit-WithError "CMake configure PAGExporter failed" }
-
-cmake --build $x64BuildDirForPlugin --config Release -j 16
-if (-not $?) { Exit-WithError "CMake build PAGExporter failed" }
+Invoke-CMakeBuild -SourceDir $PluginSourceDir -BuildDir $x64BuildDirForPlugin -Target "PAGExporter" `
+    -ConfigureArgs @("-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_PREFIX_PATH=$QtCMakePath", "-DAE_SDK_PATH=$AESDKPath")
 
 # 2.3 Compile PAGViewer
 Print-Step "PAGViewer"
-cmake -S $SourceDir -B $x64BuildDir -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$QtCMakePath" -DPAG_PATH="${PAGPath}" -DPAG_OPTIONS="${PAGOptions}"
-if (-not $?) { Exit-WithError "CMake configure PAGViewer failed" }
-
-cmake --build $x64BuildDir --config Release -j 16
-if (-not $?) { Exit-WithError "CMake build PAGViewer failed" }
+Invoke-CMakeBuild -SourceDir $SourceDir -BuildDir $x64BuildDir -Target "PAGViewer" `
+    -ConfigureArgs @("-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_PREFIX_PATH=$QtCMakePath", "-DPAG_PATH=$PAGPath", "-DPAG_OPTIONS=$PAGOptions")
 
 # 2.4 Compile H264EncoderTools
 Print-Step "H264EncoderTools"

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -259,10 +259,11 @@ if (-not (Test-Path $ISCCPath)) {
     Log-Info "InnoSetup not found, installing..."
     $Installer = "$env:TEMP\innosetup.exe"
     Invoke-WebRequest -Uri "https://www.jrsoftware.org/download.php/is.exe" -OutFile $Installer
-    Start-Process -Wait -FilePath $Installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=$InnoSetupDir"
-    $InstallStatus = $?
+    $InstallProcess = Start-Process -PassThru -Wait -FilePath $Installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=$InnoSetupDir"
     Remove-Item -Path $Installer -Force -ErrorAction SilentlyContinue
-    if (-not $InstallStatus) { Exit-WithError "Install InnoSetup failed" }
+    if ($InstallProcess.ExitCode -ne 0) { Exit-WithError "Install InnoSetup failed" }
+    # Guard against installers that report success but land outside $InnoSetupDir.
+    if (-not (Test-Path $ISCCPath)) { Exit-WithError "InnoSetup binary missing at $ISCCPath after install" }
     $UninstallInnoSetup = $true
     Log-Success "InnoSetup installed"
 } else {

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -9,37 +9,57 @@ $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 $PSDefaultParameterValues['Export-Csv:Encoding'] = 'utf8'
 $PSDefaultParameterValues['Set-Content:Encoding'] = 'utf8'
 
-function Fix-ConsoleEncoding {
-    if ($Host.Name -eq 'ConsoleHost') {
-        $console = [Console]::OutputEncoding
-        [Console]::OutputEncoding = [System.Text.Encoding]::GetEncoding(936)
-        [Console]::OutputEncoding = $console
-    }
-}
-Fix-ConsoleEncoding
+# ═══════════════════════════════════════════════════════════
+# Logging functions
+# ═══════════════════════════════════════════════════════════
+$TOTAL_SECTIONS = 6
+$SECTION_WIDTH = 60
 
-function Print-Text {
-    param (
-        [string]$text,
-        [int]$width = 40
-    )
-    
-    $text = [System.Text.Encoding]::UTF8.GetString(
-        [System.Text.Encoding]::GetEncoding(936).GetBytes($text)
-    )
-    
-    $textLength = $text.Length
-    $paddingLength = [math]::Max(0, [math]::Floor(($width - $textLength) / 2))
-    $padding = '=' * $paddingLength
-    
-    [Console]::ForegroundColor = [ConsoleColor]::Green
-    [Console]::WriteLine("${padding}${text}${padding}")
-    [Console]::ResetColor()
+function Print-Section {
+    param([int]$Index, [string]$Title)
+    $line = [string]::new([char]0x2550, $SECTION_WIDTH)
+    Write-Host ""
+    Write-Host $line -ForegroundColor Blue
+    Write-Host "  $([char]0x25B6) [$Index/$TOTAL_SECTIONS] $Title" -ForegroundColor Blue
+    Write-Host $line -ForegroundColor Blue
 }
 
+function Print-Step {
+    param([string]$Text)
+    Write-Host "  $([char]0x2192) $Text" -ForegroundColor Blue
+}
 
+function Log-Info {
+    param([string]$Text)
+    Write-Host "    [INFO] $Text" -ForegroundColor Blue
+}
+
+function Log-Success {
+    param([string]$Text)
+    Write-Host "    [OK] $Text" -ForegroundColor Green
+}
+
+function Log-Warning {
+    param([string]$Text)
+    Write-Host "    [WARN] $Text" -ForegroundColor Yellow
+}
+
+function Log-Error {
+    param([string]$Text)
+    Write-Host "    [ERROR] $Text" -ForegroundColor Red
+}
+
+function Exit-WithError {
+    param([string]$Text)
+    Log-Error $Text
+    exit 1
+}
+
+# ═══════════════════════════════════════════════════════════
 # 1 Initialize variables
-Print-Text "[ Initialize variables ]"
+# ═══════════════════════════════════════════════════════════
+$BuildStartTime = Get-Date
+Print-Section 1 "Initialize variables"
 
 $majorVersion = if ($env:MajorVersion) { $env:MajorVersion } else { "1" }
 $minorVersion = if ($env:MinorVersion) { $env:MinorVersion } else { "0" }
@@ -51,256 +71,219 @@ $RFCTime = Get-Date -Format "r"
 $SourceDir = Split-Path $PSScriptRoot -Parent
 $LibpagDir = Split-Path $SourceDir -Parent
 $BuildDir = Join-Path $SourceDir "build_viewer"
-$IsBetaVersion = if ($env:isBetaVersion) { $env:isBetaVersion } else { false }
+$IsBetaVersion = if ($env:isBetaVersion) { $env:isBetaVersion } else { $false }
 
-Write-Host "Build Time: $CurrentTime"
+Log-Info "Build Time: $CurrentTime"
+Log-Info "Version: $AppVersion"
 
 if ([string]::IsNullOrEmpty($env:PAG_DeployQt_Path) -or [string]::IsNullOrEmpty($env:PAG_Qt_Path) -or [string]::IsNullOrEmpty($env:PAG_AE_SDK_Path) -or [string]::IsNullOrEmpty($env:PAG_Openssl_Path)) {
-    Write-Host "Please set [PAG_DeployQt_Path], [PAG_Qt_Path], [PAG_AE_SDK_Path] and [PAG_Openssl_Path] before build on Windows" -ForegroundColor Red
-    exit 1
+    Exit-WithError "Please set [PAG_DeployQt_Path], [PAG_Qt_Path], [PAG_AE_SDK_Path] and [PAG_Openssl_Path] before build on Windows"
 }
 
 $Deployqt = $env:PAG_DeployQt_Path
 $OpenSSL = $env:PAG_Openssl_Path
 $QtPath = $env:PAG_Qt_Path
-$QtCMakePath = Join-Path $QtPath -ChildPath "lib" |
-               Join-Path -ChildPath "cmake"
+$QtCMakePath = Join-Path $QtPath "lib" | Join-Path -ChildPath "cmake"
 $AESDKPath = $env:PAG_AE_SDK_Path
 
+# ═══════════════════════════════════════════════════════════
 # 2 Compile
-Print-Text "[ Compile ]"
+# ═══════════════════════════════════════════════════════════
+Print-Section 2 "Compile"
 $x64BuildDir = Join-Path $BuildDir "x64"
 
 # 2.1 Set environment variables
-Print-Text "[ Set environment variables ]"
+Print-Step "Detect MSVC toolset"
 $VSPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-$VSDevEnv = Join-Path $VSPath -ChildPath "Common7" |
-            Join-Path -ChildPath "IDE" |
-            Join-Path -ChildPath "devenv.exe"
+$VSDevEnv = Join-Path $VSPath "Common7\IDE\devenv.exe"
 $MSVCToolsDir = Join-Path $VSPath 'VC\Tools\MSVC'
 $MSVCVersions = Get-ChildItem $MSVCToolsDir -Directory | Select-Object -ExpandProperty Name
 $MSVCToolSets = @()
-foreach($v in $MSVCVersions) {
-    if($v -match "^14\.(\d+)\.") {
+foreach ($v in $MSVCVersions) {
+    if ($v -match "^14\.(\d+)\.") {
         $MajorMinor = [int]$Matches[1]
-        if($MajorMinor -ge 30) { $MSVCToolSets += "v143" }
-        elseif($MajorMinor -ge 20) { $MSVCToolSets += "v142" }
-        elseif($MajorMinor -ge 10) { $MSVCToolSets += "v141" }
+        if ($MajorMinor -ge 30) { $MSVCToolSets += "v143" }
+        elseif ($MajorMinor -ge 20) { $MSVCToolSets += "v142" }
+        elseif ($MajorMinor -ge 10) { $MSVCToolSets += "v141" }
     }
 }
 $MSVCToolSets = $MSVCToolSets | Sort-Object -Unique -Descending
 if ($MSVCToolSets.Count -eq 0) {
-    Write-Host "No avaliable MSVC toolset found" -ForegroundColor Red
-    exit 1
+    Exit-WithError "No available MSVC toolset found"
 }
 $LatestMSVCToolSet = $MSVCToolSets | Select-Object -First 1
+Log-Info "Using MSVC toolset: $LatestMSVCToolSet"
+
 $WindowsSdkDir = [System.IO.Path]::Combine(${env:ProgramFiles(x86)}, "Windows Kits", "10")
 $LatestSdkVersion = (Get-ChildItem (Join-Path $WindowsSdkDir "Lib") | Sort-Object Name -Descending | Select-Object -First 1).Name
 $env:LIB = "${WindowsSdkDir}\Lib\${LatestSdkVersion}\um\x64;${WindowsSdkDir}\Lib\${LatestSdkVersion}\ucrt\x64;" + $env:LIB
+Log-Info "Windows SDK: $LatestSdkVersion"
 
 # 2.2 Compile PAGExporter
-Print-Text "[ Compile PAGExporter ]"
-$PluginSourceDir = Join-Path $LibpagDir -ChildPath "exporter"
-$x64BuildDirForPlugin = Join-Path $x64BuildDir -ChildPath "Plugin"
+Print-Step "PAGExporter"
+$PluginSourceDir = Join-Path $LibpagDir "exporter"
+$x64BuildDirForPlugin = Join-Path $x64BuildDir "Plugin"
+
 cmake -S $PluginSourceDir -B $x64BuildDirForPlugin -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$QtCMakePath" -DAE_SDK_PATH="$AESDKPath"
-if (-not $?) {
-    Write-Host "Build PAGExporter-x64 failed" -ForegroundColor Red
-    exit 1
-}
+if (-not $?) { Exit-WithError "CMake configure PAGExporter failed" }
 
 cmake --build $x64BuildDirForPlugin --config Release -j 16
-if (-not $?) {
-    Write-Host "Compile PAGExporter-x64 failed" -ForegroundColor Red
-    exit 1
-}
+if (-not $?) { Exit-WithError "CMake build PAGExporter failed" }
 
 # 2.3 Compile PAGViewer
-Print-Text "[ Compile PAGViewer ]"
+Print-Step "PAGViewer"
 cmake -S $SourceDir -B $x64BuildDir -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$QtCMakePath" -DPAG_PATH="${PAGPath}" -DPAG_OPTIONS="${PAGOptions}"
-if (-not $?) {
-    Write-Host "Build PAGViewer-x64 failed" -ForegroundColor Red
-    exit 1
-}
+if (-not $?) { Exit-WithError "CMake configure PAGViewer failed" }
 
 cmake --build $x64BuildDir --config Release -j 16
-if (-not $?) {
-    Write-Host "Compile PAGViewer-x64 failed" -ForegroundColor Red
-    exit 1
-}
+if (-not $?) { Exit-WithError "CMake build PAGViewer failed" }
 
 # 2.4 Compile H264EncoderTools
-Print-Text "[ Compile H264EncoderTools ]"
-$EncoderToolsSourceDir = Join-Path $SourceDir -ChildPath "third_party" |
-        Join-Path -ChildPath "H264EncoderTools"
-$EncoderToolsSlnPath = Join-Path $EncoderToolsSourceDir -ChildPath "H264EncoderTools.sln"
-$EncoderToolsVcxprojPath = Join-Path $EncoderToolsSourceDir -ChildPath "H264EncoderTools.vcxproj"
+Print-Step "H264EncoderTools"
+$EncoderToolsSourceDir = Join-Path $SourceDir "third_party\H264EncoderTools"
+$EncoderToolsSlnPath = Join-Path $EncoderToolsSourceDir "H264EncoderTools.sln"
+$EncoderToolsVcxprojPath = Join-Path $EncoderToolsSourceDir "H264EncoderTools.vcxproj"
 (Get-Content "$EncoderToolsVcxprojPath" -Raw) -replace "<PlatformToolset>v142</PlatformToolset>", "<PlatformToolset>$LatestMSVCToolSet</PlatformToolset>" | Set-Content "$EncoderToolsVcxprojPath"
-if (-not $?) {
-    Write-Host "Build H264EncoderTools-x64 failed" -ForegroundColor Red
-    exit 1
-}
-$process = Start-Process -FilePath $VSDevEnv -ArgumentList "`"$EncoderToolsSlnPath`" /Rebuild `"Release|x64`"" -Wait -PassThru
-if ($process.ExitCode -ne 0) {
-    Write-Host "Build H264EncoderTools-x64 failed" -ForegroundColor Red
-    exit 1
-}
+if (-not $?) { Exit-WithError "Failed to update H264EncoderTools toolset" }
 
+$process = Start-Process -FilePath $VSDevEnv -ArgumentList "`"$EncoderToolsSlnPath`" /Rebuild `"Release|x64`"" -Wait -PassThru
+if ($process.ExitCode -ne 0) { Exit-WithError "Build H264EncoderTools failed" }
+
+# ═══════════════════════════════════════════════════════════
 # 3 Organize resources
-Print-Text "[ Organize resources ]"
+# ═══════════════════════════════════════════════════════════
+Print-Section 3 "Organize resources"
+
 # 3.1 Copy files
-Print-Text "[ Copy files ]"
-$TemplatePackageDir = Join-Path $SourceDir -ChildPath "package" | 
-                      Join-Path -ChildPath "templates" | 
-                      Join-Path -ChildPath "windows-packages"
-New-Item -ItemType Directory -Path "$TemplatePackageDir\data\scripts" -Force
-New-Item -ItemType Directory -Path "$TemplatePackageDir\meta" -Force
+Print-Step "Copy application files"
+$TemplatePackageDir = Join-Path $SourceDir "package\templates\windows-packages"
+New-Item -ItemType Directory -Path "$TemplatePackageDir\data\scripts" -Force | Out-Null
+New-Item -ItemType Directory -Path "$TemplatePackageDir\meta" -Force | Out-Null
 $PackageDir = Join-Path $BuildDir "com.tencent.pagplayer"
+
+# Clean previous package to avoid incremental build issues
+if (Test-Path $PackageDir) { Remove-Item -Path $PackageDir -Recurse -Force }
 Copy-Item -Path $TemplatePackageDir -Destination $PackageDir -Recurse -Force
 
-$GeneratedExePath = Join-Path $x64BuildDir "Release" | 
-                    Join-Path -ChildPath "PAGViewer.exe"
+$GeneratedExePath = Join-Path $x64BuildDir "Release\PAGViewer.exe"
 $ExeDir = Join-Path $PackageDir "data"
 $ExePath = Join-Path $ExeDir "PAGViewer.exe"
 Copy-Item -Path $GeneratedExePath -Destination $ExePath -Force
 
 # 3.2 Copy PAGExporter and tools
-Print-Text "[ Copy PAGExporter and tools ]"
-$GeneratedPluginPath = Join-Path $x64BuildDirForPlugin -ChildPath "Release" |
-                       Join-Path -ChildPath "PAGExporter.aex"
+Print-Step "Copy PAGExporter and tools"
+$GeneratedPluginPath = Join-Path $x64BuildDirForPlugin "Release\PAGExporter.aex"
 Copy-Item -Path $GeneratedPluginPath -Destination $ExeDir -Force
 
-$GeneratedEncorderToolsPath = Join-Path $EncoderToolsSourceDir -ChildPath "x64" |
-                              Join-Path -ChildPath "Release" |
-                              Join-Path -ChildPath "H264EncoderTools.exe"
-if (-not (Test-Path $GeneratedEncorderToolsPath)) {
-    Write-Host "H264EncoderTools.exe not found at $GeneratedEncorderToolsPath" -ForegroundColor Red
-    exit 1
+$GeneratedEncoderToolsPath = Join-Path $EncoderToolsSourceDir "x64\Release\H264EncoderTools.exe"
+if (-not (Test-Path $GeneratedEncoderToolsPath)) {
+    Exit-WithError "H264EncoderTools.exe not found at $GeneratedEncoderToolsPath"
 }
-Copy-Item -Path $GeneratedEncorderToolsPath -Destination $ExeDir -Force
+Copy-Item -Path $GeneratedEncoderToolsPath -Destination $ExeDir -Force
 
 # 3.3 Copy symbol files
-Print-Text "[ Copy symbol files ]"
-$PAGViewerPdbPath = Join-Path $x64BuildDir "Release" |
-                    Join-Path -ChildPath "PAGViewer.pdb"
+Print-Step "Copy symbol files"
+$PAGViewerPdbPath = Join-Path $x64BuildDir "Release\PAGViewer.pdb"
 Copy-Item -Path $PAGViewerPdbPath -Destination $BuildDir -Force
 
-$PAGExporterPdbPath = Join-Path $x64BuildDirForPlugin "Release" |
-                      Join-Path -ChildPath "PAGExporter.pdb"
+$PAGExporterPdbPath = Join-Path $x64BuildDirForPlugin "Release\PAGExporter.pdb"
 Copy-Item -Path $PAGExporterPdbPath -Destination $BuildDir -Force
 
-# 3.4 Obtain the dependencies of PAGViewer
-Print-Text "[ Obtain the dependencies of PAGViewer ]"
-$QmlDir = Join-Path $SourceDir "assets" |
-          Join-Path -ChildPath "qml"
+# 3.4 Deploy Qt dependencies
+Print-Step "Deploy Qt dependencies"
+$QmlDir = Join-Path $SourceDir "assets\qml"
 & $Deployqt $ExePath --qmldir=$QmlDir
+if (-not $?) { Exit-WithError "Deploy Qt dependencies failed" }
 
-$WinSparklePath = Join-Path $SourceDir "vendor" | 
-                  Join-Path -ChildPath "winsparkle" | 
-                  Join-Path -ChildPath "win" |
-                  Join-Path -ChildPath "x64" | 
-                  Join-Path -ChildPath "Release" | 
-                  Join-Path -ChildPath "WinSparkle.dll"
+# 3.5 Copy vendor libraries
+Print-Step "Copy vendor libraries"
+$WinSparklePath = Join-Path $SourceDir "vendor\winsparkle\win\x64\Release\WinSparkle.dll"
 Copy-Item -Path $WinSparklePath -Destination $ExeDir -Force
 
-$FfmoviePath = Join-Path $SourceDir "vendor" |
-               Join-Path -ChildPath "ffmovie" |
-               Join-Path -ChildPath "win" |
-               Join-Path -ChildPath "x64" |
-               Join-Path -ChildPath "ffmovie.dll"
+$FfmoviePath = Join-Path $SourceDir "vendor\ffmovie\win\x64\ffmovie.dll"
 Copy-Item -Path $FfmoviePath -Destination $ExeDir -Force
 
-# 3.5 Copy VC++ Runtime DLLs
-Print-Text "[ Copy VC++ Runtime DLLs ]"
+# 3.6 Copy VC++ Runtime DLLs
+Print-Step "Copy VC++ Runtime DLLs"
 $VCRedistDir = Join-Path $VSPath "VC\Redist\MSVC"
 if (-not (Test-Path $VCRedistDir)) {
-    Write-Host "VC++ Redist directory not found: $VCRedistDir" -ForegroundColor Red
-    exit 1
+    Exit-WithError "VC++ Redist directory not found: $VCRedistDir"
 }
 $LatestRedistVersion = (Get-ChildItem $VCRedistDir -Directory | Where-Object { $_.Name -match "^\d+\." } | Sort-Object Name -Descending | Select-Object -First 1).Name
-$VCRuntimeDir = Join-Path $VCRedistDir $LatestRedistVersion | Join-Path -ChildPath "x64" | Join-Path -ChildPath "Microsoft.VC143.CRT"
+$VCRuntimeDir = Join-Path $VCRedistDir "$LatestRedistVersion\x64\Microsoft.VC143.CRT"
 if (-not (Test-Path $VCRuntimeDir)) {
-    # Fallback to VC142 if VC143 not found
-    $VCRuntimeDir = Join-Path $VCRedistDir $LatestRedistVersion | Join-Path -ChildPath "x64" | Join-Path -ChildPath "Microsoft.VC142.CRT"
+    $VCRuntimeDir = Join-Path $VCRedistDir "$LatestRedistVersion\x64\Microsoft.VC142.CRT"
 }
 if (-not (Test-Path $VCRuntimeDir)) {
-    Write-Host "VC++ Runtime directory not found: $VCRuntimeDir" -ForegroundColor Red
-    exit 1
+    Exit-WithError "VC++ Runtime directory not found"
 }
-Write-Host "VC++ Runtime directory: $VCRuntimeDir"
+Log-Info "VC++ Runtime: $VCRuntimeDir"
 
-$VCRuntimeDlls = @(
-    "msvcp140.dll",
-    "msvcp140_1.dll",
-    "msvcp140_2.dll",
-    "vcruntime140.dll",
-    "vcruntime140_1.dll"
-)
+$VCRuntimeDlls = @("msvcp140.dll", "msvcp140_1.dll", "msvcp140_2.dll", "vcruntime140.dll", "vcruntime140_1.dll")
 foreach ($dll in $VCRuntimeDlls) {
     $DllPath = Join-Path $VCRuntimeDir $dll
     if (-not (Test-Path $DllPath)) {
-        Write-Host "VC++ Runtime DLL not found: $DllPath" -ForegroundColor Red
-        exit 1
+        Exit-WithError "VC++ Runtime DLL not found: $DllPath"
     }
     Copy-Item -Path $DllPath -Destination $ExeDir -Force
-    Write-Host "Copied $dll"
 }
+Log-Success "VC++ Runtime DLLs copied"
 
-# 3.6 Install InnoSetup
-Print-Text "[ Install InnoSetup ]"
+# ═══════════════════════════════════════════════════════════
+# 4 Generate Installer
+# ═══════════════════════════════════════════════════════════
+Print-Section 4 "Generate Installer"
+
+# 4.1 Install InnoSetup if needed
+Print-Step "Check InnoSetup"
 $UninstallInnoSetup = $false
-$InnoSetupDir = Join-Path $SourceDir "tools" | 
-                Join-Path -ChildPath "InnoSetup"
+$InnoSetupDir = Join-Path $SourceDir "tools\InnoSetup"
 $ISCCPath = Join-Path $InnoSetupDir "ISCC.exe"
 if (-not (Test-Path $ISCCPath)) {
+    Log-Info "InnoSetup not found, installing..."
     $Installer = "$env:TEMP\innosetup.exe"
     Invoke-WebRequest -Uri "https://www.jrsoftware.org/download.php/is.exe" -OutFile $Installer
     Start-Process -Wait -FilePath $Installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=$InnoSetupDir"
-    if (-not $?) {
-        Write-Host "Install InnoSetup failed" -ForegroundColor Red
-        exit 1
-    }
+    if (-not $?) { Exit-WithError "Install InnoSetup failed" }
     $UninstallInnoSetup = $true
+    Log-Success "InnoSetup installed"
+} else {
+    Log-Info "InnoSetup found at $ISCCPath"
 }
 
-
-# 4 Generate Installer
-Print-Text "[ Generate Installer ]"
-$TemplateIssPath = Join-Path $SourceDir "package" | 
-                   Join-Path -ChildPath "templates" | 
-                   Join-Path -ChildPath "windows-setup.iss"
+# 4.2 Generate installer
+Print-Step "Build installer"
+$TemplateIssPath = Join-Path $SourceDir "package\templates\windows-setup.iss"
 $IssPath = Join-Path $BuildDir "PAGViewer.iss"
 Copy-Item -Path $TemplateIssPath -Destination $IssPath -Force
 
-$TemplateIslPath = Join-Path $SourceDir "package" |
-                   Join-Path -ChildPath "templates" | 
-                   Join-Path -ChildPath "windows-ChineseSimplified.isl"
+$TemplateIslPath = Join-Path $SourceDir "package\templates\windows-ChineseSimplified.isl"
 $IslPath = Join-Path $BuildDir "ChineseSimplified.isl"
 Copy-Item -Path $TemplateIslPath -Destination $IslPath -Force
 
 (Get-Content $IssPath -Raw -Encoding UTF8) -replace "~PAGViewerVersion~", $AppVersion | Set-Content $IssPath -Encoding UTF8
 & $ISCCPath $IssPath
+if (-not $?) { Exit-WithError "InnoSetup compilation failed" }
 
 $PAGViewerInstallerPath = Join-Path $BuildDir "PAGViewer_Installer.exe"
 if (-not (Test-Path $PAGViewerInstallerPath)) {
-    Write-Host "Generate PAGViewer installer failed" -ForegroundColor Red
-    exit 1
+    Exit-WithError "Installer not found at $PAGViewerInstallerPath"
 }
+Log-Success "Installer created: $PAGViewerInstallerPath"
 
-# 5 Sign
-Print-Text "[ Sign PAGViewer ]"
+# ═══════════════════════════════════════════════════════════
+# 5 Sign & Update Appcast
+# ═══════════════════════════════════════════════════════════
+Print-Section 5 "Sign & Update Appcast"
 
-# 5.1 Obtain private key
-Print-Text "[ Obtain private key ]"
 if ([string]::IsNullOrEmpty($DSAPrivateKey) -eq $false) {
-    # 5.2 Sign
-    Print-Text "[ Sign PAGViewer ]"
-    $SignScript = Join-Path $SourceDir "package" |
-            Join-Path -ChildPath "sign_update.bat"
-
+    Print-Step "Sign installer"
+    $SignScript = Join-Path $SourceDir "package\sign_update.bat"
     $Base64Code = cmd /c $SignScript $OpenSSL $PAGViewerInstallerPath $DSAPrivateKey
+    if (-not $?) { Exit-WithError "Signing installer failed" }
+    Log-Success "Installer signed"
 
-    # 5.3 Update Appcast
-    Print-Text "[ Update Appcast ]"
+    Print-Step "Update Appcast"
     $URL = (Invoke-WebRequest -Uri "https://pag.io/server.html" -UseBasicParsing).Content
     if ($IsBetaVersion -eq $true) {
         $URL = $URL + "beta/"
@@ -309,22 +292,51 @@ if ([string]::IsNullOrEmpty($DSAPrivateKey) -eq $false) {
 
     $FileLength = (Get-Item $PAGViewerInstallerPath).Length
 
-    $TemplateAppcastPath = Join-Path $SourceDir "package" |
-                           Join-Path -ChildPath "templates" |
-                           Join-Path -ChildPath "PagAppcastWindows.xml"
+    $TemplateAppcastPath = Join-Path $SourceDir "package\templates\PagAppcastWindows.xml"
     $AppcastPath = Join-Path $BuildDir "PagAppcastWindows.xml"
     Copy-Item -Path $TemplateAppcastPath -Destination $AppcastPath -Force
 
-    (Get-Content $AppcastPath -Raw -Encoding UTF8) -replace "~url~", $URL | Set-Content $AppcastPath -Encoding UTF8
-    (Get-Content $AppcastPath -Raw -Encoding UTF8) -replace "~date~", $RFCTime | Set-Content $AppcastPath -Encoding UTF8
-    (Get-Content $AppcastPath -Raw -Encoding UTF8) -replace "~sha1~", $Base64Code | Set-Content $AppcastPath -Encoding UTF8
-    (Get-Content $AppcastPath -Raw -Encoding UTF8) -replace "~length~", $FileLength | Set-Content $AppcastPath -Encoding UTF8
-    (Get-Content $AppcastPath -Raw -Encoding UTF8) -replace "~version~", $AppVersion | Set-Content $AppcastPath -Encoding UTF8
+    $AppcastContent = Get-Content $AppcastPath -Raw -Encoding UTF8
+    $AppcastContent = $AppcastContent -replace "~url~", $URL
+    $AppcastContent = $AppcastContent -replace "~date~", $RFCTime
+    $AppcastContent = $AppcastContent -replace "~sha1~", $Base64Code
+    $AppcastContent = $AppcastContent -replace "~length~", $FileLength
+    $AppcastContent = $AppcastContent -replace "~version~", $AppVersion
+    Set-Content $AppcastPath -Value $AppcastContent -Encoding UTF8
+    Log-Success "Appcast updated"
+} else {
+    Log-Warning "No DSA private key provided, skipping signing and Appcast update."
 }
 
+# ═══════════════════════════════════════════════════════════
+# 6 Cleanup
+# ═══════════════════════════════════════════════════════════
+Print-Section 6 "Cleanup"
 
-# 6 Uninstall InnoSetup
 if ($UninstallInnoSetup -eq $true) {
-    Print-Text "[ Uninstall InnoSetup ]"
+    Print-Step "Uninstall InnoSetup"
     Start-Process -Wait -FilePath "$InnoSetupDir\unins000.exe" -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
+    Log-Success "InnoSetup uninstalled"
 }
+
+# ═══════════════════════════════════════════════════════════
+# Summary
+# ═══════════════════════════════════════════════════════════
+$BuildEndTime = Get-Date
+$BuildDuration = $BuildEndTime - $BuildStartTime
+$InstallerSize = ""
+if (Test-Path $PAGViewerInstallerPath) {
+    $InstallerSize = "{0:N1} MB" -f ((Get-Item $PAGViewerInstallerPath).Length / 1MB)
+}
+
+$line = [string]::new([char]0x2550, $SECTION_WIDTH)
+Write-Host ""
+Write-Host $line -ForegroundColor Green
+Write-Host "  $([char]0x2714) Build Complete - $($BuildDuration.Minutes)m $($BuildDuration.Seconds)s" -ForegroundColor Green
+Write-Host $line -ForegroundColor Green
+Log-Info "  Version:    $AppVersion"
+Log-Info "  Installer:  $PAGViewerInstallerPath ($InstallerSize)"
+Log-Info "  PDB:        $BuildDir\PAGViewer.pdb"
+Log-Info "              $BuildDir\PAGExporter.pdb"
+Log-Info "  Signed:     $(if ($DSAPrivateKey) { 'Yes' } else { 'No' })"
+Write-Host ""

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -209,7 +209,7 @@ Copy-Item -Path $PAGExporterPdbPath -Destination $BuildDir -Force
 Print-Step "Deploy Qt dependencies"
 $QmlDir = Join-Path $SourceDir "assets\qml"
 & $Deployqt $ExePath --qmldir=$QmlDir
-if (-not $?) { Exit-WithError "Deploy Qt dependencies failed" }
+if ($LASTEXITCODE -ne 0) { Exit-WithError "Deploy Qt dependencies failed" }
 
 # 3.5 Copy vendor libraries
 Print-Step "Copy vendor libraries"
@@ -281,7 +281,7 @@ Copy-Item -Path $TemplateIslPath -Destination $IslPath -Force
 
 (Get-Content $IssPath -Raw -Encoding UTF8) -replace "~PAGViewerVersion~", $AppVersion | Set-Content $IssPath -Encoding UTF8
 & $ISCCPath $IssPath
-if (-not $?) { Exit-WithError "InnoSetup compilation failed" }
+if ($LASTEXITCODE -ne 0) { Exit-WithError "InnoSetup compilation failed" }
 
 $PAGViewerInstallerPath = Join-Path $BuildDir "PAGViewer_Installer.exe"
 if (-not (Test-Path $PAGViewerInstallerPath)) {

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -116,6 +116,9 @@ Log-Info "Using MSVC toolset: $LatestMSVCToolSet"
 
 $WindowsSdkDir = [System.IO.Path]::Combine(${env:ProgramFiles(x86)}, "Windows Kits", "10")
 $LatestSdkVersion = (Get-ChildItem (Join-Path $WindowsSdkDir "Lib") | Sort-Object Name -Descending | Select-Object -First 1).Name
+if ([string]::IsNullOrEmpty($LatestSdkVersion)) {
+    Exit-WithError "Windows SDK Lib directory not found or empty: $WindowsSdkDir\Lib"
+}
 $env:LIB = "${WindowsSdkDir}\Lib\${LatestSdkVersion}\um\x64;${WindowsSdkDir}\Lib\${LatestSdkVersion}\ucrt\x64;" + $env:LIB
 Log-Info "Windows SDK: $LatestSdkVersion"
 

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -299,6 +299,9 @@ if ([string]::IsNullOrEmpty($DSAPrivateKey) -eq $false) {
     $SignScript = Join-Path $SourceDir "package\sign_update.bat"
     $Base64Code = cmd /c $SignScript $OpenSSL $PAGViewerInstallerPath $DSAPrivateKey
     if ($LASTEXITCODE -ne 0) { Exit-WithError "Signing installer failed" }
+    # Collapse potentially multi-line cmd output into a single token before substitution;
+    # PowerShell -replace with a string[] would yield N substitutions and corrupt the XML.
+    $Base64Code = (($Base64Code -join '') -replace '\s', '')
     Log-Success "Installer signed"
 
     Print-Step "Update Appcast"


### PR DESCRIPTION
## 概述

重构 `viewer/package/build_mac.sh` 与 `viewer/package/build_windows.ps1`：引入结构化日志、加强失败检测、统一两端跨平台行为。正常路径行为不变；之前会被静默吞掉的失败现在会以可定位的错误信息中止构建。

## 主要改动

### 日志与结构
- 两个脚本都加入 section / step / info / success / warning / error 一组日志辅助函数
- 抽取辅助函数：`cleanAbsoluteRpaths`、`generateUniversalDsym`（mac）；`Invoke-CMakeBuild`（Windows）
- mac 端 `find-certificate` 结果缓存复用，避免重复查询

### 失败检测 — mac
- 所有 Plistbuddy 调用通过 `|| exitWithError` 失败即中止；只有当 `DSAPublicKey` 非空时才写 SUPublicDSAKeyFile
- H264EncoderTools 失败时输出 xcodebuild 的 stderr，便于排错
- EXIT trap（使用绝对路径）在所有退出路径上清理 notarization 临时产物
- `lipo -create` 合并 ExePath / FfmoviePath 增加退出码检查（与已有的 dSYM 合并模式对齐）
- Frameworks 下 dylib 的 codesign 循环现在捕获输出并在失败时中止（之前完全静默）
- Plugin frameworks 拷贝改为显式循环，逐项检测 cp 失败（原 `find -exec` 会吞掉错误）
- 升级 URL 抓取改为 `curl -fsS --retry 3 --connect-timeout 10`，并校验非空响应
- `isBetaVersion` 环境变量做严格小写归一化（大小写不敏感，兼容 `1`）

### 失败检测 — Windows
- `cmd /c` 签名调用通过 `$LASTEXITCODE` 检查状态
- H264EncoderTools 工具集改写改成幂等（正则从字面量 `v142` 放宽到 `v14\d`，并在替换后做匹配校验）
- Windows SDK Lib 目录在拼接 `LIB` 路径之前做存在性校验
- InnoSetup 安装器无论安装结果都会被清理
- InnoSetup 安装通过进程 `ExitCode` 验证（增加 `-PassThru`）+ 安装后再做一次 `Test-Path $ISCCPath` 兜底
- `$Base64Code` 来自 `cmd /c` 时先扁平化再代入 XML（与 mac 端对齐）
- 原生命令 `&` 调用的退出状态检查统一收敛到 `$LASTEXITCODE`（替换最后两处遗留的 `$?`）
- `$IsBetaVersion` 归一化为真正的布尔值

### 其它清理
- 删除多余的 `arm64BuildDir` 重新赋值
- 命令位置上的变量展开补齐引号，避免 word-splitting / glob 副作用
- 移除 hdiutil detach 之后多余的 `sleep 1`

## 本次有意未改动的范围

- `build_mac.sh` Appcast 更新子 shell（621-663 行）：保留现状。引入 `set -e` 并打通父进程感知是更大的结构改动；当前 CI 环境下该路径稳定
- viewer 与 plugin 之间不对称的 `rpath` 清理：确认为有意设计
- InnoSetup 下载未引入 checksum 校验，依赖到 `jrsoftware.org` 的 HTTPS

## 测试

- `bash -n viewer/package/build_mac.sh` 通过
- 这些纯粹是打包脚本，不影响 C++ 构建或 `PAGFullTest`；最终验证通过 CI 在各自平台上实际运行打包流程完成

## 复审状态

分支上跑过两轮自动化复审（reviewer / verifier 对抗校验）。共 10 个候选问题，确认 9 个并已修复（1 个被驳回为非问题）。上文"未改动范围"中的 Appcast 子 shell 项是基于综合权衡的主动决定。