### PR TITLE
Fix Android native memory leak when reusing PAGView for different VideoComposition files.

### DIFF
--- a/src/platform/android/HardwareDecoder.cpp
+++ b/src/platform/android/HardwareDecoder.cpp
@@ -53,6 +53,13 @@ HardwareDecoder::~HardwareDecoder() {
     delete bufferInfo;
     bufferInfo = nullptr;
   }
+  if (videoSurface.get() != nullptr) {
+    JNIEnvironment environment;
+    auto env = environment.current();
+    if (env != nullptr) {
+      JVideoSurface::Release(env, videoSurface.get());
+    }
+  }
 }
 
 bool HardwareDecoder::initDecoder(const VideoFormat& format) {
@@ -105,15 +112,17 @@ bool HardwareDecoder::initDecoder(const VideoFormat& format) {
     return false;
   }
 
-  auto videoSurface = JVideoSurface::Make(env, format.width, format.height);
-  if (videoSurface == nullptr) {
+  auto videoSurfaceLocal = JVideoSurface::Make(env, format.width, format.height);
+  if (videoSurfaceLocal == nullptr) {
     AMediaFormat_delete(mediaFormat);
     AMediaCodec_delete(videoDecoder);
     videoDecoder = nullptr;
     return false;
   }
+  videoSurface = videoSurfaceLocal;
+  env->DeleteLocalRef(videoSurfaceLocal);
 
-  imageReader = JVideoSurface::GetImageReader(env, videoSurface);
+  imageReader = JVideoSurface::GetImageReader(env, videoSurface.get());
   if (imageReader == nullptr) {
     AMediaFormat_delete(mediaFormat);
     AMediaCodec_delete(videoDecoder);

--- a/src/platform/android/HardwareDecoder.h
+++ b/src/platform/android/HardwareDecoder.h
@@ -56,6 +56,7 @@ class HardwareDecoder : public VideoDecoder {
   bool disableFlush = true;
 
   std::shared_ptr<tgfx::SurfaceTextureReader> imageReader = nullptr;
+  Global<jobject> videoSurface = {};
   AMediaCodec* videoDecoder = nullptr;
   ANativeWindow* nativeWindow = nullptr;
   ssize_t lastOutputBufferIndex = -1;

--- a/src/platform/android/JVideoSurface.cpp
+++ b/src/platform/android/JVideoSurface.cpp
@@ -35,6 +35,17 @@ std::shared_ptr<tgfx::SurfaceTextureReader> JVideoSurface::GetImageReader(JNIEnv
   return reader->get();
 }
 
+void JVideoSurface::Release(JNIEnv* env, jobject videoSurface) {
+  if (videoSurface == nullptr) {
+    return;
+  }
+  auto reader =
+      reinterpret_cast<JVideoSurface*>(env->GetLongField(videoSurface, VideoSurface_nativeContext));
+  if (reader != nullptr) {
+    reader->clear();
+  }
+}
+
 static Global<jclass> VideoSurfaceClass;
 
 static jmethodID VideoSurface_Make;

--- a/src/platform/android/JVideoSurface.h
+++ b/src/platform/android/JVideoSurface.h
@@ -33,7 +33,8 @@ class JVideoSurface {
    * code when the C++ owner of the videoSurface jobject (typically HardwareDecoder) is about to be
    * destroyed; otherwise the SurfaceTexture and its underlying GPU resources stay alive until the
    * Java GC eventually reclaims the Java VideoSurface, which never happens while the native
-   * SurfaceTexture still holds a global reference to the Java SurfaceTexture that listens on it.
+   * SurfaceTexture still holds a global reference to the Java android.graphics.SurfaceTexture that
+   * has the Java VideoSurface registered as its OnFrameAvailableListener.
    */
   static void Release(JNIEnv* env, jobject videoSurface);
 

--- a/src/platform/android/JVideoSurface.h
+++ b/src/platform/android/JVideoSurface.h
@@ -27,6 +27,16 @@ class JVideoSurface {
   static std::shared_ptr<tgfx::SurfaceTextureReader> GetImageReader(JNIEnv* env,
                                                                     jobject videoSurface);
 
+  /**
+   * Releases the SurfaceTextureReader held by the Java VideoSurface to break the
+   * SurfaceTextureReader <-> Java VideoSurface circular reference. This must be called from native
+   * code when the C++ owner of the videoSurface jobject (typically HardwareDecoder) is about to be
+   * destroyed; otherwise the SurfaceTexture and its underlying GPU resources stay alive until the
+   * Java GC eventually reclaims the Java VideoSurface, which never happens while the native
+   * SurfaceTexture still holds a global reference to the Java SurfaceTexture that listens on it.
+   */
+  static void Release(JNIEnv* env, jobject videoSurface);
+
   explicit JVideoSurface(std::shared_ptr<tgfx::SurfaceTextureReader> imageReader)
       : imageReader(imageReader) {
   }


### PR DESCRIPTION
修复在 Android 上复用同一个 PAGView 加载不同 VideoComposition PAG 文件时的 native 内存泄漏。

根因：HardwareDecoder 持有 Java VideoSurface 的全局引用，而 Java VideoSurface 通过 nativeContext 间接持有 SurfaceTextureReader，SurfaceTextureReader 又持有 Java SurfaceTexture 的全局引用，且 Java VideoSurface 被注册为该 SurfaceTexture 的 OnFrameAvailableListener，形成循环引用，导致 Java GC 无法回收，SurfaceTexture 及其底层 GPU 资源持续存活。

修复：在 JVideoSurface 上新增 Release 接口，由 HardwareDecoder 析构时调用，主动清空 Java VideoSurface 持有的 SurfaceTextureReader，断开循环。

变更覆盖 HardwareDecoder::Make 中的所有错误路径，确保部分初始化失败时也能正确释放。