### PR TITLE
Update tgfx dependency to latest commit.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "cb470b37a9858d4ab199ba8cb47b9ededb055823",
+        "commit": "240cbf8bd7f87427280fbd6a7957e115a4ba237c",
         "dir": "third_party/tgfx"
       },
       {


### PR DESCRIPTION
升级 tgfx 依赖版本至 240cbf8bd7f87427280fbd6a7957e115a4ba237c，主要改进 PDF 导出的规范合规性和图形状态正确性。已验证编译和全部 1155 个单测均通过。