### PR TITLE
Fix iOS PAGView dealloc crash caused by race condition with animation thread

### DIFF
--- a/src/platform/ios/PAGView.mm
+++ b/src/platform/ios/PAGView.mm
@@ -68,9 +68,14 @@
 
 - (void)dealloc {
   [animator cancel];
+  {
+    std::lock_guard<std::mutex> autoLock(lock);
+    [pagPlayer release];
+    pagPlayer = nil;
+    [pagSurface release];
+    pagSurface = nil;
+  }
   [animator release];
-  [pagPlayer release];
-  [pagSurface release];
   [filePath release];
   [listeners release];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -221,6 +226,10 @@
 }
 
 - (void)onAnimationFlush:(double)progress {
+  std::lock_guard<std::mutex> autoLock(lock);
+  if (pagPlayer == nil) {
+    return;
+  }
   [pagPlayer setProgress:progress];
   if (_isVisible) {
     [animator setDuration:[pagPlayer duration]];


### PR DESCRIPTION
## Summary

Fix a crash in `PAGView` on iOS where `dealloc` releases `pagPlayer`/`pagSurface` while `onAnimationFlush:` is still accessing them on an async animation thread.

## Changes

- Add mutex protection in `dealloc` when releasing `pagPlayer` and `pagSurface`
- Add mutex + nil-check guard in `onAnimationFlush:` to bail out if dealloc has already released the player

## Root Cause

`onAnimationFlush:` is called from an arbitrary worker thread (async animation). If `PAGView` is deallocated while a flush is in progress (after `[animator cancel]` returns but before the in-flight flush completes), the released `pagPlayer`/`pagSurface` pointers are accessed, causing a use-after-free crash.

## Fix

The existing `std::mutex lock` ivar is used to synchronize:
1. `dealloc`: acquires lock, releases and nils `pagPlayer`/`pagSurface`
2. `onAnimationFlush:`: acquires lock, checks `pagPlayer == nil` and returns early if already released

Fixes https://github.com/Tencent/libpag/issues/3401