### PR TITLE
Update tgfx dependency to latest commit.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "8888b515fff325de954fbc379b904876512fa847",
+        "commit": "9fee1c2e08223a5993554425088a55cbd3d35390",
         "dir": "third_party/tgfx"
       },
       {


### PR DESCRIPTION
更新 DEPS 文件中 tgfx 的 commit 引用，从 8888b51 升级到 9fee1c2，同步最新的 tgfx 代码。