### PR TITLE
Support color channel for PAGX Fill and Stroke nodes

### DIFF
--- a/src/pagx/PAGXImporter.cpp
+++ b/src/pagx/PAGXImporter.cpp
@@ -1000,15 +1000,19 @@ static Fill* ParseFill(const DOMNode* node, PAGXDocument* doc) {
   if (!fill) {
     return nullptr;
   }
-  fill->color = ParseColorAttr(GetAttribute(node, "color"), doc, node);
+  // Child ColorSource takes precedence over the color attribute. Parse the child first so the
+  // attribute-built SolidColor is not created and orphaned in the document's node list when a
+  // child is present.
+  auto childColor = ParseChildColorSource(node, doc);
+  if (childColor) {
+    fill->color = childColor;
+  } else {
+    fill->color = ParseColorAttr(GetAttribute(node, "color"), doc, node);
+  }
   fill->alpha = GetFloatAttribute(node, "alpha", Default<Fill>().alpha, doc);
   fill->blendMode = GET_ENUM(node, "blendMode", "normal", doc, BlendMode);
   fill->fillRule = GET_ENUM(node, "fillRule", "winding", doc, FillRule);
   fill->placement = GET_ENUM(node, "placement", "background", doc, LayerPlacement);
-  auto childColor = ParseChildColorSource(node, doc);
-  if (childColor) {
-    fill->color = childColor;
-  }
   return fill;
 }
 
@@ -1017,7 +1021,15 @@ static Stroke* ParseStroke(const DOMNode* node, PAGXDocument* doc) {
   if (!stroke) {
     return nullptr;
   }
-  stroke->color = ParseColorAttr(GetAttribute(node, "color"), doc, node);
+  // Child ColorSource takes precedence over the color attribute. Parse the child first so the
+  // attribute-built SolidColor is not created and orphaned in the document's node list when a
+  // child is present.
+  auto childColor = ParseChildColorSource(node, doc);
+  if (childColor) {
+    stroke->color = childColor;
+  } else {
+    stroke->color = ParseColorAttr(GetAttribute(node, "color"), doc, node);
+  }
   stroke->width = GetFloatAttribute(node, "width", Default<Stroke>().width, doc);
   stroke->alpha = GetFloatAttribute(node, "alpha", Default<Stroke>().alpha, doc);
   stroke->blendMode = GET_ENUM(node, "blendMode", "normal", doc, BlendMode);
@@ -1033,10 +1045,6 @@ static Stroke* ParseStroke(const DOMNode* node, PAGXDocument* doc) {
       GetBoolAttribute(node, "dashAdaptive", Default<Stroke>().dashAdaptive, doc);
   stroke->align = GET_ENUM(node, "align", "center", doc, StrokeAlign);
   stroke->placement = GET_ENUM(node, "placement", "background", doc, LayerPlacement);
-  auto childColor = ParseChildColorSource(node, doc);
-  if (childColor) {
-    stroke->color = childColor;
-  }
   return stroke;
 }
 

--- a/src/pagx/PAGXNodeChannel.cpp
+++ b/src/pagx/PAGXNodeChannel.cpp
@@ -181,10 +181,10 @@ static bool AccessFillStrokeColor(Node* node, KeyValue* getOut, const KeyValue* 
   } else if (node->nodeType() == NodeType::Stroke) {
     colorSource = static_cast<Stroke*>(node)->color;
   }
-  auto* solid = colorSource ? static_cast<SolidColor*>(colorSource) : nullptr;
-  if (solid == nullptr) {
+  if (colorSource == nullptr || colorSource->nodeType() != NodeType::SolidColor) {
     return false;
   }
+  auto* solid = static_cast<SolidColor*>(colorSource);
   if (getOut == nullptr && setIn == nullptr) {
     solid->color = Default<SolidColor>().color;
     return true;

--- a/src/pagx/PAGXNodeChannel.cpp
+++ b/src/pagx/PAGXNodeChannel.cpp
@@ -172,6 +172,35 @@ static bool AccessColor(Node* node, KeyValue* getOut, const KeyValue* setIn) {
   return true;
 }
 
+// Color channel access for Fill/Stroke nodes. Reads/writes the color through the underlying
+// SolidColor child node, since Fill and Stroke own a ColorSource pointer (not a Color directly).
+static bool AccessFillStrokeColor(Node* node, KeyValue* getOut, const KeyValue* setIn) {
+  ColorSource* colorSource = nullptr;
+  if (node->nodeType() == NodeType::Fill) {
+    colorSource = static_cast<Fill*>(node)->color;
+  } else if (node->nodeType() == NodeType::Stroke) {
+    colorSource = static_cast<Stroke*>(node)->color;
+  }
+  auto* solid = colorSource ? static_cast<SolidColor*>(colorSource) : nullptr;
+  if (solid == nullptr) {
+    return false;
+  }
+  if (getOut == nullptr && setIn == nullptr) {
+    solid->color = Default<SolidColor>().color;
+    return true;
+  }
+  if (getOut != nullptr) {
+    *getOut = solid->color;
+    return true;
+  }
+  const auto* value = std::get_if<Color>(setIn);
+  if (value == nullptr) {
+    return false;
+  }
+  solid->color = *value;
+  return true;
+}
+
 // Point sub-component access: addresses position.x / position.y etc. XAxis selects x vs y.
 template <typename T, auto Field, bool XAxis>
 static bool AccessPointAxis(Node* node, KeyValue* getOut, const KeyValue* setIn) {
@@ -463,6 +492,7 @@ static std::vector<ChannelDef> BuildTextFields() {
 
 static std::vector<ChannelDef> BuildFillFields() {
   return {
+      {"color", Anim, &AccessFillStrokeColor},
       FIELD_FLOAT(Fill, "alpha", alpha, Anim),
       FIELD_ENUM(Fill, "blendMode", blendMode, NoFlags, BlendMode),
       FIELD_ENUM(Fill, "fillRule", fillRule, NoFlags, FillRule),
@@ -472,6 +502,7 @@ static std::vector<ChannelDef> BuildFillFields() {
 
 static std::vector<ChannelDef> BuildStrokeFields() {
   return {
+      {"color", Anim, &AccessFillStrokeColor},
       FIELD_FLOAT(Stroke, "width", width, Anim),
       FIELD_FLOAT(Stroke, "alpha", alpha, Anim),
       FIELD_ENUM(Stroke, "blendMode", blendMode, NoFlags, BlendMode),

--- a/src/renderer/LayerBuilder.cpp
+++ b/src/renderer/LayerBuilder.cpp
@@ -1063,7 +1063,9 @@ class LayerBuilderContext {
       if (node->placement != LayerPlacement::Background) {
         fill->setPlacement(ToTGFX(node->placement));
       }
-      _result.binding.setWriter(node, "color", WritePainterColor<tgfx::FillStyle>);
+      if (node->color && node->color->nodeType() == NodeType::SolidColor) {
+        _result.binding.setWriter(node, "color", WritePainterColor<tgfx::FillStyle>);
+      }
       _result.binding.setWriter(
           node, "alpha",
           WriteMixedFloat<tgfx::FillStyle, &tgfx::FillStyle::alpha, &tgfx::FillStyle::setAlpha>);
@@ -1107,7 +1109,9 @@ class LayerBuilderContext {
     if (node->placement != LayerPlacement::Background) {
       stroke->setPlacement(ToTGFX(node->placement));
     }
-    _result.binding.setWriter(node, "color", WritePainterColor<tgfx::StrokeStyle>);
+    if (node->color && node->color->nodeType() == NodeType::SolidColor) {
+      _result.binding.setWriter(node, "color", WritePainterColor<tgfx::StrokeStyle>);
+    }
     _result.binding.setWriter(node, "width",
                               WriteMixedFloat<tgfx::StrokeStyle, &tgfx::StrokeStyle::strokeWidth,
                                               &tgfx::StrokeStyle::setStrokeWidth>);

--- a/src/renderer/LayerBuilder.cpp
+++ b/src/renderer/LayerBuilder.cpp
@@ -1140,18 +1140,13 @@ class LayerBuilderContext {
 
   template <typename PainterType>
   static void WritePainterColor(void* object, const KeyValue& value, float mix) {
-    auto* v = std::get_if<Color>(&value);
-    if (v == nullptr) {
-      return;
-    }
     auto* painter = static_cast<PainterType*>(object);
     auto colorSource = painter->colorSource();
     auto* solid = static_cast<tgfx::SolidColor*>(colorSource.get());
     if (solid == nullptr) {
       return;
     }
-    auto target = ToTGFX(*v);
-    solid->setColor(MixTGFXColor(solid->color(), target, mix));
+    WriteSolidColor(solid, value, mix);
   }
 
   std::shared_ptr<tgfx::ColorSource> convertColorSource(const ColorSource* node) {

--- a/src/renderer/LayerBuilder.cpp
+++ b/src/renderer/LayerBuilder.cpp
@@ -1063,6 +1063,7 @@ class LayerBuilderContext {
       if (node->placement != LayerPlacement::Background) {
         fill->setPlacement(ToTGFX(node->placement));
       }
+      _result.binding.setWriter(node, "color", WritePainterColor<tgfx::FillStyle>);
       _result.binding.setWriter(
           node, "alpha",
           WriteMixedFloat<tgfx::FillStyle, &tgfx::FillStyle::alpha, &tgfx::FillStyle::setAlpha>);
@@ -1106,6 +1107,7 @@ class LayerBuilderContext {
     if (node->placement != LayerPlacement::Background) {
       stroke->setPlacement(ToTGFX(node->placement));
     }
+    _result.binding.setWriter(node, "color", WritePainterColor<tgfx::StrokeStyle>);
     _result.binding.setWriter(node, "width",
                               WriteMixedFloat<tgfx::StrokeStyle, &tgfx::StrokeStyle::strokeWidth,
                                               &tgfx::StrokeStyle::setStrokeWidth>);
@@ -1128,6 +1130,22 @@ class LayerBuilderContext {
       return;
     }
     auto* solid = static_cast<tgfx::SolidColor*>(object);
+    auto target = ToTGFX(*v);
+    solid->setColor(MixTGFXColor(solid->color(), target, mix));
+  }
+
+  template <typename PainterType>
+  static void WritePainterColor(void* object, const KeyValue& value, float mix) {
+    auto* v = std::get_if<Color>(&value);
+    if (v == nullptr) {
+      return;
+    }
+    auto* painter = static_cast<PainterType*>(object);
+    auto colorSource = painter->colorSource();
+    auto* solid = static_cast<tgfx::SolidColor*>(colorSource.get());
+    if (solid == nullptr) {
+      return;
+    }
     auto target = ToTGFX(*v);
     solid->setColor(MixTGFXColor(solid->color(), target, mix));
   }


### PR DESCRIPTION
为 PAGX 的 Fill 和 Stroke 节点新增 color channel 支持，可在动画与文档编辑中驱动颜色。

主要变更：
- PAGXNodeChannel 注册 Fill/Stroke 的 color channel，通过底层 SolidColor 子节点读写颜色
- LayerBuilder 在 ColorSource 为 SolidColor 时注册 color writer，非 SolidColor 跳过（与 import 子项胜出语义一致）
- AccessFillStrokeColor 加类型守卫，避免非 SolidColor 时的不安全 cast
- 修复 PAGXImporter 中 Fill/Stroke 同时存在 color 属性与子项 ColorSource 时的孤儿 SolidColor 节点泄漏（改为子项优先解析）
- WritePainterColor 委托 WriteSolidColor，消除重复的 color-mixing 逻辑

注意：分支落后 main 3 个提交（平台 bug 修复 #3522/#3523/#3526），与本特性无冲突。