### PR TITLE
Add version resource to PAGExporter and fix plugin update detection

### DIFF
--- a/exporter/CMakeLists.txt
+++ b/exporter/CMakeLists.txt
@@ -108,6 +108,13 @@ configure_file(${CMAKE_SOURCE_DIR}/templates/version.h.in
         @ONLY
 )
 
+if (WIN32)
+    configure_file(${CMAKE_SOURCE_DIR}/templates/PAGExporter.rc.in
+            ${CMAKE_BINARY_DIR}/PAGExporter.rc
+            @ONLY
+    )
+endif ()
+
 list(APPEND PAG_EXPORTER_INCLUDES ./ src ../ ../include ../src ../third_party/tgfx/include)
 file(GLOB_RECURSE PAG_EXPORTER_SOURCE_FILES src/*.*)
 file(GLOB_RECURSE PAG_EXPORTER_THIRD_PARTY_SOURCE_FILES
@@ -269,6 +276,7 @@ elseif (WIN32)
             COMMENT "Compiling the PiPL"
     )
     target_sources(${PROJECT_NAME} PRIVATE PAGExporterPiPL.rc)
+    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/PAGExporter.rc)
 
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(deploy_build_type "debug")

--- a/exporter/templates/PAGExporter.rc.in
+++ b/exporter/templates/PAGExporter.rc.in
@@ -1,0 +1,52 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <winver.h>
+
+VS_VERSION_INFO VERSIONINFO
+    FILEVERSION @MajorVersion@,@MinorVersion@,@BuildNumber@,0
+    PRODUCTVERSION @MajorVersion@,@MinorVersion@,@BuildNumber@,0
+    FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef DEBUG
+    FILEFLAGS VS_FF_DEBUG
+#else
+    FILEFLAGS 0x0L
+#endif
+    FILEOS VOS_NT_WINDOWS32
+    FILETYPE VFT_DLL
+    FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "CompanyName", "Tencent"
+            VALUE "FileDescription", "PAG Exporter Plugin for Adobe After Effects"
+            VALUE "FileVersion", "@MajorVersion@.@MinorVersion@.@BuildNumber@"
+            VALUE "InternalName", "PAGExporter"
+            VALUE "LegalCopyright", "Copyright (C) 2026 Tencent. All rights reserved."
+            VALUE "OriginalFilename", "PAGExporter.aex"
+            VALUE "ProductName", "PAGExporter"
+            VALUE "ProductVersion", "@MajorVersion@.@MinorVersion@.@BuildNumber@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 0x04B0
+    END
+END

--- a/viewer/src/platform/PluginInstaller.cpp
+++ b/viewer/src/platform/PluginInstaller.cpp
@@ -43,8 +43,8 @@ bool PluginInstaller::hasUpdate() const {
     // Flag an update when the source version is strictly newer, or when the installed version
     // is unparseable (returns 0) but the source version is valid — this handles upgrading from
     // old builds that lacked embedded version resources.
-    auto sourceVersion = getPluginVersion(sourcePath);
-    auto installedVersion = getPluginVersion(installPath);
+    int64_t sourceVersion = getPluginVersion(sourcePath);
+    int64_t installedVersion = getPluginVersion(installPath);
     if (sourceVersion == 0) {
       continue;
     }

--- a/viewer/src/platform/PluginInstaller.cpp
+++ b/viewer/src/platform/PluginInstaller.cpp
@@ -40,16 +40,15 @@ bool PluginInstaller::hasUpdate() const {
       continue;
     }
 
-    // Only flag an update when we can actually compare versions and the source is strictly
-    // newer. A zero result from getPluginVersion() means either the file is missing or the
-    // version string is unparseable (e.g. dev builds that ship a placeholder like ".." in
-    // Info.plist) — in both cases we skip rather than risk spamming the user.
+    // Flag an update when the source version is strictly newer, or when the installed version
+    // is unparseable (returns 0) but the source version is valid — this handles upgrading from
+    // old builds that lacked embedded version resources.
     auto sourceVersion = getPluginVersion(sourcePath);
     auto installedVersion = getPluginVersion(installPath);
-    if (sourceVersion == 0 || installedVersion == 0) {
+    if (sourceVersion == 0) {
       continue;
     }
-    if (sourceVersion > installedVersion) {
+    if (installedVersion == 0 || sourceVersion > installedVersion) {
       return true;
     }
   }

--- a/viewer/src/platform/PluginInstaller.h
+++ b/viewer/src/platform/PluginInstaller.h
@@ -126,14 +126,9 @@ class PluginInstaller : public QObject {
   QStringList getPluginList() const;
   static const QList<PluginInfo>& pluginInfoList();
 
-  void appendQtResourceCopyCommands(QStringList& commands, const QStringList& aePaths) const;
-  void appendQtResourceDeleteCommands(QStringList& commands, const QStringList& aePaths) const;
   QString getQtResourceDir() const;
   bool shouldExcludeFile(const QString& fileName) const;
   bool shouldExcludeDir(const QString& dirName) const;
-
-  void appendExporterCopyCommands(QStringList& commands, const QStringList& aePaths) const;
-  void appendExporterDeleteCommands(QStringList& commands, const QStringList& aePaths) const;
 
   void storeViewerPathForPlugin() const;
 

--- a/viewer/src/platform/win/PluginInstaller.cpp
+++ b/viewer/src/platform/win/PluginInstaller.cpp
@@ -395,7 +395,11 @@ bool PluginInstaller::copyPluginFiles(const QStringList& plugins) const {
         operations << FileOperation::copyFile(sourcePath, targetPath);
       }
 
-      // Copy Qt DLLs to AE directories for DLL search path.
+      // Copy Qt DLLs to AE directories for DLL search path, and remove any legacy
+      // PAGExporter.aex left behind in <AE>/Plug-ins/ from earlier builds that installed
+      // the plugin there instead of Common/Plug-ins/.../MediaCore. Without this cleanup,
+      // upgrading users would end up with two copies of the plugin and AE may load the
+      // wrong one.
       if (!aePaths.isEmpty()) {
         QString appDir = getQtResourceDir();
         QDir dir(appDir);
@@ -403,6 +407,8 @@ bool PluginInstaller::copyPluginFiles(const QStringList& plugins) const {
         QStringList subDirs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
 
         for (const QString& aePath : aePaths) {
+          operations << FileOperation::deleteFile(aePath + "/Plug-ins/PAGExporter.aex");
+
           for (const QString& dllFile : dllFiles) {
             if (shouldExcludeFile(dllFile)) {
               continue;
@@ -413,7 +419,8 @@ bool PluginInstaller::copyPluginFiles(const QStringList& plugins) const {
             if (shouldExcludeDir(subDir)) {
               continue;
             }
-            operations << FileOperation::copyDirectory(appDir + "/" + subDir, aePath + "/" + subDir);
+            operations << FileOperation::copyDirectory(appDir + "/" + subDir,
+                                                       aePath + "/" + subDir);
           }
         }
       }

--- a/viewer/src/platform/win/PluginInstaller.cpp
+++ b/viewer/src/platform/win/PluginInstaller.cpp
@@ -386,33 +386,35 @@ bool PluginInstaller::copyPluginFiles(const QStringList& plugins) const {
       continue;
     }
 
-    if (plugin == "PAGExporter" && !aePaths.isEmpty()) {
+    if (plugin == "PAGExporter") {
       QString sourcePath = getPluginSourcePath("PAGExporter");
+      QString targetPath = getPluginInstallPath("PAGExporter");
       if (QFile::exists(sourcePath)) {
-        for (const QString& aePath : aePaths) {
-          QString pluginsDir = aePath + "/Plug-ins";
-          operations << FileOperation::createDirectory(pluginsDir);
-          operations << FileOperation::copyFile(sourcePath, pluginsDir + "/PAGExporter.aex");
-        }
+        QString targetDir = QFileInfo(targetPath).absolutePath();
+        operations << FileOperation::createDirectory(targetDir);
+        operations << FileOperation::copyFile(sourcePath, targetPath);
       }
 
-      QString appDir = getQtResourceDir();
-      QDir dir(appDir);
-      QStringList dllFiles = dir.entryList(QStringList() << "*.dll", QDir::Files);
-      QStringList subDirs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+      // Copy Qt DLLs to AE directories for DLL search path.
+      if (!aePaths.isEmpty()) {
+        QString appDir = getQtResourceDir();
+        QDir dir(appDir);
+        QStringList dllFiles = dir.entryList(QStringList() << "*.dll", QDir::Files);
+        QStringList subDirs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
 
-      for (const QString& aePath : aePaths) {
-        for (const QString& dllFile : dllFiles) {
-          if (shouldExcludeFile(dllFile)) {
-            continue;
+        for (const QString& aePath : aePaths) {
+          for (const QString& dllFile : dllFiles) {
+            if (shouldExcludeFile(dllFile)) {
+              continue;
+            }
+            operations << FileOperation::copyFile(appDir + "/" + dllFile, aePath + "/" + dllFile);
           }
-          operations << FileOperation::copyFile(appDir + "/" + dllFile, aePath + "/" + dllFile);
-        }
-        for (const QString& subDir : subDirs) {
-          if (shouldExcludeDir(subDir)) {
-            continue;
+          for (const QString& subDir : subDirs) {
+            if (shouldExcludeDir(subDir)) {
+              continue;
+            }
+            operations << FileOperation::copyDirectory(appDir + "/" + subDir, aePath + "/" + subDir);
           }
-          operations << FileOperation::copyDirectory(appDir + "/" + subDir, aePath + "/" + subDir);
         }
       }
       continue;
@@ -459,28 +461,32 @@ bool PluginInstaller::removePluginFiles(const QStringList& plugins) const {
       continue;
     }
 
-    if (plugin == "PAGExporter" && !aePaths.isEmpty()) {
-      for (const QString& aePath : aePaths) {
-        operations << FileOperation::deleteFile(aePath + "/Plug-ins/PAGExporter.aex");
-      }
+    if (plugin == "PAGExporter") {
+      operations << FileOperation::deleteFile(getPluginInstallPath("PAGExporter"));
 
-      QString appDir = getQtResourceDir();
-      QDir dir(appDir);
-      QStringList dllFiles = dir.entryList(QStringList() << "*.dll", QDir::Files);
-      QStringList subDirs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+      // Remove Qt DLLs and legacy PAGExporter.aex from AE directories.
+      if (!aePaths.isEmpty()) {
+        QString appDir = getQtResourceDir();
+        QDir dir(appDir);
+        QStringList dllFiles = dir.entryList(QStringList() << "*.dll", QDir::Files);
+        QStringList subDirs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
 
-      for (const QString& aePath : aePaths) {
-        for (const QString& dllFile : dllFiles) {
-          if (shouldExcludeFile(dllFile)) {
-            continue;
+        for (const QString& aePath : aePaths) {
+          // Remove legacy PAGExporter.aex installed in AE directory.
+          operations << FileOperation::deleteFile(aePath + "/Plug-ins/PAGExporter.aex");
+
+          for (const QString& dllFile : dllFiles) {
+            if (shouldExcludeFile(dllFile)) {
+              continue;
+            }
+            operations << FileOperation::deleteFile(aePath + "/" + dllFile);
           }
-          operations << FileOperation::deleteFile(aePath + "/" + dllFile);
-        }
-        for (const QString& subDir : subDirs) {
-          if (shouldExcludeDir(subDir)) {
-            continue;
+          for (const QString& subDir : subDirs) {
+            if (shouldExcludeDir(subDir)) {
+              continue;
+            }
+            operations << FileOperation::deleteDirectory(aePath + "/" + subDir);
           }
-          operations << FileOperation::deleteDirectory(aePath + "/" + subDir);
         }
       }
       continue;


### PR DESCRIPTION
为 PAGExporter 插件添加版本资源，并修复插件更新检测逻辑：

- 为 PAGExporter 添加 Windows 版本资源文件，使安装器能够读取插件版本号
- 修复 hasUpdate() 中版本比较逻辑，使用 int64_t 替代 auto 确保类型正确
- 安装时移除旧版 PAGExporter.aex 文件，避免新旧版本共存冲突
- 清理 PluginInstaller 头文件中已废弃的方法声明