### PR TITLE
Fix iOS VideoToolbox watchdog hangs on app deactivation by invalidating decoder session.

### DIFF
--- a/src/platform/ios/private/HardwareDecoder.h
+++ b/src/platform/ios/private/HardwareDecoder.h
@@ -21,6 +21,7 @@
 #include <CoreMedia/CoreMedia.h>
 #include <VideoToolbox/VideoToolbox.h>
 #include <list>
+#include <mutex>
 #include <unordered_map>
 #include "rendering/video/VideoDecoder.h"
 
@@ -41,9 +42,17 @@ class HardwareDecoder : public VideoDecoder {
 
   std::shared_ptr<tgfx::ImageBuffer> onRenderFrame() override;
 
+  /**
+   * Aborts any in-progress synchronous decompression by invalidating the underlying VT session.
+   * Safe to call from any thread. Used by the willResignActive observer to unblock the worker
+   * thread so it can release device.locker before the main thread enters EAGLDevice::finish().
+   */
+  void invalidateSession();
+
  private:
   bool isInitialized = false;
   VTDecompressionSessionRef session = nullptr;
+  std::mutex sessionLocker = {};
   CMFormatDescriptionRef videoFormatDescription = nullptr;
   tgfx::YUVColorSpace sourceColorSpace = tgfx::YUVColorSpace::BT601_LIMITED;
   tgfx::YUVColorSpace destinationColorSpace = tgfx::YUVColorSpace::BT601_LIMITED;

--- a/src/platform/ios/private/HardwareDecoder.mm
+++ b/src/platform/ios/private/HardwareDecoder.mm
@@ -19,6 +19,7 @@
 #include "HardwareDecoder.h"
 #import <UIKit/UIKit.h>
 #include <algorithm>
+#include <atomic>
 #include <mutex>
 #include <vector>
 #include "base/utils/Log.h"
@@ -37,26 +38,40 @@ std::vector<HardwareDecoder*>& GetActiveDecoders() {
   return list;
 }
 
-// Registers a global willResignActive observer once. The observer block runs on a dedicated
-// NSOperationQueue (not the main thread), so it bypasses the synchronous-observer ordering
-// that lets EAGLDevice::finish() acquire device.locker first and stall the main thread before
-// HardwareDecoder gets a chance to abort its in-progress VT decode.
-void RegisterWillResignObserverOnce() {
+// Reflects whether the application is currently inactive (between willResignActive and
+// didBecomeActive). Read by onDecodeFrame() to fast-fail any decode attempt while in this
+// window, since calling VTDecompressionSessionDecodeFrame may block indefinitely once the
+// app moves to the background, defeating the invalidateSession() unblock done at willResign.
+std::atomic<bool> g_appInactive{false};
+
+// Registers global willResignActive / didBecomeActive observers once. The blocks run on a
+// dedicated NSOperationQueue (not the main thread), so they bypass the synchronous-observer
+// ordering that lets EAGLDevice::finish() acquire device.locker first and stall the main
+// thread before HardwareDecoder gets a chance to abort its in-progress VT decode.
+void RegisterAppLifecycleObserversOnce() {
   static dispatch_once_t once;
   dispatch_once(&once, ^{
     NSOperationQueue* queue = [[NSOperationQueue alloc] init];
     queue.maxConcurrentOperationCount = 1;
-    queue.name = @"libpag.HardwareDecoder.willResign";
+    queue.name = @"libpag.HardwareDecoder.lifecycle";
     [[NSNotificationCenter defaultCenter]
         addObserverForName:UIApplicationWillResignActiveNotification
                     object:nil
                      queue:queue
                 usingBlock:^(NSNotification*) {
-          std::lock_guard<std::mutex> lock(GetActiveDecodersMutex());
-          for (auto* decoder : GetActiveDecoders()) {
-            decoder->invalidateSession();
-          }
-        }];
+                  g_appInactive.store(true, std::memory_order_release);
+                  std::lock_guard<std::mutex> lock(GetActiveDecodersMutex());
+                  for (auto* decoder : GetActiveDecoders()) {
+                    decoder->invalidateSession();
+                  }
+                }];
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:UIApplicationDidBecomeActiveNotification
+                    object:nil
+                     queue:queue
+                usingBlock:^(NSNotification*) {
+                  g_appInactive.store(false, std::memory_order_release);
+                }];
   });
 }
 }  // namespace
@@ -69,7 +84,8 @@ void HardwareDecoder::invalidateSession() {
   {
     std::lock_guard<std::mutex> lock(sessionLocker);
     if (session) {
-      sessionToInvalidate = static_cast<VTDecompressionSessionRef>(CFRetain(session));
+      CFRetain(session);
+      sessionToInvalidate = session;
     }
   }
   if (sessionToInvalidate) {
@@ -83,7 +99,7 @@ HardwareDecoder::HardwareDecoder(const VideoFormat& format)
       destinationColorSpace(format.colorSpace),
       maxNumReorder(format.maxReorderSize) {
   isInitialized = initVideoToolBox(format.headers, format.mimeType);
-  RegisterWillResignObserverOnce();
+  RegisterAppLifecycleObserversOnce();
   std::lock_guard<std::mutex> lock(GetActiveDecodersMutex());
   GetActiveDecoders().push_back(this);
 }
@@ -238,9 +254,8 @@ bool HardwareDecoder::resetVideoToolBox() {
   CFRelease(ioSurfaceParam);
 
   if (@available(iOS 10.0, *)) {
-    if (newSession != nullptr &&
-        (sourceColorSpace == tgfx::YUVColorSpace::BT2020_LIMITED ||
-         sourceColorSpace == tgfx::YUVColorSpace::BT2020_FULL)) {
+    if (newSession != nullptr && (sourceColorSpace == tgfx::YUVColorSpace::BT2020_LIMITED ||
+                                  sourceColorSpace == tgfx::YUVColorSpace::BT2020_FULL)) {
       CFStringRef destinationColorPrimaries = CFStringCreateWithCString(
           kCFAllocatorDefault, "DestinationColorPrimaries", kCFStringEncodingUTF8);
       CFStringRef destinationTransferFunction = CFStringCreateWithCString(
@@ -326,6 +341,15 @@ pag::DecodingResult HardwareDecoder::onDecodeFrame() {
     CVPixelBufferRelease(outputFrame->outputPixelBuffer);
     delete outputFrame;
     outputFrame = nullptr;
+  }
+
+  // Fast-fail while the app is inactive (between willResignActive and didBecomeActive).
+  // Calling VTDecompressionSessionDecodeFrame in this window may block indefinitely because
+  // iOS suspends the hardware decoder pipeline as the app heads to the background; returning
+  // Error here lets the caller release device.locker so the main thread can complete
+  // EAGLDevice::finish() within the watchdog window.
+  if (g_appInactive.load(std::memory_order_acquire)) {
+    return DecodingResult::Error;
   }
 
   CVPixelBufferRef outputPixelBuffer = nullptr;

--- a/src/platform/ios/private/HardwareDecoder.mm
+++ b/src/platform/ios/private/HardwareDecoder.mm
@@ -42,7 +42,7 @@ std::vector<HardwareDecoder*>& GetActiveDecoders() {
 // didBecomeActive). Read by onDecodeFrame() to fast-fail any decode attempt while in this
 // window, since calling VTDecompressionSessionDecodeFrame may block indefinitely once the
 // app moves to the background, defeating the invalidateSession() unblock done at willResign.
-std::atomic<bool> g_appInactive{false};
+std::atomic<bool> appInactive{false};
 
 // Registers global willResignActive / didBecomeActive observers once. The blocks run on a
 // dedicated NSOperationQueue (not the main thread), so they bypass the synchronous-observer
@@ -59,7 +59,7 @@ void RegisterAppLifecycleObserversOnce() {
                     object:nil
                      queue:queue
                 usingBlock:^(NSNotification*) {
-                  g_appInactive.store(true, std::memory_order_release);
+                  appInactive.store(true, std::memory_order_release);
                   std::lock_guard<std::mutex> lock(GetActiveDecodersMutex());
                   for (auto* decoder : GetActiveDecoders()) {
                     decoder->invalidateSession();
@@ -70,7 +70,7 @@ void RegisterAppLifecycleObserversOnce() {
                     object:nil
                      queue:queue
                 usingBlock:^(NSNotification*) {
-                  g_appInactive.store(false, std::memory_order_release);
+                  appInactive.store(false, std::memory_order_release);
                 }];
   });
 }
@@ -348,7 +348,7 @@ pag::DecodingResult HardwareDecoder::onDecodeFrame() {
   // iOS suspends the hardware decoder pipeline as the app heads to the background; returning
   // Error here lets the caller release device.locker so the main thread can complete
   // EAGLDevice::finish() within the watchdog window.
-  if (g_appInactive.load(std::memory_order_acquire)) {
+  if (appInactive.load(std::memory_order_acquire)) {
     return DecodingResult::Error;
   }
 

--- a/src/platform/ios/private/HardwareDecoder.mm
+++ b/src/platform/ios/private/HardwareDecoder.mm
@@ -17,24 +17,91 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "HardwareDecoder.h"
+#import <UIKit/UIKit.h>
+#include <algorithm>
+#include <mutex>
+#include <vector>
 #include "base/utils/Log.h"
 #include "base/utils/USE.h"
 
 namespace pag {
+
+namespace {
+std::mutex& GetActiveDecodersMutex() {
+  static std::mutex m;
+  return m;
+}
+
+std::vector<HardwareDecoder*>& GetActiveDecoders() {
+  static std::vector<HardwareDecoder*> list;
+  return list;
+}
+
+// Registers a global willResignActive observer once. The observer block runs on a dedicated
+// NSOperationQueue (not the main thread), so it bypasses the synchronous-observer ordering
+// that lets EAGLDevice::finish() acquire device.locker first and stall the main thread before
+// HardwareDecoder gets a chance to abort its in-progress VT decode.
+void RegisterWillResignObserverOnce() {
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    NSOperationQueue* queue = [[NSOperationQueue alloc] init];
+    queue.maxConcurrentOperationCount = 1;
+    queue.name = @"libpag.HardwareDecoder.willResign";
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:UIApplicationWillResignActiveNotification
+                    object:nil
+                     queue:queue
+                usingBlock:^(NSNotification*) {
+          std::lock_guard<std::mutex> lock(GetActiveDecodersMutex());
+          for (auto* decoder : GetActiveDecoders()) {
+            decoder->invalidateSession();
+          }
+        }];
+  });
+}
+}  // namespace
+
+void HardwareDecoder::invalidateSession() {
+  // Retain a reference under the lock so concurrent resetVideoToolBox()/dealloc cannot release
+  // the session pointer between our load and the VT call below. Then drop the lock before
+  // calling into VT to avoid blocking the worker thread that may also touch the session.
+  VTDecompressionSessionRef sessionToInvalidate = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(sessionLocker);
+    if (session) {
+      sessionToInvalidate = static_cast<VTDecompressionSessionRef>(CFRetain(session));
+    }
+  }
+  if (sessionToInvalidate) {
+    VTDecompressionSessionInvalidate(sessionToInvalidate);
+    CFRelease(sessionToInvalidate);
+  }
+}
 
 HardwareDecoder::HardwareDecoder(const VideoFormat& format)
     : sourceColorSpace(format.colorSpace),
       destinationColorSpace(format.colorSpace),
       maxNumReorder(format.maxReorderSize) {
   isInitialized = initVideoToolBox(format.headers, format.mimeType);
+  RegisterWillResignObserverOnce();
+  std::lock_guard<std::mutex> lock(GetActiveDecodersMutex());
+  GetActiveDecoders().push_back(this);
 }
 
 HardwareDecoder::~HardwareDecoder() {
-  if (session) {
-    VTDecompressionSessionFinishDelayedFrames(session);
-    VTDecompressionSessionInvalidate(session);
-    CFRelease(session);
-    session = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(GetActiveDecodersMutex());
+    auto& list = GetActiveDecoders();
+    list.erase(std::remove(list.begin(), list.end(), this), list.end());
+  }
+  {
+    std::lock_guard<std::mutex> lock(sessionLocker);
+    if (session) {
+      VTDecompressionSessionFinishDelayedFrames(session);
+      VTDecompressionSessionInvalidate(session);
+      CFRelease(session);
+      session = nullptr;
+    }
   }
 
   if (videoFormatDescription) {
@@ -122,11 +189,18 @@ bool HardwareDecoder::initVideoToolBox(const std::vector<std::shared_ptr<tgfx::D
 }
 
 bool HardwareDecoder::resetVideoToolBox() {
-  if (session) {
-    VTDecompressionSessionFinishDelayedFrames(session);
-    VTDecompressionSessionInvalidate(session);
-    CFRelease(session);
-    session = nullptr;
+  // Release the old session under the lock so concurrent invalidateSession() never observes a
+  // pointer that's mid-CFRelease. The new session is built into a local first and assigned to
+  // the member only after creation succeeds, again under the lock.
+  {
+    std::lock_guard<std::mutex> lock(sessionLocker);
+    if (session) {
+      auto old = session;
+      session = nullptr;
+      VTDecompressionSessionFinishDelayedFrames(old);
+      VTDecompressionSessionInvalidate(old);
+      CFRelease(old);
+    }
   }
 
   // create decompression session
@@ -153,9 +227,10 @@ bool HardwareDecoder::resetVideoToolBox() {
   callBackRecord.decompressionOutputCallback = DidDecompress;
   callBackRecord.decompressionOutputRefCon = NULL;
 
+  VTDecompressionSessionRef newSession = nullptr;
   OSStatus status;
   status = VTDecompressionSessionCreate(kCFAllocatorDefault, videoFormatDescription, NULL, attrs,
-                                        &callBackRecord, &session);
+                                        &callBackRecord, &newSession);
 
   CFRelease(attrs);
   CFRelease(pixelFormatTypeValue);
@@ -163,8 +238,9 @@ bool HardwareDecoder::resetVideoToolBox() {
   CFRelease(ioSurfaceParam);
 
   if (@available(iOS 10.0, *)) {
-    if (sourceColorSpace == tgfx::YUVColorSpace::BT2020_LIMITED ||
-        sourceColorSpace == tgfx::YUVColorSpace::BT2020_FULL) {
+    if (newSession != nullptr &&
+        (sourceColorSpace == tgfx::YUVColorSpace::BT2020_LIMITED ||
+         sourceColorSpace == tgfx::YUVColorSpace::BT2020_FULL)) {
       CFStringRef destinationColorPrimaries = CFStringCreateWithCString(
           kCFAllocatorDefault, "DestinationColorPrimaries", kCFStringEncodingUTF8);
       CFStringRef destinationTransferFunction = CFStringCreateWithCString(
@@ -182,7 +258,7 @@ bool HardwareDecoder::resetVideoToolBox() {
                            kCVImageBufferTransferFunction_ITU_R_709_2);
       CFDictionarySetValue(pixelTransferPropertiesParam, destinationYCbCrMatrix,
                            kCVImageBufferYCbCrMatrix_ITU_R_709_2);
-      VTSessionSetProperty(session, pixelTransferProperties, pixelTransferPropertiesParam);
+      VTSessionSetProperty(newSession, pixelTransferProperties, pixelTransferPropertiesParam);
 
       CFRelease(destinationColorPrimaries);
       CFRelease(destinationTransferFunction);
@@ -196,11 +272,15 @@ bool HardwareDecoder::resetVideoToolBox() {
     }
   }
 
-  if (status != noErr || !session) {
+  if (status != noErr || !newSession) {
     LOGE("HardwareDecoder:decoder session create failed status = %d", status);
     return false;
   }
 
+  {
+    std::lock_guard<std::mutex> lock(sessionLocker);
+    session = newSession;
+  }
   return true;
 }
 


### PR DESCRIPTION
## 问题

iOS 线上 crash 显示，App 切后台时主线程卡在 `EAGLDevice::finish()` 等 `device.locker` 超过 10 秒，被 scene-update watchdog（`0x8BADF00D`）杀进程。`device.locker` 被 PAG 后台渲染线程持有，该线程在 `VTDecompressionSessionDecodeFrame` 内部 `dispatch_semaphore_wait` 阻塞。

线上多份独立实例覆盖 A9/A12/A15 设备、iOS 15~18，crash 栈完全一致——是结构性问题，跟具体设备/系统无关。

## 业界已知问题（Apple 工程团队官方指导）

这不是 PAG 独有问题。**Apple Developer Forums Thread #19046（2015 年）** 就有业界开发者报告同样现象：

> [VTDecompressionSessionDecodeFrame hangs during applicationDidEnterBackground](https://developer.apple.com/forums/thread/19046)

Apple Video Toolbox 工程团队在该帖中的指导意见：

> "Hanging and never returning is definitely not expected - the API should return an error if it fails due to your application no longer being in the foreground. However, that being said, **the application should monitor device state and immediately stop trying to use the Video Toolbox if it is not in the foreground**."

帖子里业界开发者 robgaunt 验证的解决方案：

> "Checking the status and calling **VTDecompressionSessionInvalidate** on failure seems to allow the call to VTDecompressionSessionDecodeFrameWithOutputHandler to return"

并特别强调：
> "必须从**另一个线程 / dispatch queue** 调用 VTDecompressionSessionInvalidate（不能在 output handler 内同步调，否则会自我阻塞）"

Apple 已收到 bug 报告 **#22796982**（2015 年），但 9 年来未公开修复。

## 修复方案

完全对齐 Apple 工程团队推荐做法：

### 1. 监听 device state（`UIApplicationWillResignActiveNotification` / `UIApplicationDidBecomeActiveNotification`）

通过 `dispatch_once` 注册全局监听，使用**独立 NSOperationQueue（非主线程）**，绕开 NSNotificationCenter 同步监听器顺序问题——`EAGLDevice` 在 framework 加载时已注册 willResignActive 同步监听并调 `glFinish`，HardwareDecoder 监听器晚于它注册，用同步形式永远轮不到执行。

### 2. willResignActive 时主动 invalidate VT session

在异步 block 内遍历活跃 HardwareDecoder 实例调 `VTDecompressionSessionInvalidate`，让卡住的同步 decode 调用从 wait 中返回。

### 3. inactive 期间 fast-fail

新增全局 `g_appInactive` 标志，`onDecodeFrame` 开头检查；进入 inactive 状态后所有 decode 调用直接返回 Error，避免 VideoReader 的 retry 逻辑再次触发 VT decode 卡死。

### 4. 线程安全保护

- 全局 `activeDecoders` 列表用 mutex 保护，确保 block 遍历期间所有 decoder 实例都活着，不会 use-after-free。
- `session` 指针用 per-instance `sessionLocker` 保护读写，`invalidateSession()` 锁内 `CFRetain` + 锁外调用 VT API，避免与 `resetVideoToolBox` 并发引发野指针。

## 现象对比

### 切后台时（含 PAG 视频播放）
- 改动前：大概率 watchdog 闪退
- 改动后：App 正常进入后台

### 切回前台
- 改动前：（已闪退）
- 改动后：PAG 视频从最近 keyframe 重新解码，可能跳 1~2 帧后正常播放

### 不含视频的 PAG
- 完全无影响（HardwareDecoder 不创建实例）

## 局限

1. Apple 文档对 `VTDecompressionSessionInvalidate` 在 in-progress decode 时的具体行为只承诺 "deterministic, orderly teardown"，业界经验上能解开同步 decode wait，但需要线上验证实际降量效果。
2. 此修复只覆盖 willResignActive 触发的 VT 卡死。非切后台场景的 VT 卡死（系统资源紧张、其他 App 抢占硬件解码器、码流损坏）仍可能存在，需要后续叠加 VT decode timeout 兜底。

## 涉及文件

- `src/platform/ios/private/HardwareDecoder.h`
- `src/platform/ios/private/HardwareDecoder.mm`
