### PR TITLE
Update tgfx dependency to latest commit. 

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "b3f43154ab58d5b75c7b9f4d20aad7c9aa0a851c",
+        "commit": "c373c4e09a33e478ce5ad092aa1bf649b6fec036",
         "dir": "third_party/tgfx"
       },
       {

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -8810,7 +8810,7 @@
         "spec_merge_path": "4d8a9803",
         "spec_multiple_fills": "4d8a9803",
         "spec_multiple_strokes": "9c8fb076",
-        "spec_nebula_cadet": "eb9361216",
+        "spec_nebula_cadet": "bf1261391",
         "spec_pagx_features": "451bc13e",
         "spec_path": "4d8a9803",
         "spec_polystar": "4d8a9803",


### PR DESCRIPTION
将 third_party/tgfx 更新到 main 分支最新 commit c373c4e09a33e478ce5ad092aa1bf649b6fec036。

变更内容：
- 旧 commit: b3f43154ab58d5b75c7b9f4d20aad7c9aa0a851c
- 新 commit: c373c4e09a33e478ce5ad092aa1bf649b6fec036
- 包含 tgfx 提交: Fix sub-pixel rounded corners wrongly degenerated to rect under scaled CTM. (#1481)

验证：本地完成 depsync 同步，PAGFullTest 编译通过，1421 个测试全部通过。