### PR TITLE
Fix GCC 12 incomplete type error on PAGScene displayList.

### DIFF
--- a/include/pagx/PAGScene.h
+++ b/include/pagx/PAGScene.h
@@ -172,7 +172,7 @@ class PAGScene : public std::enable_shared_from_this<PAGScene> {
   std::shared_ptr<PAGComposition> _rootComposition = nullptr;
   std::unordered_map<Animation*, std::shared_ptr<PAGTimeline>> timelinesByAnimation = {};
 
-  std::unique_ptr<tgfx::DisplayList> displayList = {};
+  std::unique_ptr<tgfx::DisplayList> displayList;
 
   std::unique_ptr<PAGDisplayOptions> displayOptions = nullptr;
 


### PR DESCRIPTION
GCC 12 在编译任何包含 include/pagx/PAGScene.h 的翻译单元时，会评估 std::unique_ptr<tgfx::DisplayList> displayList = {}; 这个非静态数据成员默认初始化器（NSDMI）的异常清理路径，因而实例化 ~unique_ptr<tgfx::DisplayList>()。default_delete 内部的 static_assert(sizeof(_Tp) > 0) 在 tgfx::DisplayList 仅前向声明时触发，导致 PAGLayer.cpp 等文件编译失败。Apple Clang 不在 NSDMI 处强制实例化析构链，所以问题只在 Linux GCC 12 暴露。

去掉 displayList 的 NSDMI 即可，unique_ptr 默认构造已是空指针，语义不变，仅消除头文件中触发 unique_ptr 析构实例化的路径。本地构造、销毁、make_unique 都在 PAGScene.cpp 里，那里已包含 tgfx/layers/DisplayList.h 完整定义，不受影响。