### PR TITLE
Fix Swift 6 strict concurrency crash in PAGView and PAGImageView listeners.

### DIFF
--- a/src/platform/ios/PAGImageView.h
+++ b/src/platform/ios/PAGImageView.h
@@ -25,30 +25,28 @@
 
 @optional
 /**
- * Notifies the beginning of the animation. It can be called from either the UI thread or the thread
- * that calls the play method.
+ * Notifies the beginning of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationStart:(PAGImageView* _Nonnull)pagView;
 
 /**
- * Notifies the end of the animation. It can only be called from the UI thread.
+ * Notifies the end of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationEnd:(PAGImageView* _Nonnull)pagView;
 
 /**
- * Notifies the cancellation of the animation. It can be called from either the UI thread or the
- * thread that calls the stop method.
+ * Notifies the cancellation of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationCancel:(PAGImageView* _Nonnull)pagView;
 
 /**
- * Notifies the repetition of the animation. It can only be called from the UI thread.
+ * Notifies the repetition of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationRepeat:(PAGImageView* _Nonnull)pagView;
 
 /**
- * Notifies another frame of the animation has occurred. It may be called from an arbitrary
- * thread if the animation is running asynchronously.
+ * Notifies another frame of the animation has occurred. This will only be called from the UI
+ * thread.
  */
 - (void)onAnimationUpdate:(PAGImageView* _Nonnull)pagView;
 

--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -67,6 +67,9 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
 
 @end
 
+@interface PAGImageView () <PAGAnimatorUpdater, PAGAnimatorListener>
+@end
+
 @implementation PAGImageView {
   NSString* filePath;
   PAGAnimator* animator;
@@ -82,6 +85,8 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
   NSMutableDictionary<NSNumber*, UIImage*>* imagesMap;
   std::mutex imageViewLock;
   CVPixelBufferPoolRef diskBufferPool;
+  NSHashTable* listeners;
+  std::mutex listenerLock;
 }
 
 @synthesize memoryCacheEnabled = _memoryCacheEnabled;
@@ -109,6 +114,8 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
   numFrames = 0;
   self.backgroundColor = [UIColor clearColor];
   animator = [[PAGAnimator alloc] initWithUpdater:(id<PAGAnimatorUpdater>)self];
+  listeners = [[NSHashTable weakObjectsHashTable] retain];
+  [animator addListener:self];
 
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(applicationDidBecomeActive:)
@@ -127,6 +134,7 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
   if (filePath != nil) {
     [filePath release];
   }
+  [listeners release];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [super dealloc];
 }
@@ -494,11 +502,72 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
 }
 
 - (void)addListener:(id<PAGImageViewListener>)listener {
-  [animator addListener:(id<PAGAnimatorListener>)listener];
+  if (listener == nil) {
+    return;
+  }
+  std::lock_guard<std::mutex> autoLock(listenerLock);
+  [listeners addObject:listener];
 }
 
 - (void)removeListener:(id<PAGImageViewListener>)listener {
-  [animator removeListener:(id<PAGAnimatorListener>)listener];
+  if (listener == nil) {
+    return;
+  }
+  std::lock_guard<std::mutex> autoLock(listenerLock);
+  [listeners removeObject:listener];
+}
+
+#pragma mark - PAGAnimatorListener
+
+- (void)onAnimationStart:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationStart:)];
+}
+
+- (void)onAnimationEnd:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationEnd:)];
+}
+
+- (void)onAnimationCancel:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationCancel:)];
+}
+
+- (void)onAnimationRepeat:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationRepeat:)];
+}
+
+- (void)onAnimationUpdate:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationUpdate:)];
+}
+
+- (void)dispatchListenerEvent:(SEL)selector {
+  if ([NSThread isMainThread]) {
+    [self performListenerEventOnMainThread:selector];
+    return;
+  }
+  // Retain self before crossing threads to keep the receiver alive until the
+  // dispatched block finishes notifying listeners on the main thread.
+  [self retain];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self performListenerEventOnMainThread:selector];
+    [self release];
+  });
+}
+
+- (void)performListenerEventOnMainThread:(SEL)selector {
+  NSArray* copiedListeners = nil;
+  {
+    std::lock_guard<std::mutex> autoLock(listenerLock);
+    copiedListeners = [[listeners allObjects] retain];
+  }
+  for (id<PAGImageViewListener> listener in copiedListeners) {
+    if ([listener respondsToSelector:selector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+      [listener performSelector:selector withObject:self];
+#pragma clang diagnostic pop
+    }
+  }
+  [copiedListeners release];
 }
 
 - (int)repeatCount {

--- a/src/platform/ios/PAGView.h
+++ b/src/platform/ios/PAGView.h
@@ -26,30 +26,28 @@
 
 @optional
 /**
- * Notifies the beginning of the animation. It can be called from either the UI thread or the thread
- * that calls the play method.
+ * Notifies the beginning of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationStart:(PAGView*)pagView;
 
 /**
- * Notifies the end of the animation. It can only be called from the UI thread.
+ * Notifies the end of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationEnd:(PAGView*)pagView;
 
 /**
- * Notifies the cancellation of the animation. It can be called from either the UI thread or the
- * thread that calls the stop method.
+ * Notifies the cancellation of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationCancel:(PAGView*)pagView;
 
 /**
- * Notifies the repetition of the animation. It can only be called from the UI thread.
+ * Notifies the repetition of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationRepeat:(PAGView*)pagView;
 
 /**
- * Notifies another frame of the animation has occurred. It may be called from an arbitrary
- * thread if the animation is running asynchronously.
+ * Notifies another frame of the animation has occurred. This will only be called from the UI
+ * thread.
  */
 - (void)onAnimationUpdate:(PAGView*)pagView;
 

--- a/src/platform/ios/PAGView.mm
+++ b/src/platform/ios/PAGView.mm
@@ -22,6 +22,9 @@
 #import "platform/cocoa/private/PAGAnimator.h"
 #import "platform/ios/private/GPUDrawable.h"
 
+@interface PAGView () <PAGAnimatorUpdater, PAGAnimatorListener>
+@end
+
 @implementation PAGView {
   PAGPlayer* pagPlayer;
   PAGSurface* pagSurface;
@@ -29,6 +32,8 @@
   PAGAnimator* animator;
   BOOL _isVisible;
   std::mutex lock;
+  NSHashTable* listeners;
+  std::mutex listenerLock;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -45,6 +50,8 @@
   self.backgroundColor = [UIColor clearColor];
   pagPlayer = [[PAGPlayer alloc] init];
   animator = [[PAGAnimator alloc] initWithUpdater:(id<PAGAnimatorUpdater>)self];
+  listeners = [[NSHashTable weakObjectsHashTable] retain];
+  [animator addListener:self];
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(applicationDidBecomeActive:)
                                                name:UIApplicationDidBecomeActiveNotification
@@ -65,6 +72,7 @@
   [pagPlayer release];
   [pagSurface release];
   [filePath release];
+  [listeners release];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [super dealloc];
 }
@@ -144,11 +152,72 @@
 }
 
 - (void)addListener:(id<PAGViewListener>)listener {
-  [animator addListener:(id<PAGAnimatorListener>)listener];
+  if (listener == nil) {
+    return;
+  }
+  std::lock_guard<std::mutex> autoLock(listenerLock);
+  [listeners addObject:listener];
 }
 
 - (void)removeListener:(id<PAGViewListener>)listener {
-  [animator removeListener:(id<PAGAnimatorListener>)listener];
+  if (listener == nil) {
+    return;
+  }
+  std::lock_guard<std::mutex> autoLock(listenerLock);
+  [listeners removeObject:listener];
+}
+
+#pragma mark - PAGAnimatorListener
+
+- (void)onAnimationStart:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationStart:)];
+}
+
+- (void)onAnimationEnd:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationEnd:)];
+}
+
+- (void)onAnimationCancel:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationCancel:)];
+}
+
+- (void)onAnimationRepeat:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationRepeat:)];
+}
+
+- (void)onAnimationUpdate:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationUpdate:)];
+}
+
+- (void)dispatchListenerEvent:(SEL)selector {
+  if ([NSThread isMainThread]) {
+    [self performListenerEventOnMainThread:selector];
+    return;
+  }
+  // Retain self before crossing threads to keep the receiver alive until the
+  // dispatched block finishes notifying listeners on the main thread.
+  [self retain];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self performListenerEventOnMainThread:selector];
+    [self release];
+  });
+}
+
+- (void)performListenerEventOnMainThread:(SEL)selector {
+  NSArray* copiedListeners = nil;
+  {
+    std::lock_guard<std::mutex> autoLock(listenerLock);
+    copiedListeners = [[listeners allObjects] retain];
+  }
+  for (id<PAGViewListener> listener in copiedListeners) {
+    if ([listener respondsToSelector:selector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+      [listener performSelector:selector withObject:self];
+#pragma clang diagnostic pop
+    }
+  }
+  [copiedListeners release];
 }
 
 - (void)onAnimationFlush:(double)progress {

--- a/src/platform/mac/PAGView.h
+++ b/src/platform/mac/PAGView.h
@@ -25,30 +25,28 @@
 
 @optional
 /**
- * Notifies the beginning of the animation. It can be called from either the UI thread or the thread
- * that calls the play method.
+ * Notifies the beginning of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationStart:(PAGView*)pagView;
 
 /**
- * Notifies the end of the animation. It can only be called from the UI thread.
+ * Notifies the end of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationEnd:(PAGView*)pagView;
 
 /**
- * Notifies the cancellation of the animation. It can be called from either the UI thread or the
- * thread that calls the stop method.
+ * Notifies the cancellation of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationCancel:(PAGView*)pagView;
 
 /**
- * Notifies the repetition of the animation. It can only be called from the UI thread.
+ * Notifies the repetition of the animation. This will only be called from the UI thread.
  */
 - (void)onAnimationRepeat:(PAGView*)pagView;
 
 /**
- * Notifies another frame of the animation has occurred. It may be called from an arbitrary
- * thread if the animation is running asynchronously.
+ * Notifies another frame of the animation has occurred. This will only be called from the UI
+ * thread.
  */
 - (void)onAnimationUpdate:(PAGView*)pagView;
 

--- a/src/platform/mac/PAGView.m
+++ b/src/platform/mac/PAGView.m
@@ -20,6 +20,9 @@
 #import "PAGPlayer.h"
 #import "platform/cocoa/private/PAGAnimator.h"
 
+@interface PAGView () <PAGAnimatorUpdater, PAGAnimatorListener>
+@end
+
 @implementation PAGView {
   PAGPlayer* pagPlayer;
   PAGSurface* pagSurface;
@@ -27,6 +30,8 @@
   NSString* filePath;
   PAGAnimator* animator;
   BOOL _isVisible;
+  NSHashTable* listeners;
+  NSLock* listenerLock;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -43,6 +48,9 @@
   self.layer.backgroundColor = [NSColor clearColor].CGColor;
   pagPlayer = [[PAGPlayer alloc] init];
   animator = [[PAGAnimator alloc] initWithUpdater:(id<PAGAnimatorUpdater>)self];
+  listeners = [[NSHashTable weakObjectsHashTable] retain];
+  listenerLock = [[NSLock alloc] init];
+  [animator addListener:self];
   // The animator must be set to sync mode. Otherwise, the internal surface in the PAGSurface could
   // not be created.
   [animator setSync:YES];
@@ -55,6 +63,8 @@
   [pagSurface release];
   [pagFile release];
   [filePath release];
+  [listeners release];
+  [listenerLock release];
   [super dealloc];
 }
 
@@ -120,11 +130,72 @@
 }
 
 - (void)addListener:(id<PAGViewListener>)listener {
-  [animator addListener:(id<PAGAnimatorListener>)listener];
+  if (listener == nil) {
+    return;
+  }
+  [listenerLock lock];
+  [listeners addObject:listener];
+  [listenerLock unlock];
 }
 
 - (void)removeListener:(id<PAGViewListener>)listener {
-  [animator removeListener:(id<PAGAnimatorListener>)listener];
+  if (listener == nil) {
+    return;
+  }
+  [listenerLock lock];
+  [listeners removeObject:listener];
+  [listenerLock unlock];
+}
+
+#pragma mark - PAGAnimatorListener
+
+- (void)onAnimationStart:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationStart:)];
+}
+
+- (void)onAnimationEnd:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationEnd:)];
+}
+
+- (void)onAnimationCancel:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationCancel:)];
+}
+
+- (void)onAnimationRepeat:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationRepeat:)];
+}
+
+- (void)onAnimationUpdate:(id<PAGAnimatorUpdater>)updater {
+  [self dispatchListenerEvent:@selector(onAnimationUpdate:)];
+}
+
+- (void)dispatchListenerEvent:(SEL)selector {
+  if ([NSThread isMainThread]) {
+    [self performListenerEventOnMainThread:selector];
+    return;
+  }
+  // Retain self before crossing threads to keep the receiver alive until the
+  // dispatched block finishes notifying listeners on the main thread.
+  [self retain];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self performListenerEventOnMainThread:selector];
+    [self release];
+  });
+}
+
+- (void)performListenerEventOnMainThread:(SEL)selector {
+  [listenerLock lock];
+  NSArray* copiedListeners = [[listeners allObjects] retain];
+  [listenerLock unlock];
+  for (id<PAGViewListener> listener in copiedListeners) {
+    if ([listener respondsToSelector:selector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+      [listener performSelector:selector withObject:self];
+#pragma clang diagnostic pop
+    }
+  }
+  [copiedListeners release];
 }
 
 - (void)onAnimationFlush:(double)progress {


### PR DESCRIPTION
将 PAGView 和 PAGImageView (iOS/macOS) 的 listener 回调统一调度到主线程执行，修复 Swift 6 严格并发模式下的崩溃。

背景：Swift 6 的严格并发检查要求 UI 相关的回调必须在主线程触发，否则会触发运行时崩溃。原实现可能在非主线程调用 listener 方法，从用户角度看会导致接入 Swift 6 的工程在播放/帧更新等回调路径上出现 crash。

修改将所有对外的 listener 回调封装为主线程派发，确保回调始终在 UI 线程交付，消除该崩溃。

## 行为变化（Behavior change）

此前在子线程调用 play/stop 时，onAnimationStart/onAnimationCancel 会同步在调用线程交付；改动后所有 listener 回调统一为主线程派发，会在主线程的下一轮 runloop 交付。虽然 API 文档此前并未承诺同步交付，但若接入方存在依赖该同步时序的逻辑，需相应调整。