### PR TITLE
Fix web video listener and object URL memory leaks.

### DIFF
--- a/web/src/core/video-reader.ts
+++ b/web/src/core/video-reader.ts
@@ -78,6 +78,7 @@ export class VideoReader {
     private currentFrame = -1;
     private targetFrame = -1;
     private visibilityHandle: (() => void) | null = null;
+    private objectURL: string | null = null;
 
     public constructor(
         source: Uint8Array | HTMLVideoElement,
@@ -102,7 +103,8 @@ export class VideoReader {
             });
             const buffer = (source as Uint8Array).slice();
             const blob = new Blob([buffer], {type: 'video/mp4'});
-            this.videoEl.src = URL.createObjectURL(blob);
+            this.objectURL = URL.createObjectURL(blob);
+            this.videoEl.src = this.objectURL;
             if (IPHONE) {
                 // use load() will make a bug on Chrome.
                 this.videoEl.load();
@@ -256,6 +258,10 @@ export class VideoReader {
         removeAllListeners(this.videoEl!, 'timeupdate');
         removeAllListeners(this.videoEl!, 'seeked');
         removeAllListeners(this.videoEl!, 'canplay');
+        if (this.objectURL) {
+            URL.revokeObjectURL(this.objectURL);
+            this.objectURL = null;
+        }
         this.videoEl = null;
         this.bitmapCanvas = null;
         this.bitmapCtx = null;

--- a/web/src/utils/video-listener.ts
+++ b/web/src/utils/video-listener.ts
@@ -30,6 +30,12 @@ export const removeListener = (
   eventHandlers[event]
     ?.filter(({ node, handler }) => node === targetNode && handler === targetHandler)
     .forEach(({ node, handler, capture }) => node.removeEventListener(event, handler, capture));
+  // Remove the matched entries from the registry as well. Otherwise the retained handler closures
+  // (which capture the video element, promise resolvers and timers) accumulate on every seek/canplay
+  // and leak memory during looping playback.
+  eventHandlers[event] = eventHandlers[event]?.filter(
+    ({ node, handler }) => !(node === targetNode && handler === targetHandler),
+  );
 };
 
 export const removeAllListeners = (targetNode: HTMLElement, event: K) => {


### PR DESCRIPTION
修复 web 端 VideoReader 在循环播放过程中的两处内存泄漏。

变更内容：
1. web/src/utils/video-listener.ts：removeListener 在调用浏览器 removeEventListener 后，未从内部 eventHandlers 注册表中移除已匹配的条目。每次 seek/canplay 都会向注册表追加新闭包（捕获 video 元素、Promise resolver 与 timer），导致内存随播放时长线性增长。修复后 removeListener 与 removeAllListeners 行为对称，匹配项从注册表中清理。
2. web/src/core/video-reader.ts：构造函数通过 URL.createObjectURL 创建的 mp4 Blob URL 未被 revoke，导致 video 销毁后 mp4 数据仍驻留内存。新增 objectURL 字段，在 onDestroy 中调用 URL.revokeObjectURL 释放。