### PR TITLE
Replace C++ checkerboard rendering with CSS background in pagx-playground

### DIFF
--- a/playground/pagx-playground/src/index.ts
+++ b/playground/pagx-playground/src/index.ts
@@ -647,7 +647,7 @@ async function loadWasm(): Promise<void> {
         throw new Error('Failed to create PAGXView');
     }
     playgroundState.pagxView = pagxView;
-    pagxView.setBackgroundColor("F5F5F5");
+    pagxView.setBackgroundColor('#000000', 0);
     updateSize();
     pagxView.updateZoomScaleAndOffset(1.0, 0, 0);
     const canvas = document.getElementById('pagx-canvas') as HTMLCanvasElement;

--- a/playground/pagx-playground/static/index.css
+++ b/playground/pagx-playground/static/index.css
@@ -29,6 +29,8 @@ html, body {
     right: 0;
     z-index: 1;
     touch-action: none;
+    background:
+        repeating-conic-gradient(#d0d0d0 0% 25%, #fff 0% 50%) 0 0 / 32px 32px;
 }
 
 .canvas.hidden {
@@ -524,7 +526,8 @@ html, body {
 .samples-list .sample-image {
     width: 100%;
     aspect-ratio: 1 / 1;
-    background: #f5f5f5;
+    background:
+            repeating-conic-gradient(#ccc 0% 25%, #fff 0% 50%) 0 0 / 16px 16px;
     border-radius: 6px;
     object-fit: contain;
 }


### PR DESCRIPTION
pagx-playground 的棋盘格背景改为 CSS 实现

具体变更：
- canvas 元素添加 CSS repeating-conic-gradient 棋盘格背景
- 初始化时设置全透明背景色，让 CSS 背景透过 canvas 透明区域显示

这样无需修改 PAGScene，棋盘格效果完全由前端 CSS 控制。