### PR TITLE
Fix PAGAnimator.start() missing onAnimationStart callback when animator duration scale is turned off.

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGAnimator.java
+++ b/android/libpag/src/main/java/org/libpag/PAGAnimator.java
@@ -129,6 +129,7 @@ class PAGAnimator {
             Log.e("libpag", "PAGAnimator.play() The scale of animator duration is turned off!");
             Listener listener = weakListener.get();
             if (listener != null) {
+                listener.onAnimationStart(this);
                 listener.onAnimationUpdate(this);
                 listener.onAnimationEnd(this);
             }


### PR DESCRIPTION
Fixes https://github.com/Tencent/libpag/issues/3511

When `animationScale == 0` (Android developer setting "Animator duration scale" is off), `PAGAnimator.start()` was calling `onAnimationUpdate` and `onAnimationEnd` without first calling `onAnimationStart`. This caused listeners to miss the start event, leading to inconsistent behavior compared to the normal animation path.

This fix adds the missing `onAnimationStart` callback to align the scale=0 early-return path with the normal animation lifecycle sequence (Start → Update → End).