### PR TITLE
Fix PAGEncodeThread to close encoder on encode thread via signal-slot.

### DIFF
--- a/exporter/src/export/encode/PAGEncodeThread.cpp
+++ b/exporter/src/export/encode/PAGEncodeThread.cpp
@@ -28,11 +28,15 @@ PAGEncodeThread::PAGEncodeThread(QObject* parent) : QThread(parent) {
           &PAGEncodeThread::encodeHeadersInternal, Qt::QueuedConnection);
   connect(this, &PAGEncodeThread::encodeFrameSignal, this, &PAGEncodeThread::encodeFrameInternal,
           Qt::QueuedConnection);
+  connect(this, &PAGEncodeThread::closeSignal, this, &PAGEncodeThread::closeInternal,
+          Qt::QueuedConnection);
   start();
 }
 
 PAGEncodeThread::~PAGEncodeThread() {
-  encoder->close();
+  if (encoder != nullptr) {
+    encoder->close();
+  }
   quit();
   wait();
 }
@@ -43,6 +47,10 @@ bool PAGEncodeThread::isValid() const {
 
 void PAGEncodeThread::close() {
   inputFinished = true;
+  Q_EMIT closeSignal();
+}
+
+void PAGEncodeThread::closeInternal() {
   if (encoder != nullptr) {
     encoder->close();
   }

--- a/exporter/src/export/encode/PAGEncodeThread.cpp
+++ b/exporter/src/export/encode/PAGEncodeThread.cpp
@@ -34,8 +34,9 @@ PAGEncodeThread::PAGEncodeThread(QObject* parent) : QThread(parent) {
 }
 
 PAGEncodeThread::~PAGEncodeThread() {
-  if (encoder != nullptr) {
-    encoder->close();
+  if (!inputFinished) {
+    inputFinished = true;
+    Q_EMIT closeSignal();
   }
   quit();
   wait();

--- a/exporter/src/export/encode/PAGEncodeThread.h
+++ b/exporter/src/export/encode/PAGEncodeThread.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <pag/types.h>
 #include <tgfx/core/Buffer.h>
 #include <QThread>
@@ -61,7 +62,7 @@ class PAGEncodeThread : public QThread {
   Q_SLOT void closeInternal();
 
   bool valid = true;
-  bool inputFinished = false;
+  std::atomic<bool> inputFinished = false;
   int64_t needEncodeNum = 0;
   int64_t hasEncodedNum = 0;
   int32_t alphaStartX = 0;

--- a/exporter/src/export/encode/PAGEncodeThread.h
+++ b/exporter/src/export/encode/PAGEncodeThread.h
@@ -52,11 +52,13 @@ class PAGEncodeThread : public QThread {
   Q_SIGNAL void encodeHeadersSignal();
   Q_SIGNAL void encodeFrameSignal(std::shared_ptr<pag::ByteData> data, FrameType frameType,
                                   int stride);
+  Q_SIGNAL void closeSignal();
 
   Q_SLOT void getEncodeFrame();
   Q_SLOT void encodeHeadersInternal();
   Q_SLOT void encodeFrameInternal(std::shared_ptr<pag::ByteData> data, FrameType frameType,
                                   int stride);
+  Q_SLOT void closeInternal();
 
   bool valid = true;
   bool inputFinished = false;

--- a/exporter/src/export/encode/PAGEncodeThread.h
+++ b/exporter/src/export/encode/PAGEncodeThread.h
@@ -18,10 +18,10 @@
 
 #pragma once
 
-#include <atomic>
 #include <pag/types.h>
 #include <tgfx/core/Buffer.h>
 #include <QThread>
+#include <atomic>
 #include "VideoEncoder.h"
 
 namespace exporter {

--- a/exporter/src/export/sequence/VideoSequence.cpp
+++ b/exporter/src/export/sequence/VideoSequence.cpp
@@ -362,6 +362,8 @@ static void GetVideoSequence(std::shared_ptr<PAGExportSession> session,
 
     if (session->videoHasAlpha != hasAlpha) {
       session->videoHasAlpha = hasAlpha;
+      pagEncodeThread->close();
+      pagEncodeThread.reset();
       delete sequence;
       continue;
     }


### PR DESCRIPTION
## 概述

将 `encoder->close()` 从跨线程直接调用改为通过 Qt 信号槽队列机制执行，确保始终在 encode 线程上关闭编码器。

## 修改内容

- 新增 `closeSignal()` / `closeInternal()` 信号槽对，使用 `Qt::QueuedConnection` 连接
- `close()` 改为发射 `closeSignal()`，不再直接调用 `encoder->close()`
- 析构函数：若 `close()` 未被调用则发射 `closeSignal()`，随后 `quit()` + `wait()`
- `inputFinished` 改为 `std::atomic<bool>`，消除跨线程数据竞争
- VideoSequence：alpha 不匹配时先正确关闭并重置 encode 线程再重试

## 变更文件

- `exporter/src/export/encode/PAGEncodeThread.cpp`
- `exporter/src/export/encode/PAGEncodeThread.h`
- `exporter/src/export/sequence/VideoSequence.cpp`