### PR TITLE
Fix fdsan crash on PAGView surface detach by serializing flush with render lock

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGView.java
@@ -74,6 +74,11 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
     private String filePath = "";
     private boolean isAttachedToWindow = false;
     private EGLContext sharedContext = null;
+    // Serializes the asynchronous flush() with surface lifecycle changes (create/destroy/release).
+    // Without it, an in-flight async render on the worker thread may present to an ANativeWindow
+    // while the framework is tearing down its SurfaceTexture, leading to a double-close of the
+    // underlying GraphicBuffer fd. This mirrors the std::mutex used in the iOS/macOS PAGView.
+    private final Object renderLock = new Object();
 
     /**
      * [Deprecated](Please use PAGViewListener's onAnimationUpdate instead.)
@@ -497,16 +502,20 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
 
     @Override
     public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {
-        if (pagSurface != null) {
-            pagSurface.release();
-            pagSurface = null;
+        synchronized (renderLock) {
+            if (pagSurface != null) {
+                pagSurface.release();
+                pagSurface = null;
+            }
+            pagSurface = PAGSurface.FromSurfaceTexture(surface, sharedContext);
+            pagPlayer.setSurface(pagSurface);
+            if (pagSurface != null) {
+                pagSurface.clearAll();
+            }
         }
-        pagSurface = PAGSurface.FromSurfaceTexture(surface, sharedContext);
-        pagPlayer.setSurface(pagSurface);
         if (pagSurface == null) {
             return;
         }
-        pagSurface.clearAll();
         animator.update();
         if (mListener != null) {
             mListener.onSurfaceTextureAvailable(surface, width, height);
@@ -515,9 +524,13 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
 
     @Override
     public void onSurfaceTextureSizeChanged(SurfaceTexture surfaceTexture, int width, int height) {
+        synchronized (renderLock) {
+            if (pagSurface != null) {
+                pagSurface.updateSize();
+                pagSurface.clearAll();
+            }
+        }
         if (pagSurface != null) {
-            pagSurface.updateSize();
-            pagSurface.clearAll();
             animator.update();
         }
         if (mListener != null) {
@@ -527,12 +540,14 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
 
     @Override
     public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
-        pagPlayer.setSurface(null);
+        synchronized (renderLock) {
+            pagPlayer.setSurface(null);
+            if (pagSurface != null) {
+                pagSurface.freeCache();
+            }
+        }
         if (mListener != null) {
             mListener.onSurfaceTextureDestroyed(surface);
-        }
-        if (pagSurface != null) {
-            pagSurface.freeCache();
         }
         // 延迟释放 SurfaceTexture，否则Android 4.4之前版本会在 onDetachedFromWindow() 时 Crash:
         // https://www.jianshu.com/p/675455c225bd
@@ -564,9 +579,11 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
     protected void onDetachedFromWindow() {
         isAttachedToWindow = false;
         super.onDetachedFromWindow();
-        if (pagSurface != null) {
-            pagSurface.release();
-            pagSurface = null;
+        synchronized (renderLock) {
+            if (pagSurface != null) {
+                pagSurface.release();
+                pagSurface = null;
+            }
         }
         checkVisible();
     }
@@ -670,7 +687,10 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
         if (isVisible) {
             animator.setDuration(pagPlayer.duration());
         }
-        boolean changed = flush();
+        boolean changed;
+        synchronized (renderLock) {
+            changed = flush();
+        }
         if (changed) {
             updateTextureView();
         }


### PR DESCRIPTION
## 问题

在 Android 异步渲染模式下，PAGView.onSurfaceTextureDestroyed 拆除 surface 时未停止或等待in-flight中的异步渲染任务（DisplayLink/PAGAnimator 触发的 flush() -> present()），导致 worker 线程仍在向 ANativeWindow 执行 eglSwapBuffers 时，framework 已开始废弃 SurfaceTexture 的 BufferQueue。这会引发 GraphicBuffer 底层文件描述符被双重关闭（fdsan），触发 SIGABRT 崩溃。

详见：#3534

## 根因

三个平台对比（iOS/macOS/Android）确认，iOS 和 macOS 的 PAGView 均使用 std::mutex lock 串行化异步 flush 与 surface 拆除。macOS 甚至强制同步渲染（setSync:YES）从机制上杜绝此竞态。唯独 Android 在异步模式下拆除 surface 前没有任何同步保护，且 rootLocker 在 detach 时被 setSurfaceInternal 换锁，导致 freeCache() 与渲染管线不再互斥。

## 修复

在 PAGView.java 引入专用渲染锁 renderLock，串行化所有 surface 生命周期操作与 flush()：

- onAnimationUpdate 中的 flush() 在锁内执行
- onSurfaceTextureAvailable / onSurfaceTextureDestroyed / onDetachedFromWindow 中的 surface 创建与释放也在锁内执行
- 当 onSurfaceTextureDestroyed 获取锁时，任何 in-flight 的 flush/present 均已结束；拆除期间新的 flush 被阻塞在锁外，随后因 pagSurface==null 变为 no-op

与原 iOS 实现的 std::mutex lock 机制完全对齐。

## 改动

android/libpag/src/main/java/org/libpag/PAGView.java：新增 renderLock 对象 + 5 处 synchronized 保护，净增 36 行