### PR TITLE
Fix exporter crashes when AE stream APIs return null

### DIFF
--- a/exporter/src/export/ExportLayer.cpp
+++ b/exporter/src/export/ExportLayer.cpp
@@ -77,13 +77,17 @@ static void ModifyTransform3DForCameraLayer(pag::Layer* layer, AEGP_LayerFlags l
     return;
   }
 
-  if (transform3D->scale->animatable()) {
+  if (transform3D->scale == nullptr) {
+    transform3D->scale = new pag::Property<pag::Point3D>();
+  } else if (transform3D->scale->animatable()) {
     delete transform3D->scale;
     transform3D->scale = new pag::Property<pag::Point3D>();
   }
   transform3D->scale->value = pag::Point3D::Make(1, 1, 1);
 
-  if (transform3D->opacity->animatable()) {
+  if (transform3D->opacity == nullptr) {
+    transform3D->opacity = new pag::Property<pag::Opacity>();
+  } else if (transform3D->opacity->animatable()) {
     delete transform3D->opacity;
     transform3D->opacity = new pag::Property<pag::Opacity>();
   }
@@ -93,7 +97,9 @@ static void ModifyTransform3DForCameraLayer(pag::Layer* layer, AEGP_LayerFlags l
     delete transform3D->anchorPoint;
 
     auto position = transform3D->position;
-    if (!position->animatable()) {
+    if (position == nullptr) {
+      transform3D->anchorPoint = new pag::Property<pag::Point3D>();
+    } else if (!position->animatable()) {
       transform3D->anchorPoint = new pag::Property<pag::Point3D>();
       transform3D->anchorPoint->value = position->value;
     } else {

--- a/exporter/src/export/ExportVerify.cpp
+++ b/exporter/src/export/ExportVerify.cpp
@@ -779,8 +779,7 @@ static void CheckTextLayerPathOption(std::shared_ptr<PAGExportSession> session,
       perpendicularToPath->value != true) {
     session->pushWarning(AlertInfoType::TextPathParamPerpendicularToPath);
   }
-  if (forceAlignment == nullptr || forceAlignment->animatable() ||
-      forceAlignment->value != false) {
+  if (forceAlignment == nullptr || forceAlignment->animatable() || forceAlignment->value != false) {
     session->pushWarning(AlertInfoType::TextPathParamForceAlignment);
   }
 

--- a/exporter/src/export/ExportVerify.cpp
+++ b/exporter/src/export/ExportVerify.cpp
@@ -775,12 +775,12 @@ static void CheckTextLayerPathOption(std::shared_ptr<PAGExportSession> session,
 
   auto perpendicularToPath = layer->pathOption->perpendicularToPath;
   auto forceAlignment = layer->pathOption->forceAlignment;
-  if (perpendicularToPath != nullptr &&
-      (perpendicularToPath->animatable() || perpendicularToPath->value != true)) {
+  if (perpendicularToPath == nullptr || perpendicularToPath->animatable() ||
+      perpendicularToPath->value != true) {
     session->pushWarning(AlertInfoType::TextPathParamPerpendicularToPath);
   }
-  if (forceAlignment != nullptr &&
-      (forceAlignment->animatable() || forceAlignment->value != false)) {
+  if (forceAlignment == nullptr || forceAlignment->animatable() ||
+      forceAlignment->value != false) {
     session->pushWarning(AlertInfoType::TextPathParamForceAlignment);
   }
 

--- a/exporter/src/export/ExportVerify.cpp
+++ b/exporter/src/export/ExportVerify.cpp
@@ -775,10 +775,12 @@ static void CheckTextLayerPathOption(std::shared_ptr<PAGExportSession> session,
 
   auto perpendicularToPath = layer->pathOption->perpendicularToPath;
   auto forceAlignment = layer->pathOption->forceAlignment;
-  if (perpendicularToPath->animatable() || perpendicularToPath->value != true) {
+  if (perpendicularToPath != nullptr &&
+      (perpendicularToPath->animatable() || perpendicularToPath->value != true)) {
     session->pushWarning(AlertInfoType::TextPathParamPerpendicularToPath);
   }
-  if (forceAlignment->animatable() || forceAlignment->value != false) {
+  if (forceAlignment != nullptr &&
+      (forceAlignment->animatable() || forceAlignment->value != false)) {
     session->pushWarning(AlertInfoType::TextPathParamForceAlignment);
   }
 

--- a/exporter/src/export/data/Effect.cpp
+++ b/exporter/src/export/data/Effect.cpp
@@ -153,8 +153,7 @@ static pag::Effect* GetDisplacementMapEffect(const AEGP_StreamRefH& streamHandle
       GetProperty(streamHandle, "ADBE Displacement Map-0008", AEStreamParser::BooleanParser);
   if (effect->useForHorizontalDisplacement == nullptr ||
       effect->maxHorizontalDisplacement == nullptr ||
-      effect->useForVerticalDisplacement == nullptr ||
-      effect->maxVerticalDisplacement == nullptr ||
+      effect->useForVerticalDisplacement == nullptr || effect->maxVerticalDisplacement == nullptr ||
       effect->displacementMapBehavior == nullptr || effect->edgeBehavior == nullptr ||
       effect->expandOutput == nullptr) {
     delete effect->displacementMapLayer;

--- a/exporter/src/export/data/Effect.cpp
+++ b/exporter/src/export/data/Effect.cpp
@@ -447,6 +447,9 @@ std::vector<pag::Effect*> GetEffects(const AEGP_LayerH& layerHandle) {
 
 static void GetTextBackground(const AEGP_StreamRefH& streamHandle,
                               pag::Property<pag::TextDocumentHandle>* textDocument) {
+  if (textDocument == nullptr) {
+    return;
+  }
   auto backgroundColor =
       GetValue(streamHandle, "ADBE Text Background-0001", AEStreamParser::ColorParser);
   auto backgroundAlpha =
@@ -495,7 +498,7 @@ static pag::ImageFillRule* GetImageFillRule(const AEGP_StreamRefH& streamHandle,
 
   if (!(type == AEEffectType::ImageFillRuleV2 &&
         tagLevel >= static_cast<uint16_t>(pag::TagCode::ImageFillRuleV2)) &&
-      imageFillRule->timeRemap->animatable()) {
+      imageFillRule->timeRemap != nullptr && imageFillRule->timeRemap->animatable()) {
     auto timeRemap = imageFillRule->timeRemap;
     for (auto& keyFrame : static_cast<pag::AnimatableProperty<pag::Frame>*>(timeRemap)->keyframes) {
       keyFrame->interpolationType = pag::KeyframeInterpolationType::Linear;

--- a/exporter/src/export/data/Effect.cpp
+++ b/exporter/src/export/data/Effect.cpp
@@ -151,6 +151,17 @@ static pag::Effect* GetDisplacementMapEffect(const AEGP_StreamRefH& streamHandle
       GetProperty(streamHandle, "ADBE Displacement Map-0007", AEStreamParser::BooleanParser);
   effect->expandOutput =
       GetProperty(streamHandle, "ADBE Displacement Map-0008", AEStreamParser::BooleanParser);
+  if (effect->useForHorizontalDisplacement == nullptr ||
+      effect->maxHorizontalDisplacement == nullptr ||
+      effect->useForVerticalDisplacement == nullptr ||
+      effect->maxVerticalDisplacement == nullptr ||
+      effect->displacementMapBehavior == nullptr || effect->edgeBehavior == nullptr ||
+      effect->expandOutput == nullptr) {
+    delete effect->displacementMapLayer;
+    effect->displacementMapLayer = nullptr;
+    delete effect;
+    return nullptr;
+  }
   return effect;
 }
 

--- a/exporter/src/export/data/Effect.cpp
+++ b/exporter/src/export/data/Effect.cpp
@@ -127,8 +127,12 @@ static pag::Effect* GetDisplacementMapEffect(const AEGP_StreamRefH& streamHandle
   auto effect = new pag::DisplacementMapEffect();
 
   effect->displacementMapLayer = new pag::Layer();
-  effect->displacementMapLayer->id =
-      GetProperty(streamHandle, "ADBE Displacement Map-0001", AEStreamParser::LayerIDParser)->value;
+  auto idProperty =
+      GetProperty(streamHandle, "ADBE Displacement Map-0001", AEStreamParser::LayerIDParser);
+  if (idProperty != nullptr) {
+    effect->displacementMapLayer->id = idProperty->value;
+    delete idProperty;
+  }
   if (effect->displacementMapLayer->id <= 0) {
     delete effect->displacementMapLayer;
     effect->displacementMapLayer = nullptr;
@@ -290,6 +294,9 @@ static void InitEffect(const AEGP_StreamRefH& streamHandle, pag::Effect* effect)
   AEGP_StreamRefH builtInParams = nullptr;
   Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByIndex(PluginID, streamHandle, numParams - 1,
                                                              &builtInParams);
+  if (builtInParams == nullptr) {
+    return;
+  }
   Suites->DynamicStreamSuite4()->AEGP_GetMatchName(builtInParams, matchName);
   if (strcmp(matchName, "ADBE Effect Built In Params") != 0) {
     Suites->StreamSuite4()->AEGP_DisposeStream(builtInParams);
@@ -297,21 +304,28 @@ static void InitEffect(const AEGP_StreamRefH& streamHandle, pag::Effect* effect)
   }
   AEGP_StreamRefH masks = nullptr;
   Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByIndex(PluginID, builtInParams, 0, &masks);
-  A_long numMasks = 0;
-  Suites->DynamicStreamSuite4()->AEGP_GetNumStreamsInGroup(masks, &numMasks);
-  for (int i = 0; i < numMasks; i++) {
-    AEGP_StreamRefH maskReference = nullptr;
-    Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByIndex(PluginID, masks, i, &maskReference);
-    auto maskID = GetValue(maskReference, AEStreamParser::MaskIDParser);
-    auto mask = new pag::MaskData();
-    mask->id = maskID;
-    Suites->StreamSuite4()->AEGP_DisposeStream(maskReference);
-    effect->maskReferences.push_back(mask);
+  if (masks != nullptr) {
+    A_long numMasks = 0;
+    Suites->DynamicStreamSuite4()->AEGP_GetNumStreamsInGroup(masks, &numMasks);
+    for (int i = 0; i < numMasks; i++) {
+      AEGP_StreamRefH maskReference = nullptr;
+      Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByIndex(PluginID, masks, i,
+                                                                 &maskReference);
+      if (maskReference == nullptr) {
+        continue;
+      }
+      auto maskID = GetValue(maskReference, AEStreamParser::MaskIDParser);
+      auto mask = new pag::MaskData();
+      mask->id = maskID;
+      Suites->StreamSuite4()->AEGP_DisposeStream(maskReference);
+      effect->maskReferences.push_back(mask);
+    }
+    Suites->StreamSuite4()->AEGP_DisposeStream(masks);
   }
-  Suites->StreamSuite4()->AEGP_DisposeStream(masks);
   effect->effectOpacity = GetProperty(builtInParams, 1, AEStreamParser::Opacity0_100Parser);
   Suites->StreamSuite4()->AEGP_DisposeStream(builtInParams);
-  if (!effect->effectOpacity->animatable() && effect->effectOpacity->value == pag::Opaque) {
+  if (effect->effectOpacity != nullptr && !effect->effectOpacity->animatable() &&
+      effect->effectOpacity->value == pag::Opaque) {
     delete effect->effectOpacity;
     effect->effectOpacity = nullptr;
   }

--- a/exporter/src/export/data/Mask.cpp
+++ b/exporter/src/export/data/Mask.cpp
@@ -53,6 +53,9 @@ std::vector<pag::MaskData*> GetMasks(const AEGP_LayerH& layerHandle) {
   for (int i = 0; i < numMask; i++) {
     AEGP_MaskRefH maskHandle = nullptr;
     Suites->MaskSuite6()->AEGP_GetLayerMaskByIndex(layerHandle, i, &maskHandle);
+    if (maskHandle == nullptr) {
+      continue;
+    }
     auto mask = GetMask(maskHandle);
     masks.push_back(mask);
     Suites->MaskSuite6()->AEGP_DisposeMask(maskHandle);

--- a/exporter/src/export/data/Shape.cpp
+++ b/exporter/src/export/data/Shape.cpp
@@ -60,27 +60,32 @@ static pag::ShapeElement* GetShapeGroup(const AEGP_StreamRefH& streamHandle) {
   Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByMatchname(
       PluginID, streamHandle, "ADBE Vector Transform Group", &transformStreamHandle);
   auto transform = new pag::ShapeTransform();
-  transform->anchorPoint =
-      GetProperty(transformStreamHandle, "ADBE Vector Anchor", AEStreamParser::PointParser);
-  transform->position =
-      GetProperty(transformStreamHandle, "ADBE Vector Position", AEStreamParser::PointParser);
-  transform->scale =
-      GetProperty(transformStreamHandle, "ADBE Vector Scale", AEStreamParser::ScaleParser);
-  transform->skew =
-      GetProperty(transformStreamHandle, "ADBE Vector Skew", AEStreamParser::FloatParser);
-  transform->skewAxis =
-      GetProperty(transformStreamHandle, "ADBE Vector Skew Axis", AEStreamParser::FloatParser);
-  transform->rotation =
-      GetProperty(transformStreamHandle, "ADBE Vector Rotation", AEStreamParser::FloatParser);
-  transform->opacity = GetProperty(transformStreamHandle, "ADBE Vector Group Opacity",
-                                   AEStreamParser::Opacity0_100Parser);
+  if (transformStreamHandle != nullptr) {
+    transform->anchorPoint =
+        GetProperty(transformStreamHandle, "ADBE Vector Anchor", AEStreamParser::PointParser);
+    transform->position =
+        GetProperty(transformStreamHandle, "ADBE Vector Position", AEStreamParser::PointParser);
+    transform->scale =
+        GetProperty(transformStreamHandle, "ADBE Vector Scale", AEStreamParser::ScaleParser);
+    transform->skew =
+        GetProperty(transformStreamHandle, "ADBE Vector Skew", AEStreamParser::FloatParser);
+    transform->skewAxis =
+        GetProperty(transformStreamHandle, "ADBE Vector Skew Axis", AEStreamParser::FloatParser);
+    transform->rotation =
+        GetProperty(transformStreamHandle, "ADBE Vector Rotation", AEStreamParser::FloatParser);
+    transform->opacity = GetProperty(transformStreamHandle, "ADBE Vector Group Opacity",
+                                     AEStreamParser::Opacity0_100Parser);
+    Suites->StreamSuite4()->AEGP_DisposeStream(transformStreamHandle);
+  }
   element->transform = transform;
-  Suites->StreamSuite4()->AEGP_DisposeStream(transformStreamHandle);
 
   int gradientIndex = 0;
   AEGP_StreamRefH contents = nullptr;
   Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByMatchname(PluginID, streamHandle,
                                                                  "ADBE Vectors Group", &contents);
+  if (contents == nullptr) {
+    return element;
+  }
   A_long numElements = 0;
   Suites->DynamicStreamSuite4()->AEGP_GetNumStreamsInGroup(contents, &numElements);
   for (A_long index = 0; index < numElements; index++) {
@@ -212,7 +217,11 @@ static void GetDashes(const AEGP_StreamRefH& streamHandle, pag::ShapeElement* el
       AEGP_StreamRefH childStreamHandle = nullptr;
       Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByIndex(PluginID, dashStreamHandle, index,
                                                                  &childStreamHandle);
+      if (childStreamHandle == nullptr) {
+        continue;
+      }
       if (IsStreamHidden(childStreamHandle)) {
+        Suites->StreamSuite4()->AEGP_DisposeStream(childStreamHandle);
         continue;
       }
       if (!IsStreamHidden(childStreamHandle)) {
@@ -360,8 +369,10 @@ static pag::ShapeElement* GetRepeater(const AEGP_StreamRefH& streamHandle) {
   AEGP_StreamRefH transform = nullptr;
   Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByMatchname(
       PluginID, streamHandle, "ADBE Vector Repeater Transform", &transform);
-  element->transform = GetRepeaterTransform(transform);
-  Suites->StreamSuite4()->AEGP_DisposeStream(transform);
+  if (transform != nullptr) {
+    element->transform = GetRepeaterTransform(transform);
+    Suites->StreamSuite4()->AEGP_DisposeStream(transform);
+  }
   return element;
 }
 
@@ -435,10 +446,16 @@ std::vector<pag::ShapeElement*> GetShapes(const AEGP_LayerH& layerHandle) {
   AEGP_StreamRefH layerStreamHandle = nullptr;
   Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefForLayer(PluginID, layerHandle,
                                                               &layerStreamHandle);
+  if (layerStreamHandle == nullptr) {
+    return contents;
+  }
   AEGP_StreamRefH rootStreamHandle = nullptr;
   Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByMatchname(
       PluginID, layerStreamHandle, "ADBE Root Vectors Group", &rootStreamHandle);
   Suites->StreamSuite4()->AEGP_DisposeStream(layerStreamHandle);
+  if (rootStreamHandle == nullptr) {
+    return contents;
+  }
   A_long numStreams = 0;
   Suites->DynamicStreamSuite4()->AEGP_GetNumStreamsInGroup(rootStreamHandle, &numStreams);
   for (A_long index = 0; index < numStreams; index++) {

--- a/exporter/src/export/data/Shape.cpp
+++ b/exporter/src/export/data/Shape.cpp
@@ -161,7 +161,7 @@ static pag::ShapeElement* GetShapePath(const AEGP_StreamRefH& streamHandle) {
   auto reversed = GetValue(streamHandle, "ADBE Vector Shape Direction",
                            AEStreamParser::ShapeDirectionReversedParser);
   element->shapePath = GetProperty(streamHandle, "ADBE Vector Shape", AEStreamParser::PathParser);
-  if (reversed) {
+  if (reversed && element->shapePath != nullptr) {
     if (element->shapePath->animatable()) {
       auto property = static_cast<pag::AnimatableProperty<pag::PathHandle>*>(element->shapePath);
       for (auto& keyframe : property->keyframes) {

--- a/exporter/src/export/data/TextProperty.cpp
+++ b/exporter/src/export/data/TextProperty.cpp
@@ -138,27 +138,29 @@ static pag::TextRangeSelector* GetTextRangeSelector(const AEGP_StreamRefH& strea
   AEGP_StreamRefH advancedStream = nullptr;
   Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByMatchname(
       PluginID, streamHandle, "ADBE Text Range Advanced", &advancedStream);
-  selector->units = GetValue(advancedStream, "ADBE Text Range Units",
-                             AEStreamParser::TextRangeSelectorUnitsParser);
-  selector->basedOn =
-      GetValue(advancedStream, "ADBE Text Range Type2", AEStreamParser::TextSelectorBasedOnParser);
-  selector->mode = GetProperty(advancedStream, "ADBE Text Selector Mode",
-                               AEStreamParser::TextSelectorModeParser);
-  selector->amount =
-      GetProperty(advancedStream, "ADBE Text Selector Max Amount", AEStreamParser::PercentParser);
-  selector->shape = GetValue(advancedStream, "ADBE Text Range Shape",
-                             AEStreamParser::TextRangeSelectorShapeParser);
-  selector->smoothness =
-      GetProperty(advancedStream, "ADBE Text Selector Smoothness", AEStreamParser::PercentParser);
-  selector->easeHigh =
-      GetProperty(advancedStream, "ADBE Text Levels Max Ease", AEStreamParser::PercentParser);
-  selector->easeLow =
-      GetProperty(advancedStream, "ADBE Text Levels Min Ease", AEStreamParser::PercentParser);
-  selector->randomizeOrder =
-      GetValue(advancedStream, "ADBE Text Randomize Order", AEStreamParser::BooleanParser);
-  selector->randomSeed =
-      GetProperty(advancedStream, "ADBE Text Random Seed", AEStreamParser::Uint16Parser);
-
+  if (advancedStream != nullptr) {
+    selector->units = GetValue(advancedStream, "ADBE Text Range Units",
+                               AEStreamParser::TextRangeSelectorUnitsParser);
+    selector->basedOn = GetValue(advancedStream, "ADBE Text Range Type2",
+                                 AEStreamParser::TextSelectorBasedOnParser);
+    selector->mode = GetProperty(advancedStream, "ADBE Text Selector Mode",
+                                 AEStreamParser::TextSelectorModeParser);
+    selector->amount =
+        GetProperty(advancedStream, "ADBE Text Selector Max Amount", AEStreamParser::PercentParser);
+    selector->shape = GetValue(advancedStream, "ADBE Text Range Shape",
+                               AEStreamParser::TextRangeSelectorShapeParser);
+    selector->smoothness =
+        GetProperty(advancedStream, "ADBE Text Selector Smoothness", AEStreamParser::PercentParser);
+    selector->easeHigh =
+        GetProperty(advancedStream, "ADBE Text Levels Max Ease", AEStreamParser::PercentParser);
+    selector->easeLow =
+        GetProperty(advancedStream, "ADBE Text Levels Min Ease", AEStreamParser::PercentParser);
+    selector->randomizeOrder =
+        GetValue(advancedStream, "ADBE Text Randomize Order", AEStreamParser::BooleanParser);
+    selector->randomSeed =
+        GetProperty(advancedStream, "ADBE Text Random Seed", AEStreamParser::Uint16Parser);
+    Suites->StreamSuite4()->AEGP_DisposeStream(advancedStream);
+  }
   return selector;
 }
 

--- a/exporter/src/export/data/TextProperty.cpp
+++ b/exporter/src/export/data/TextProperty.cpp
@@ -584,7 +584,7 @@ static void GetFirstBaseLineByPos(pag::TextDocumentHandle textDocument,
 
 static void GetFirstBaseLinesByPos(pag::Property<pag::TextDocumentHandle>* sourceText,
                                    std::vector<pag::TextAnimator*>* animators) {
-  if (animators == nullptr || animators->empty()) {
+  if (sourceText == nullptr || animators == nullptr || animators->empty()) {
     return;
   }
 

--- a/exporter/src/export/data/Transform2D.cpp
+++ b/exporter/src/export/data/Transform2D.cpp
@@ -29,21 +29,27 @@ pag::Transform2D* GetTransform2D(const AEGP_LayerH& layerHandle, float frameRate
   AEGP_StreamRefH streamHandle = nullptr;
   Suites->StreamSuite4()->AEGP_GetNewLayerStream(PluginID, layerHandle, AEGP_LayerStream_POSITION,
                                                  &streamHandle);
-  A_Boolean dimensionSeparated = 0;
-  Suites->DynamicStreamSuite4()->AEGP_AreDimensionsSeparated(streamHandle, &dimensionSeparated);
-  if (dimensionSeparated != 0) {
-    AEGP_StreamRefH xPosition = nullptr;
-    Suites->DynamicStreamSuite4()->AEGP_GetSeparationFollower(streamHandle, 0, &xPosition);
-    transform->xPosition = GetProperty(xPosition, AEStreamParser::FloatParser);
-    Suites->StreamSuite4()->AEGP_DisposeStream(xPosition);
-    AEGP_StreamRefH yPosition = nullptr;
-    Suites->DynamicStreamSuite4()->AEGP_GetSeparationFollower(streamHandle, 1, &yPosition);
-    transform->yPosition = GetProperty(yPosition, AEStreamParser::FloatParser);
-    Suites->StreamSuite4()->AEGP_DisposeStream(yPosition);
-  } else {
-    transform->position = GetProperty(streamHandle, AEStreamParser::PointParser);
+  if (streamHandle != nullptr) {
+    A_Boolean dimensionSeparated = 0;
+    Suites->DynamicStreamSuite4()->AEGP_AreDimensionsSeparated(streamHandle, &dimensionSeparated);
+    if (dimensionSeparated != 0) {
+      AEGP_StreamRefH xPosition = nullptr;
+      Suites->DynamicStreamSuite4()->AEGP_GetSeparationFollower(streamHandle, 0, &xPosition);
+      if (xPosition != nullptr) {
+        transform->xPosition = GetProperty(xPosition, AEStreamParser::FloatParser);
+        Suites->StreamSuite4()->AEGP_DisposeStream(xPosition);
+      }
+      AEGP_StreamRefH yPosition = nullptr;
+      Suites->DynamicStreamSuite4()->AEGP_GetSeparationFollower(streamHandle, 1, &yPosition);
+      if (yPosition != nullptr) {
+        transform->yPosition = GetProperty(yPosition, AEStreamParser::FloatParser);
+        Suites->StreamSuite4()->AEGP_DisposeStream(yPosition);
+      }
+    } else {
+      transform->position = GetProperty(streamHandle, AEStreamParser::PointParser);
+    }
+    Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
   }
-  Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
   transform->anchorPoint =
       GetProperty(layerHandle, AEGP_LayerStream_ANCHORPOINT, AEStreamParser::PointParser);
   QVariantMap map;

--- a/exporter/src/export/data/Transform3D.cpp
+++ b/exporter/src/export/data/Transform3D.cpp
@@ -119,7 +119,7 @@ static pag::Property<pag::Point3D>* GetOrientationKeyframe(const AEGP_LayerH& la
                                                            float frameRate) {
   auto orientation =
       GetProperty(layerHandle, AEGP_LayerStream_ORIENTATION, AEStreamParser::Point3DParser);
-  if (!orientation->animatable()) {
+  if (orientation == nullptr || !orientation->animatable()) {
     return orientation;
   }
 
@@ -129,6 +129,9 @@ static pag::Property<pag::Point3D>* GetOrientationKeyframe(const AEGP_LayerH& la
   AEGP_StreamRefH streamHandle = nullptr;
   Suites->StreamSuite4()->AEGP_GetNewLayerStream(PluginID, layerHandle,
                                                  AEGP_LayerStream_ORIENTATION, &streamHandle);
+  if (streamHandle == nullptr) {
+    return orientation;
+  }
   std::vector<AEGP_KeyframeIndex> list = {};
   for (auto keyframe :
        static_cast<pag::AnimatableProperty<pag::Point3D>*>(orientation)->keyframes) {
@@ -164,27 +167,35 @@ pag::Transform3D* GetTransform3D(const AEGP_LayerH& layerHandle, float frameRate
   AEGP_StreamRefH streamHandle = nullptr;
   Suites->StreamSuite4()->AEGP_GetNewLayerStream(PluginID, layerHandle, AEGP_LayerStream_POSITION,
                                                  &streamHandle);
-  A_Boolean dimensionSeparated = 0;
-  Suites->DynamicStreamSuite4()->AEGP_AreDimensionsSeparated(streamHandle, &dimensionSeparated);
-  if (dimensionSeparated != 0) {
-    AEGP_StreamRefH xPosition = nullptr;
-    Suites->DynamicStreamSuite4()->AEGP_GetSeparationFollower(streamHandle, 0, &xPosition);
-    transform->xPosition = GetProperty(xPosition, AEStreamParser::FloatParser);
-    Suites->StreamSuite4()->AEGP_DisposeStream(xPosition);
+  if (streamHandle != nullptr) {
+    A_Boolean dimensionSeparated = 0;
+    Suites->DynamicStreamSuite4()->AEGP_AreDimensionsSeparated(streamHandle, &dimensionSeparated);
+    if (dimensionSeparated != 0) {
+      AEGP_StreamRefH xPosition = nullptr;
+      Suites->DynamicStreamSuite4()->AEGP_GetSeparationFollower(streamHandle, 0, &xPosition);
+      if (xPosition != nullptr) {
+        transform->xPosition = GetProperty(xPosition, AEStreamParser::FloatParser);
+        Suites->StreamSuite4()->AEGP_DisposeStream(xPosition);
+      }
 
-    AEGP_StreamRefH yPosition = nullptr;
-    Suites->DynamicStreamSuite4()->AEGP_GetSeparationFollower(streamHandle, 1, &yPosition);
-    transform->yPosition = GetProperty(yPosition, AEStreamParser::FloatParser);
-    Suites->StreamSuite4()->AEGP_DisposeStream(yPosition);
+      AEGP_StreamRefH yPosition = nullptr;
+      Suites->DynamicStreamSuite4()->AEGP_GetSeparationFollower(streamHandle, 1, &yPosition);
+      if (yPosition != nullptr) {
+        transform->yPosition = GetProperty(yPosition, AEStreamParser::FloatParser);
+        Suites->StreamSuite4()->AEGP_DisposeStream(yPosition);
+      }
 
-    AEGP_StreamRefH zPosition = nullptr;
-    Suites->DynamicStreamSuite4()->AEGP_GetSeparationFollower(streamHandle, 1, &zPosition);
-    transform->zPosition = GetProperty(zPosition, AEStreamParser::FloatParser);
-    Suites->StreamSuite4()->AEGP_DisposeStream(zPosition);
-  } else {
-    transform->position = GetProperty(streamHandle, AEStreamParser::Point3DParser);
+      AEGP_StreamRefH zPosition = nullptr;
+      Suites->DynamicStreamSuite4()->AEGP_GetSeparationFollower(streamHandle, 2, &zPosition);
+      if (zPosition != nullptr) {
+        transform->zPosition = GetProperty(zPosition, AEStreamParser::FloatParser);
+        Suites->StreamSuite4()->AEGP_DisposeStream(zPosition);
+      }
+    } else {
+      transform->position = GetProperty(streamHandle, AEStreamParser::Point3DParser);
+    }
+    Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
   }
-  Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
   transform->anchorPoint =
       GetProperty(layerHandle, AEGP_LayerStream_ANCHORPOINT, AEStreamParser::Point3DParser);
   transform->scale =

--- a/exporter/src/export/sequence/VideoSequence.cpp
+++ b/exporter/src/export/sequence/VideoSequence.cpp
@@ -421,6 +421,12 @@ static void AdjustMainCompositionParam(pag::VectorComposition* newComposition,
     transform->position->value.x *= factorSize;
     transform->position->value.y *= factorSize;
   }
+  if (transform->xPosition != nullptr) {
+    transform->xPosition->value *= factorSize;
+  }
+  if (transform->yPosition != nullptr) {
+    transform->yPosition->value *= factorSize;
+  }
 
   composition->width = sequence->width;
   composition->height = sequence->height;

--- a/exporter/src/export/sequence/VideoSequence.cpp
+++ b/exporter/src/export/sequence/VideoSequence.cpp
@@ -413,10 +413,14 @@ static void AdjustMainCompositionParam(pag::VectorComposition* newComposition,
   newComposition->height = static_cast<int>(floor(newComposition->height * factorSize));
 
   auto& transform = newComposition->layers[0]->transform;
-  transform->anchorPoint->value.x *= factorSize;
-  transform->anchorPoint->value.y *= factorSize;
-  transform->position->value.x *= factorSize;
-  transform->position->value.y *= factorSize;
+  if (transform->anchorPoint != nullptr) {
+    transform->anchorPoint->value.x *= factorSize;
+    transform->anchorPoint->value.y *= factorSize;
+  }
+  if (transform->position != nullptr) {
+    transform->position->value.x *= factorSize;
+    transform->position->value.y *= factorSize;
+  }
 
   composition->width = sequence->width;
   composition->height = sequence->height;

--- a/exporter/src/export/stream/StreamProperty.h
+++ b/exporter/src/export/stream/StreamProperty.h
@@ -194,7 +194,9 @@ pag::Property<T>* GetProperty(AEGP_StreamRefH groupStreamHandle, int index, Stre
   Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByIndex(PluginID, groupStreamHandle, index,
                                                              &streamHandle);
   auto result = GetProperty(streamHandle, parser, map, dimensionality);
-  Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  if (streamHandle != nullptr) {
+    Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  }
   return result;
 }
 
@@ -209,7 +211,9 @@ pag::Property<T>* GetProperty(AEGP_StreamRefH groupStreamHandle, const A_char* k
   Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByMatchname(PluginID, groupStreamHandle, key,
                                                                  &streamHandle);
   auto result = GetProperty(streamHandle, parser, map, dimensionality);
-  Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  if (streamHandle != nullptr) {
+    Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  }
   return result;
 }
 
@@ -223,7 +227,9 @@ pag::Property<T>* GetProperty(const AEGP_LayerH& layerHandle, AEGP_LayerStream l
   AEGP_StreamRefH streamHandle = nullptr;
   Suites->StreamSuite4()->AEGP_GetNewLayerStream(PluginID, layerHandle, layerStream, &streamHandle);
   auto result = GetProperty(streamHandle, parser, map, dimensionality);
-  Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  if (streamHandle != nullptr) {
+    Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  }
   return result;
 }
 
@@ -237,7 +243,9 @@ pag::Property<T>* GetProperty(const AEGP_MaskRefH& maskHandle, AEGP_MaskStream m
   AEGP_StreamRefH streamHandle = nullptr;
   Suites->StreamSuite4()->AEGP_GetNewMaskStream(PluginID, maskHandle, maskStream, &streamHandle);
   auto result = GetProperty(streamHandle, parser, map, dimensionality);
-  Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  if (streamHandle != nullptr) {
+    Suites->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  }
   return result;
 }
 

--- a/exporter/src/export/stream/StreamValue.h
+++ b/exporter/src/export/stream/StreamValue.h
@@ -122,7 +122,9 @@ T GetValue(AEGP_StreamRefH groupStreamHandle, int index, StreamParser<T> parser,
   GetSuites()->DynamicStreamSuite4()->AEGP_GetNewStreamRefByIndex(GetPluginID(), groupStreamHandle,
                                                                   index, &streamHandle);
   auto result = GetValue(streamHandle, parser, map);
-  GetSuites()->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  if (streamHandle != nullptr) {
+    GetSuites()->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  }
   return result;
 }
 
@@ -136,7 +138,9 @@ T GetValue(AEGP_StreamRefH groupStreamHandle, const A_char* key, StreamParser<T>
   GetSuites()->DynamicStreamSuite4()->AEGP_GetNewStreamRefByMatchname(
       GetPluginID(), groupStreamHandle, key, &streamHandle);
   auto result = GetValue(streamHandle, parser, map);
-  GetSuites()->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  if (streamHandle != nullptr) {
+    GetSuites()->StreamSuite4()->AEGP_DisposeStream(streamHandle);
+  }
   return result;
 }
 

--- a/exporter/src/utils/AEHelper.cpp
+++ b/exporter/src/utils/AEHelper.cpp
@@ -490,9 +490,13 @@ void SelectLayer(const AEGP_ItemH& itemHandle, const AEGP_LayerH& layerHandle) {
   if (hasLayer) {
     Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefForLayer(PluginID, layerHandle,
                                                                 &streamHandle);
-    collectionItem.type = AEGP_CollectionItemType_LAYER;
-    collectionItem.u.layer.layerH = layerHandle;
-    collectionItem.stream_refH = streamHandle;
+    if (streamHandle == nullptr) {
+      hasLayer = false;
+    } else {
+      collectionItem.type = AEGP_CollectionItemType_LAYER;
+      collectionItem.u.layer.layerH = layerHandle;
+      collectionItem.stream_refH = streamHandle;
+    }
   }
 
   Suites->ItemSuite6()->AEGP_SelectItem(itemHandle, true, true);


### PR DESCRIPTION
## What
Fix exporter plugin crashes that happened when After Effects stream APIs returned null handles or properties (e.g. on broken/edge-case projects).

## Why
`GetProperty` / `GetValue` previously dereferenced unchecked stream handles, crashing AE when the SDK returned null. Callers across the exporter assumed the result was always non-null.

## How
- Bottom-up: `StreamProperty.h` / `StreamValue.h` now return nullptr / `T{}` when the underlying stream is null, instead of crashing.
- Top-down: 13 caller sites that dereferenced the result without a guard were updated. Includes a separate fix for `Transform3D` z-axis using the wrong separation-follower index.
- Resource lifecycle: `AEGP_StreamRefH` dispose paths cover all early-return branches; one `Property` leak in `GetDisplacementMapEffect` fixed.

## Risk
Behavior on the success path is unchanged. On null/failure paths the exporter now skips the affected field instead of crashing.