### PR TITLE
Fix PAGImageView.setPathAsync returning null composition for path loads.

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGImageView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageView.java
@@ -159,9 +159,13 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
      */
     public void setPathAsync(String path, float maxFrameRate, PAGFile.LoadListener listener) {
         NativeTask.Run(() -> {
-            setPath(path, maxFrameRate);
+            // Keep a local reference to the loaded composition. The _composition field may be reset
+            // to null by the render thread in initDecoderInfo() for path-loaded views, so reading it
+            // here would race and frequently return null to the callback.
+            PAGComposition composition = getCompositionFromPath(path);
+            refreshResource(path, composition, maxFrameRate);
             if (listener != null) {
-                listener.onLoad((PAGFile) _composition);
+                listener.onLoad(composition instanceof PAGFile ? (PAGFile) composition : null);
             }
         });
     }


### PR DESCRIPTION
问题：PAGImageView.setPathAsync 的回调有时返回 null composition，导致 play() 被跳过、视图卡在第一帧。

根因：回调原本返回 _composition 字段，而渲染线程在 initDecoderInfo() 中会把 _composition 重置为 null（路径加载场景下经由 refreshResource -> animator.update() 同步触发）。自 _composition 改为 volatile 后，工作线程能稳定观察到这次写入 null，回调便频繁返回 null。

修复：让 setPathAsync 的回调直接返回本次调用加载到的 composition，而不是读共享的 _composition 字段，与 PAGFile.LoadAsync 的语义保持一致。