### PR TITLE
Update tgfx to b3f43154 and replace allowZoomBlur with TileUpdateMode enum.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "9fee1c2e08223a5993554425088a55cbd3d35390",
+        "commit": "b3f43154ab58d5b75c7b9f4d20aad7c9aa0a851c",
         "dir": "third_party/tgfx"
       },
       {

--- a/include/pagx/PAGDisplayOptions.h
+++ b/include/pagx/PAGDisplayOptions.h
@@ -52,6 +52,36 @@ enum class PAGRenderMode {
 };
 
 /**
+ * PAGTileUpdateMode defines how missing tiles are produced in tiled rendering mode when the
+ * zoomScale changes or when the viewport scrolls into uncached regions.
+ */
+enum class PAGTileUpdateMode {
+  /**
+   * Missing tiles are rasterized at the current zoomScale within the same frame. Cached tiles from
+   * other zoom scales are never reused. This produces the highest visual fidelity but may cause
+   * frame drops during heavy zoom or pan. This is the default mode.
+   */
+  Immediate,
+
+  /**
+   * For each missing tile, the display list first tries to reuse a cached tile from another zoom
+   * scale as a temporary fallback (producing brief zoom blur). When no such cache is available, the
+   * tile is rasterized at the current zoomScale within the same frame to keep the result correct.
+   * Use this mode for a smoother visual transition during zoom while still guaranteeing visible
+   * content on every frame.
+   */
+  Smooth,
+
+  /**
+   * The number of tiles rasterized per frame is capped by setMaxTilesRefinedPerFrame(). Tiles
+   * beyond the cap are filled with cached content from other zoom scales, or with the background
+   * color when no fallback is available. This keeps the frame rate stable during heavy zoom or pan
+   * at the cost of longer-lasting blur or background-colored regions.
+   */
+  Fast,
+};
+
+/**
  * PAGDisplayOptions exposes display-list rendering options owned by a PAGScene. Use
  * PAGScene::getDisplayOptions() to obtain the options and PAGScene::draw() to render with them.
  */
@@ -132,23 +162,25 @@ class PAGDisplayOptions {
   void setMaxTileCount(int count);
 
   /**
-   * Returns whether temporary blurred fallback tiles are allowed while zooming.
+   * Returns the tile update mode used in tiled rendering mode.
    */
-  bool getAllowZoomBlur() const;
+  PAGTileUpdateMode getTileUpdateMode() const;
 
   /**
-   * Sets whether temporary blurred fallback tiles are allowed while zooming in tiled mode.
-   * @param allow true to allow fallback tiles from other zoom levels.
+   * Sets the tile update mode used in tiled rendering mode. This setting only applies in tiled
+   * rendering mode and controls how missing tiles are produced when the zoomScale changes. The
+   * default is PAGTileUpdateMode::Immediate.
+   * @param mode the tile update strategy to use.
    */
-  void setAllowZoomBlur(bool allow);
+  void setTileUpdateMode(PAGTileUpdateMode mode);
 
   /**
-   * Returns the maximum number of zoom-blur fallback tiles refined per frame.
+   * Returns the maximum number of tiles refined per frame in tiled rendering mode.
    */
   int getMaxTilesRefinedPerFrame() const;
 
   /**
-   * Sets the maximum number of zoom-blur fallback tiles refined per frame.
+   * Sets the maximum number of tiles refined per frame in tiled rendering mode.
    * @param count maximum number of tiles to refine each frame.
    */
   void setMaxTilesRefinedPerFrame(int count);

--- a/playground/pagx-viewer/src/cpp/PAGXView.cpp
+++ b/playground/pagx-viewer/src/cpp/PAGXView.cpp
@@ -86,7 +86,7 @@ static std::shared_ptr<Data> GetPagxDataFromEmscripten(const val& emscriptenData
 
 PAGXView::PAGXView(const std::string& canvasID) : canvasID(canvasID) {
   displayList.setRenderMode(tgfx::RenderMode::Tiled);
-  displayList.setAllowZoomBlur(true);
+  displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
   displayList.setMaxTileCount(512);
   displayList.setMaxTilesRefinedPerFrame(currentMaxTilesRefinedPerFrame);
 }

--- a/src/pagx/PAGDisplayOptions.cpp
+++ b/src/pagx/PAGDisplayOptions.cpp
@@ -44,6 +44,18 @@ Color ToPAGX(const tgfx::Color& color) {
   return {color.red, color.green, color.blue, color.alpha, ColorSpace::SRGB};
 }
 
+PAGTileUpdateMode ToPAGX(tgfx::TileUpdateMode mode) {
+  switch (mode) {
+    case tgfx::TileUpdateMode::Immediate:
+      return PAGTileUpdateMode::Immediate;
+    case tgfx::TileUpdateMode::Smooth:
+      return PAGTileUpdateMode::Smooth;
+    case tgfx::TileUpdateMode::Fast:
+      return PAGTileUpdateMode::Fast;
+  }
+  return PAGTileUpdateMode::Immediate;
+}
+
 }  // namespace
 
 PAGDisplayOptions::PAGDisplayOptions(PAGScene* scene) : scene(scene) {
@@ -131,15 +143,16 @@ void PAGDisplayOptions::setMaxTileCount(int count) {
   }
 }
 
-bool PAGDisplayOptions::getAllowZoomBlur() const {
+PAGTileUpdateMode PAGDisplayOptions::getTileUpdateMode() const {
   auto displayList = getDisplayList();
-  return displayList != nullptr ? displayList->allowZoomBlur() : false;
+  return displayList != nullptr ? ToPAGX(displayList->tileUpdateMode())
+                                : PAGTileUpdateMode::Immediate;
 }
 
-void PAGDisplayOptions::setAllowZoomBlur(bool allow) {
+void PAGDisplayOptions::setTileUpdateMode(PAGTileUpdateMode mode) {
   auto displayList = getDisplayList();
   if (displayList != nullptr) {
-    displayList->setAllowZoomBlur(allow);
+    displayList->setTileUpdateMode(ToTGFX(mode));
   }
 }
 

--- a/src/renderer/ToTGFX.cpp
+++ b/src/renderer/ToTGFX.cpp
@@ -331,6 +331,18 @@ tgfx::RenderMode ToTGFX(PAGRenderMode renderMode) {
   return tgfx::RenderMode::Partial;
 }
 
+tgfx::TileUpdateMode ToTGFX(PAGTileUpdateMode mode) {
+  switch (mode) {
+    case PAGTileUpdateMode::Immediate:
+      return tgfx::TileUpdateMode::Immediate;
+    case PAGTileUpdateMode::Smooth:
+      return tgfx::TileUpdateMode::Smooth;
+    case PAGTileUpdateMode::Fast:
+      return tgfx::TileUpdateMode::Fast;
+  }
+  return tgfx::TileUpdateMode::Immediate;
+}
+
 tgfx::Matrix3D ToTGFX3D(const Matrix3D& matrix3D) {
   tgfx::Matrix3D m = {};
   for (int r = 0; r < 4; r++) {

--- a/src/renderer/ToTGFX.h
+++ b/src/renderer/ToTGFX.h
@@ -58,6 +58,7 @@ enum class StrokeAlign;
 enum class MergePathOp;
 enum class LayerMaskType;
 enum class RenderMode;
+enum class TileUpdateMode;
 enum class RepeaterOrder;
 enum class SelectorUnit;
 enum class SelectorShape;
@@ -112,6 +113,8 @@ tgfx::MipmapMode ToTGFX(MipmapMode mode);
 tgfx::ScaleMode ToTGFX(ScaleMode mode);
 
 tgfx::RenderMode ToTGFX(PAGRenderMode renderMode);
+
+tgfx::TileUpdateMode ToTGFX(PAGTileUpdateMode mode);
 
 tgfx::Matrix3D ToTGFX3D(const Matrix3D& matrix3D);
 

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -6570,8 +6570,8 @@ PAGX_TEST(PAGXTest, DisplayOptionsSetGet) {
   options->setMaxTileCount(64);
   EXPECT_EQ(options->getMaxTileCount(), 64);
 
-  options->setAllowZoomBlur(true);
-  EXPECT_TRUE(options->getAllowZoomBlur());
+  options->setTileUpdateMode(pagx::PAGTileUpdateMode::Smooth);
+  EXPECT_EQ(options->getTileUpdateMode(), pagx::PAGTileUpdateMode::Smooth);
 
   options->setMaxTilesRefinedPerFrame(8);
   EXPECT_EQ(options->getMaxTilesRefinedPerFrame(), 8);


### PR DESCRIPTION
## Summary

Updates tgfx dependency to `b3f43154ab58d5b75c7b9f4d20aad7c9aa0a851c` and adapts to the interface change where `DisplayList::allowZoomBlur(bool)` was replaced by the `TileUpdateMode` enum (Immediate / Smooth / Fast).

## Changes

- `DEPS`: bump tgfx commit
- `include/pagx/PAGDisplayOptions.h`: add public `PAGTileUpdateMode` enum; replace `getAllowZoomBlur/setAllowZoomBlur(bool)` with `getTileUpdateMode/setTileUpdateMode(PAGTileUpdateMode)`
- `src/renderer/ToTGFX.{h,cpp}`: add `ToTGFX(PAGTileUpdateMode)` conversion
- `src/pagx/PAGDisplayOptions.cpp`: add `ToPAGX(tgfx::TileUpdateMode)`; rewrite the two accessors
- `playground/pagx-viewer`: map previous `setAllowZoomBlur(true)` to `setTileUpdateMode(Smooth)`
- `test/src/PAGXTest.cpp`: update the corresponding test case

## Test

`PAGFullTest` compiles successfully.