### PR TITLE
Fix Android display distortion and interval timer leak in lite WeChat

### DIFF
--- a/web/lite/demo/wechat-miniprogram/pages/index/index.wxml
+++ b/web/lite/demo/wechat-miniprogram/pages/index/index.wxml
@@ -1,7 +1,7 @@
 <!-- index.wxml -->
 <view class="container">
   <view>
-    <canvas class="zebra" type="webgl" id="pag" style="width: 300px; height:300px;"></canvas>
+    <canvas class="zebra" type="webgl" id="pag" style="width: 690rpx; height:900rpx;"></canvas>
   </view>
   <view hidden="{{pagLoaded}}">
     <button class="btn-load" size="default" type="default" bindtap="load">加载测试PAG</button>

--- a/web/lite/demo/wechat-miniprogram/pages/index/index.wxss
+++ b/web/lite/demo/wechat-miniprogram/pages/index/index.wxss
@@ -31,6 +31,10 @@
   background-size: 30px 30px;
 }
 
+.container {
+  overflow-y: scroll;
+}
+
 .btn-box {
   width: 720rpx;
   display: flex;

--- a/web/lite/package.json
+++ b/web/lite/package.json
@@ -8,7 +8,8 @@
   "typings": "types/pag.d.ts",
   "scripts": {
     "build": "rimraf lib/* types/* && rollup -c ./script/rollup.config.js && tsc -p ./tsconfig.type.json",
-    "build:wx": "rimraf wechat/lib/* wechat/types/* && rollup -c ./script/rollup.config.wechat.js && tsc -p ./wechat/tsconfig.type.json",
+    "build:wx": "rimraf wechat/lib/* wechat/types/* && rollup -c ./script/rollup.config.wechat.js && tsc -p ./wechat/tsconfig.type.json && npm run copy:wx:demo",
+    "copy:wx:demo": "node -e \"const fs=require('fs');fs.mkdirSync('demo/wechat-miniprogram/utils',{recursive:true});fs.copyFileSync('wechat/lib/pag.js','demo/wechat-miniprogram/utils/pag.js')\"",
     "dev": "rollup -c ./script/rollup.config.dev.js -w",
     "dev:wx": "rollup -c ./script/rollup.config.wechat.dev.js -w",
     "eslint": "eslint --ext .ts src/",

--- a/web/lite/src/wechat/pag-view.ts
+++ b/web/lite/src/wechat/pag-view.ts
@@ -109,8 +109,8 @@ export class PAGView extends PAGWebGLView {
           // region (MP4Width/MP4Height) is sampled, excluding the padding that would otherwise
           // squeeze and distort the visible image.
           this.scale = {
-            x: this.frameData.width / this.videoParam.MP4Width,
-            y: this.frameData.height / this.videoParam.MP4Height,
+            x: frameData.width / this.videoParam.MP4Width,
+            y: frameData.height / this.videoParam.MP4Height,
           };
         }
         draw();

--- a/web/lite/src/wechat/pag-view.ts
+++ b/web/lite/src/wechat/pag-view.ts
@@ -9,8 +9,6 @@ import type { VideoSequence } from '../base/video-sequence';
 
 declare const setInterval: (callback: () => void, delay: number) => number;
 
-const ANDROID_16_ALIGN = 16;
-
 export class PAGView extends PAGWebGLView {
   public static init(data: ArrayBuffer, canvas: HTMLCanvasElement) {
     const clock = new Clock();
@@ -105,9 +103,14 @@ export class PAGView extends PAGWebGLView {
         this.currentFrame = frameData.id;
         this.setDebugData({ getFrame: Date.now() - getFrameMark });
         if (isAndroid) {
+          // On Android, WeChat's VideoDecoder returns frames padded to 16-pixel (macroblock)
+          // alignment, so frameData.width/height are the aligned buffer dimensions with padding on
+          // the right/bottom. Scale the texture coordinates by aligned/real so only the real content
+          // region (MP4Width/MP4Height) is sampled, excluding the padding that would otherwise
+          // squeeze and distort the visible image.
           this.scale = {
-            x: (Math.ceil(this.frameData.width / ANDROID_16_ALIGN) * ANDROID_16_ALIGN) / this.frameData.width,
-            y: (Math.ceil(this.frameData.height / ANDROID_16_ALIGN) * ANDROID_16_ALIGN) / this.frameData.height,
+            x: this.frameData.width / this.videoParam.MP4Width,
+            y: this.frameData.height / this.videoParam.MP4Height,
           };
         }
         draw();
@@ -170,7 +173,7 @@ export class PAGView extends PAGWebGLView {
 
   protected override clearTimer() {
     if (this.renderTimer) {
-      clearTimeout(this.renderTimer);
+      clearInterval(this.renderTimer);
       this.renderTimer = null;
     }
     this.videoReader.clearCallback();

--- a/web/lite/tsconfig.type.json
+++ b/web/lite/tsconfig.type.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es6", "dom"],
     "target": "es5",
+    "types": [],
     "declaration": true,
     "declarationDir": "./types",
     "emitDeclarationOnly": true,

--- a/web/lite/wechat/tsconfig.type.json
+++ b/web/lite/wechat/tsconfig.type.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es6", "dom"],
     "target": "es5",
+    "types": [],
     "declaration": true,
     "declarationDir": "./types",
     "emitDeclarationOnly": true,


### PR DESCRIPTION
## 背景

修复 issue #3533：微信小程序在安卓端显示 PAG 时画面失真模糊，且销毁时循环报错 `getFrameData:fail`。

## 修改内容

### 1. 修复安卓端显示失真（`web/lite/src/wechat/pag-view.ts`）

安卓端微信 VideoDecoder 返回的帧被填充到 16 像素（宏块）对齐，`frameData.width/height` 是带右侧/底部 padding 的对齐缓冲尺寸。原有缩放公式 `ceil(frameData.width/16)*16 / frameData.width` 对一个**已经 16 对齐**的值再次对齐，结果恒等于约 1.0，等于没有做 padding 校正，导致画面被 padding 挤压而失真。

改为按 `frameData.width / videoParam.MP4Width`（对齐尺寸 ÷ 真实内容尺寸）计算缩放，使纹理坐标只采样真实内容区域，排除 padding，从而消除失真。同时移除不再使用的 `ANDROID_16_ALIGN` 常量。

### 2. 修复定时器泄漏导致销毁报错（`web/lite/src/wechat/pag-view.ts`）

`renderTimer` 由 `setInterval` 创建，但 `clearTimer()` 中错误地使用 `clearTimeout` 清理，在小程序环境下无法取消 interval，导致销毁后回调仍在触发并循环报错 `getFrameData:fail`。改为 `clearInterval` 正确释放。

### 3. 其他配套改动

- `package.json`：新增 `copy:wx:demo` 脚本并接入 `build:wx`，构建后自动将产物拷贝到 demo 目录，方便运行验证。
- `tsconfig.type.json` / `wechat/tsconfig.type.json`：新增 `"types": []`，声明构建时避免自动引入全部 `@types` 包。
- demo 页面（wxml/wxss）：画布尺寸改用 rpx 并支持滚动，仅用于演示。

## 关联 issue

Fixes #3533