### PR TITLE
Cherry-pick: fixes for #3438, #3511, #3401 to release/4.5

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGAnimator.java
+++ b/android/libpag/src/main/java/org/libpag/PAGAnimator.java
@@ -129,6 +129,7 @@ class PAGAnimator {
             Log.e("libpag", "PAGAnimator.play() The scale of animator duration is turned off!");
             Listener listener = weakListener.get();
             if (listener != null) {
+                listener.onAnimationStart(this);
                 listener.onAnimationUpdate(this);
                 listener.onAnimationEnd(this);
             }

--- a/src/platform/ios/PAGView.mm
+++ b/src/platform/ios/PAGView.mm
@@ -68,9 +68,14 @@
 
 - (void)dealloc {
   [animator cancel];
+  {
+    std::lock_guard<std::mutex> autoLock(lock);
+    [pagPlayer release];
+    pagPlayer = nil;
+    [pagSurface release];
+    pagSurface = nil;
+  }
   [animator release];
-  [pagPlayer release];
-  [pagSurface release];
   [filePath release];
   [listeners release];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -221,6 +226,10 @@
 }
 
 - (void)onAnimationFlush:(double)progress {
+  std::lock_guard<std::mutex> autoLock(lock);
+  if (pagPlayer == nil) {
+    return;
+  }
   [pagPlayer setProgress:progress];
   if (_isVisible) {
     [animator setDuration:[pagPlayer duration]];

--- a/src/platform/ohos/JPAGImageView.cpp
+++ b/src/platform/ohos/JPAGImageView.cpp
@@ -874,6 +874,7 @@ napi_value JPAGImageView::getCurrentPixelMap(napi_env env) {
 }
 
 void JPAGImageView::release() {
+  XComponentHandler::RemoveListener(id);
   // A memory leak may occur if the timer is not cancelled upon release.
   if (_animator) {
     _animator->cancel();

--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -911,6 +911,7 @@ void JPAGView::onSurfaceDestroyed() {
 }
 
 void JPAGView::release() {
+  XComponentHandler::RemoveListener(id);
   // A memory leak may occur if the timer is not cancelled upon release.
   if (animator) {
     animator->cancel();


### PR DESCRIPTION
Cherry-pick three fixes from main:

- #3522 / #3438: OHOS deadlock in JPAGView::release()
- #3523 / #3511: Missing onAnimationStart when animator scale is 0
- #3526 / #3401: iOS PAGView dealloc race condition