### PR TITLE
Move OHOSVideoDecoder destruction to a background task to avoid blocking the caller thread on synchronous IPC.

### DIFF
--- a/src/platform/ohos/OHOSVideoDecoder.cpp
+++ b/src/platform/ohos/OHOSVideoDecoder.cpp
@@ -29,6 +29,7 @@
 #include "base/utils/Log.h"
 #include "rendering/video/SoftwareData.h"
 #include "tgfx/core/ImageCodec.h"
+#include "tgfx/core/Task.h"
 
 namespace pag {
 #define NV12_PLANE_COUNT 2
@@ -111,17 +112,37 @@ OHOSVideoDecoder::OHOSVideoDecoder(const VideoFormat& format, bool hardware) {
 }
 
 OHOSVideoDecoder::~OHOSVideoDecoder() {
-  if (videoCodec != nullptr) {
-    releaseOutputBuffer();
-    OH_VideoDecoder_Flush(videoCodec);
-    OH_VideoDecoder_Stop(videoCodec);
-    OH_VideoDecoder_Destroy(videoCodec);
-    videoCodec = nullptr;
+  // Move ownership of the codec and user data to a background task to avoid blocking the
+  // caller thread (e.g. ArkUI main thread) on synchronous IPC into av_codec_service.
+  // OH_VideoDecoder_Flush/Stop/Destroy wait for all pending callbacks to finish, which can
+  // take seconds on busy devices and trigger ANR when invoked on the UI thread.
+  // Per the OHOS documentation, after OH_VideoDecoder_Destroy returns the codec will not
+  // deliver any further callbacks, so it is safe to release CodecUserData afterwards.
+  if (videoCodec == nullptr) {
+    if (codecUserData) {
+      delete codecUserData;
+      codecUserData = nullptr;
+    }
+    return;
   }
-  if (codecUserData) {
-    codecUserData->clearQueue();
-    delete codecUserData;
-  }
+  auto codec = videoCodec;
+  auto userData = codecUserData;
+  auto pendingBuffer = codecBufferInfo;
+  videoCodec = nullptr;
+  codecUserData = nullptr;
+  codecBufferInfo = {0, nullptr};
+  tgfx::Task::Run([codec, userData, pendingBuffer]() {
+    if (pendingBuffer.buffer) {
+      OH_VideoDecoder_FreeOutputBuffer(codec, pendingBuffer.bufferIndex);
+    }
+    OH_VideoDecoder_Flush(codec);
+    OH_VideoDecoder_Stop(codec);
+    OH_VideoDecoder_Destroy(codec);
+    if (userData) {
+      userData->clearQueue();
+      delete userData;
+    }
+  });
 }
 
 bool OHOSVideoDecoder::initDecoder(const OH_AVCodecCategory avCodecCategory) {


### PR DESCRIPTION
## 背景
鸿蒙端业务方反馈线上偶现 APP_INPUT_BLOCK ANR，主线程被 PAGView 销毁路径卡住 5 秒以上。
调用栈显示主线程同步执行：
JPAGView::release → PAGPlayer 析构 → RenderCache::clearAllSequenceCaches
  → VideoReader 析构 → OHOSVideoDecoder 析构
  → OH_VideoDecoder_Flush / Stop / Destroy（IPC 同步等待 av_codec_service 返回）

按 OpenHarmony 官方文档说明，OH_VideoDecoder_Flush / Reset / Stop / Destroy 在非回调线程执行时会等待所有回调执行完成才返回。当系统 av_codec_service 响应慢或者 callback 队列堆积时，主线程就会被这条同步链路卡住，触发 ANR。

## 改动
将 ~OHOSVideoDecoder 中对系统 vdec API 的同步调用通过 tgfx::Task::Run 转移到后台线程：
- 转移 videoCodec、codecUserData、codecBufferInfo 的所有权到后台 task
- 主线程立即返回，不再因系统 IPC 卡死
- 依据官方文档承诺 "OH_VideoDecoder_Destroy 返回后不再投递回调"，在 Destroy 之后再释放 CodecUserData 是安全的

## 影响
- 修复主线程触发 PAGView 销毁时可能出现的 ANR
- 不改变 vdec 的销毁顺序与语义，仅切换执行线程