### PR TITLE
Fix potential crash by creating the macOS PAGView render surface on the main thread

### DIFF
--- a/src/platform/ios/PAGView.mm
+++ b/src/platform/ios/PAGView.mm
@@ -62,7 +62,7 @@
                                              object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(AsyncSurfacePrepared:)
-                                               name:pag::kAsyncSurfacePreparedNotification
+                                               name:pag::AsyncSurfacePreparedNotification
                                              object:self.layer];
 }
 

--- a/src/platform/ios/private/GPUDrawable.h
+++ b/src/platform/ios/private/GPUDrawable.h
@@ -23,7 +23,7 @@
 
 namespace pag {
 
-extern NSString* const kAsyncSurfacePreparedNotification;
+extern NSString* const AsyncSurfacePreparedNotification;
 
 class GPUDrawable : public Drawable {
  public:

--- a/src/platform/ios/private/GPUDrawable.mm
+++ b/src/platform/ios/private/GPUDrawable.mm
@@ -19,7 +19,7 @@
 #include "GPUDrawable.h"
 
 namespace pag {
-NSString* const kAsyncSurfacePreparedNotification = @"io.pag.AsyncSurfacePrepared";
+NSString* const AsyncSurfacePreparedNotification = @"io.pag.AsyncSurfacePrepared";
 
 std::shared_ptr<GPUDrawable> GPUDrawable::FromLayer(CAEAGLLayer* layer) {
   if (layer == nil) {
@@ -103,7 +103,7 @@ std::shared_ptr<tgfx::Surface> GPUDrawable::onCreateSurface(tgfx::Context* conte
       strongThis->bufferPreparing = false;
       strongThis->window->getDevice()->unlock();
       if (strongThis->surface) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:kAsyncSurfacePreparedNotification
+        [[NSNotificationCenter defaultCenter] postNotificationName:AsyncSurfacePreparedNotification
                                                             object:strongThis->layer
                                                           userInfo:nil];
       }

--- a/src/platform/mac/PAGView.mm
+++ b/src/platform/mac/PAGView.mm
@@ -19,6 +19,7 @@
 #import "PAGView.h"
 #import "PAGPlayer.h"
 #import "platform/cocoa/private/PAGAnimator.h"
+#import "platform/mac/private/GPUDrawable.h"
 
 @implementation PAGView {
   PAGPlayer* pagPlayer;
@@ -46,6 +47,10 @@
   // The animator must be set to sync mode. Otherwise, the internal surface in the PAGSurface could
   // not be created.
   [animator setSync:YES];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(AsyncSurfacePrepared:)
+                                               name:pag::kAsyncSurfacePreparedNotification
+                                             object:self];
 }
 
 - (void)dealloc {
@@ -55,6 +60,7 @@
   [pagSurface release];
   [pagFile release];
   [filePath release];
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
   [super dealloc];
 }
 
@@ -279,5 +285,9 @@
     return [pagPlayer getBounds:pagLayer];
   }
   return CGRectNull;
+}
+
+- (void)AsyncSurfacePrepared:(NSNotification*)notification {
+  [animator update];
 }
 @end

--- a/src/platform/mac/PAGView.mm
+++ b/src/platform/mac/PAGView.mm
@@ -48,7 +48,7 @@
   // not be created.
   [animator setSync:YES];
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(AsyncSurfacePrepared:)
+                                           selector:@selector(onAsyncSurfacePrepared:)
                                                name:pag::kAsyncSurfacePreparedNotification
                                              object:self];
 }
@@ -287,7 +287,7 @@
   return CGRectNull;
 }
 
-- (void)AsyncSurfacePrepared:(NSNotification*)notification {
+- (void)onAsyncSurfacePrepared:(NSNotification*)notification {
   [animator update];
 }
 @end

--- a/src/platform/mac/PAGView.mm
+++ b/src/platform/mac/PAGView.mm
@@ -57,7 +57,7 @@
   [animator setSync:YES];
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(onAsyncSurfacePrepared:)
-                                               name:pag::kAsyncSurfacePreparedNotification
+                                               name:pag::AsyncSurfacePreparedNotification
                                              object:self];
 }
 

--- a/src/platform/mac/private/GPUDrawable.h
+++ b/src/platform/mac/private/GPUDrawable.h
@@ -23,7 +23,7 @@
 
 namespace pag {
 
-extern NSString* const kAsyncSurfacePreparedNotification;
+extern NSString* const AsyncSurfacePreparedNotification;
 
 class GPUDrawable : public Drawable {
  public:

--- a/src/platform/mac/private/GPUDrawable.h
+++ b/src/platform/mac/private/GPUDrawable.h
@@ -22,6 +22,9 @@
 #include "tgfx/gpu/opengl/cgl/CGLWindow.h"
 
 namespace pag {
+
+extern NSString* const kAsyncSurfacePreparedNotification;
+
 class GPUDrawable : public Drawable {
  public:
   static std::shared_ptr<GPUDrawable> FromView(NSView* view);
@@ -46,11 +49,15 @@ class GPUDrawable : public Drawable {
   void onFreeSurface() override;
 
  private:
+  std::weak_ptr<GPUDrawable> weakThis;
   int _width = 0;
   int _height = 0;
   NSView* view = nil;
   std::shared_ptr<tgfx::CGLWindow> window = nullptr;
+  std::atomic<bool> bufferPreparing = false;
 
   explicit GPUDrawable(NSView* view);
+
+  void tryCreateSurface();
 };
 }  // namespace pag

--- a/src/platform/mac/private/GPUDrawable.mm
+++ b/src/platform/mac/private/GPUDrawable.mm
@@ -29,13 +29,13 @@ std::shared_ptr<GPUDrawable> GPUDrawable::FromView(NSView* view) {
   }
   auto drawable = std::shared_ptr<GPUDrawable>(new GPUDrawable(view));
   drawable->weakThis = drawable;
+  drawable->tryCreateSurface();
   return drawable;
 }
 
 GPUDrawable::GPUDrawable(NSView* view) : view(view) {
   // do not retain view here, otherwise it can cause circular reference.
   updateSize();
-  tryCreateSurface();
 }
 
 void GPUDrawable::tryCreateSurface() {

--- a/src/platform/mac/private/GPUDrawable.mm
+++ b/src/platform/mac/private/GPUDrawable.mm
@@ -77,15 +77,11 @@ std::shared_ptr<tgfx::Surface> GPUDrawable::onCreateSurface(tgfx::Context* conte
   if (window == nullptr || bufferPreparing) {
     return nullptr;
   }
-  if (surface) {
-    return surface;
-  }
   // https://github.com/Tencent/libpag/issues/1870
   // Creating a surface in a non-main thread may lead to a crash because CGLWindow needs to access
   // the NSView geometry on the main thread.
   if (NSThread.isMainThread) {
-    surface = tgfx::Surface::MakeFrom(context, window);
-    return surface;
+    return tgfx::Surface::MakeFrom(context, window);
   }
   bufferPreparing = true;
   auto strongThis = weakThis.lock();

--- a/src/platform/mac/private/GPUDrawable.mm
+++ b/src/platform/mac/private/GPUDrawable.mm
@@ -21,16 +21,40 @@
 #include "tgfx/gpu/opengl/cgl/CGLWindow.h"
 
 namespace pag {
+NSString* const kAsyncSurfacePreparedNotification = @"io.pag.AsyncSurfacePrepared";
+
 std::shared_ptr<GPUDrawable> GPUDrawable::FromView(NSView* view) {
   if (view == nil) {
     return nullptr;
   }
-  return std::shared_ptr<GPUDrawable>(new GPUDrawable(view));
+  auto drawable = std::shared_ptr<GPUDrawable>(new GPUDrawable(view));
+  drawable->weakThis = drawable;
+  return drawable;
 }
 
 GPUDrawable::GPUDrawable(NSView* view) : view(view) {
   // do not retain view here, otherwise it can cause circular reference.
   updateSize();
+  tryCreateSurface();
+}
+
+void GPUDrawable::tryCreateSurface() {
+  // try to create the surface if the view is ready, because CGLWindow needs to access the NSView
+  // geometry on the main thread.
+  if (!NSThread.isMainThread || _width <= 0 || _height <= 0) {
+    return;
+  }
+  if (window == nullptr) {
+    window = tgfx::CGLWindow::MakeFrom(view);
+  }
+  if (window != nullptr) {
+    auto device = window->getDevice();
+    auto context = device->lockContext();
+    if (context != nullptr) {
+      surface = tgfx::Surface::MakeFrom(context, window);
+      device->unlock();
+    }
+  }
 }
 
 void GPUDrawable::updateSize() {
@@ -50,10 +74,40 @@ std::shared_ptr<tgfx::Device> GPUDrawable::getDevice() {
 }
 
 std::shared_ptr<tgfx::Surface> GPUDrawable::onCreateSurface(tgfx::Context* context) {
-  if (window == nullptr) {
+  if (window == nullptr || bufferPreparing) {
     return nullptr;
   }
-  return tgfx::Surface::MakeFrom(context, window);
+  if (surface) {
+    return surface;
+  }
+  // https://github.com/Tencent/libpag/issues/1870
+  // Creating a surface in a non-main thread may lead to a crash because CGLWindow needs to access
+  // the NSView geometry on the main thread.
+  if (NSThread.isMainThread) {
+    surface = tgfx::Surface::MakeFrom(context, window);
+    return surface;
+  }
+  bufferPreparing = true;
+  auto strongThis = weakThis.lock();
+  [view retain];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    auto context = strongThis->window->getDevice()->lockContext();
+    if (context == nullptr) {
+      strongThis->bufferPreparing = false;
+      [strongThis->view release];
+      return;
+    }
+    strongThis->surface = tgfx::Surface::MakeFrom(context, strongThis->window);
+    strongThis->bufferPreparing = false;
+    strongThis->window->getDevice()->unlock();
+    if (strongThis->surface) {
+      [[NSNotificationCenter defaultCenter] postNotificationName:kAsyncSurfacePreparedNotification
+                                                          object:strongThis->view
+                                                        userInfo:nil];
+    }
+    [strongThis->view release];
+  });
+  return nullptr;
 }
 
 void GPUDrawable::onFreeSurface() {

--- a/src/platform/mac/private/GPUDrawable.mm
+++ b/src/platform/mac/private/GPUDrawable.mm
@@ -85,6 +85,10 @@ std::shared_ptr<tgfx::Surface> GPUDrawable::onCreateSurface(tgfx::Context* conte
   }
   bufferPreparing = true;
   auto strongThis = weakThis.lock();
+  if (strongThis == nullptr) {
+    bufferPreparing = false;
+    return nullptr;
+  }
   [view retain];
   dispatch_async(dispatch_get_main_queue(), ^{
     auto context = strongThis->window->getDevice()->lockContext();

--- a/src/platform/mac/private/GPUDrawable.mm
+++ b/src/platform/mac/private/GPUDrawable.mm
@@ -21,7 +21,7 @@
 #include "tgfx/gpu/opengl/cgl/CGLWindow.h"
 
 namespace pag {
-NSString* const kAsyncSurfacePreparedNotification = @"io.pag.AsyncSurfacePrepared";
+NSString* const AsyncSurfacePreparedNotification = @"io.pag.AsyncSurfacePrepared";
 
 std::shared_ptr<GPUDrawable> GPUDrawable::FromView(NSView* view) {
   if (view == nil) {
@@ -101,7 +101,7 @@ std::shared_ptr<tgfx::Surface> GPUDrawable::onCreateSurface(tgfx::Context* conte
     strongThis->bufferPreparing = false;
     strongThis->window->getDevice()->unlock();
     if (strongThis->surface) {
-      [[NSNotificationCenter defaultCenter] postNotificationName:kAsyncSurfacePreparedNotification
+      [[NSNotificationCenter defaultCenter] postNotificationName:AsyncSurfacePreparedNotification
                                                           object:strongThis->view
                                                         userInfo:nil];
     }


### PR DESCRIPTION
为修复 issue #1870 的崩溃问题，将 macOS PAGView 的渲染 surface 创建放到主线程执行。

当 onCreateSurface 在非主线程被调用时（例如视图缩放或缓存释放触发的重新创建），CGLWindow 需要在主线程访问 NSView 的几何信息，否则可能崩溃。此改动参照 iOS 的既有方案，在非主线程调用时通过 dispatch_async 把 surface 创建推迟到主队列，完成后发出通知触发重绘。PAGView 改名为 PAGView.mm 以支持 C++ 互操作。

同时包含针对该实现的若干代码审查修复：统一异步通知回调方法的小写开头命名、移除 onCreateSurface 中不可达的缓存分支与冗余成员赋值、在派发异步块前对 lock 失败做空指针保护、并将首次 surface 创建移至 weakThis 赋值之后以消除构造期的时序隐患。