### PR TITLE
Fix GradientOverlayFilter double-scaling issue when layer has scale transform.

### DIFF
--- a/resources/filter/GradientOverlayScale.pag
+++ b/resources/filter/GradientOverlayScale.pag
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bdf7ba8cae24a4c9e51dc734416c44cc67a5867fe56c2f22554c7d30229bb56
+size 270

--- a/src/rendering/filters/layerstyle/GradientOverlayFilter.cpp
+++ b/src/rendering/filters/layerstyle/GradientOverlayFilter.cpp
@@ -27,8 +27,7 @@ GradientOverlayFilter::GradientOverlayFilter(GradientOverlayStyle* layerStyle)
     : layerStyle(layerStyle) {
 }
 
-void GradientOverlayFilter::update(Frame layerFrame, const tgfx::Point&,
-                                   const tgfx::Point&) {
+void GradientOverlayFilter::update(Frame layerFrame, const tgfx::Point&, const tgfx::Point&) {
   opacity = layerStyle->opacity->getValueAt(layerFrame);
   colors = layerStyle->colors->getValueAt(layerFrame);
   angle = layerStyle->angle->getValueAt(layerFrame);

--- a/src/rendering/filters/layerstyle/GradientOverlayFilter.cpp
+++ b/src/rendering/filters/layerstyle/GradientOverlayFilter.cpp
@@ -27,7 +27,7 @@ GradientOverlayFilter::GradientOverlayFilter(GradientOverlayStyle* layerStyle)
     : layerStyle(layerStyle) {
 }
 
-void GradientOverlayFilter::update(Frame layerFrame, const tgfx::Point& filterScale,
+void GradientOverlayFilter::update(Frame layerFrame, const tgfx::Point&,
                                    const tgfx::Point&) {
   opacity = layerStyle->opacity->getValueAt(layerFrame);
   colors = layerStyle->colors->getValueAt(layerFrame);
@@ -37,7 +37,6 @@ void GradientOverlayFilter::update(Frame layerFrame, const tgfx::Point& filterSc
   scale = layerStyle->scale->getValueAt(layerFrame) / 100.f;
   offset = layerStyle->offset->getValueAt(layerFrame);
   blendMode = layerStyle->blendMode->getValueAt(layerFrame);
-  _filterScale = filterScale;
 }
 
 bool GradientOverlayFilter::draw(Canvas* canvas, std::shared_ptr<tgfx::Image> source) {

--- a/src/rendering/filters/layerstyle/GradientOverlayFilter.cpp
+++ b/src/rendering/filters/layerstyle/GradientOverlayFilter.cpp
@@ -82,10 +82,7 @@ bool GradientOverlayFilter::draw(Canvas* canvas, std::shared_ptr<tgfx::Image> so
   tgfx::Paint paint;
   paint.setShader(shader);
   auto rect = tgfx::Rect::MakeWH(width, height);
-  canvas->save();
-  canvas->scale(1.f / _filterScale.x, 1.f / _filterScale.y);
   canvas->drawRect(rect, paint);
-  canvas->restore();
   return true;
 }
 

--- a/src/rendering/filters/layerstyle/GradientOverlayFilter.h
+++ b/src/rendering/filters/layerstyle/GradientOverlayFilter.h
@@ -40,6 +40,5 @@ class GradientOverlayFilter : public LayerStyleFilter {
   bool reverse = false;
   float scale = 1.0;
   Point offset = Point::Zero();
-  tgfx::Point _filterScale = tgfx::Point::Make(1.0f, 1.0f);
 };
 }  // namespace pag

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -8334,6 +8334,7 @@
         "GaussianBlur_NoRepeat_Clip": "60a88e548",
         "Glow": "60a88e548",
         "GradientOverlayFilter": "60a88e548",
+        "GradientOverlayFilter_Scale": "432167b87",
         "GradientOverlayFilter_Star": "60a88e548",
         "HueSaturation": "60a88e548",
         "LevelsIndividualFilter": "60a88e548",

--- a/test/src/PAGFilterTest.cpp
+++ b/test/src/PAGFilterTest.cpp
@@ -345,6 +345,22 @@ PAG_TEST(PAGFilterTest, GradientOverlayFilter_Star) {
 }
 
 /**
+ * 用例描述: GradientOverlayFilter_Scale
+ */
+PAG_TEST(PAGFilterTest, GradientOverlayFilter_Scale) {
+  auto pagFile = LoadPAGFile("resources/filter/GradientOverlayScale.pag");
+  ASSERT_NE(pagFile, nullptr);
+  auto pagSurface = OffscreenSurface::Make(pagFile->width(), pagFile->height());
+  ASSERT_NE(pagSurface, nullptr);
+  auto pagPlayer = std::make_shared<PAGPlayer>();
+  pagPlayer->setSurface(pagSurface);
+  pagPlayer->setComposition(pagFile);
+  pagPlayer->setProgress(0.0);
+  pagPlayer->flush();
+  EXPECT_TRUE(Baseline::Compare(pagSurface, "PAGFilterTest/GradientOverlayFilter_Scale"));
+}
+
+/**
  * 用例描述: FeatherMask
  */
 PAG_TEST(PAGFilterTest, FeatherMask) {


### PR DESCRIPTION
## Summary

Fix the double-scaling issue in `GradientOverlayFilter::draw()` where the gradient was incorrectly scaled by the inverse of `_filterScale`, causing rendering artifacts when the layer had a scale transform.

## Changes

- Remove the `canvas->save()/scale(1/filterScale)/restore()` wrapper around `drawRect` in `GradientOverlayFilter::draw()`, aligning with the pattern used by other LayerStyleFilters (DropShadowFilter, OuterGlowFilter, StrokeFilter).
- Remove the now-unused `_filterScale` member variable and its assignment in `update()`.

Fixes https://github.com/Tencent/libpag/issues/3384