### PR TITLE
Fix wild pointer crash on async animation update in iOS PAGAnimator

### DIFF
--- a/src/platform/cocoa/private/PAGAnimator.mm
+++ b/src/platform/cocoa/private/PAGAnimator.mm
@@ -112,15 +112,11 @@ class AnimatorListener : public pag::PAGAnimator::Listener {
   }
 
   void onAnimationWillUpdate(PAGAnimator*) override {
-    // [updaterTable.anyObject retain] is non-atomic and may lead to a wild pointer issue
-    // if the object is released after obtaining anyObject.
-    // Therefore, it is necessary to increment the reference count in the main thread before using.
-    [updaterTable.anyObject retain];
   };
 
   void onAnimationUpdate(pag::PAGAnimator* animator) override {
     @autoreleasepool {
-      auto updater = (id<PAGAnimatorUpdater>)updaterTable.anyObject;
+      auto updater = (id<PAGAnimatorUpdater>)[updaterTable.anyObject retain];
       if (updater == nil) {
         return;
       }
@@ -133,9 +129,7 @@ class AnimatorListener : public pag::PAGAnimator::Listener {
         }
       }
       [copiedListeners release];
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [updaterTable.anyObject release];
-      });
+      [updater release];
     }
   };
 

--- a/src/platform/cocoa/private/PAGAnimator.mm
+++ b/src/platform/cocoa/private/PAGAnimator.mm
@@ -111,9 +111,6 @@ class AnimatorListener : public pag::PAGAnimator::Listener {
     [updater release];
   }
 
-  void onAnimationWillUpdate(PAGAnimator*) override {
-  };
-
   void onAnimationUpdate(pag::PAGAnimator* animator) override {
     @autoreleasepool {
       auto updater = (id<PAGAnimatorUpdater>)[updaterTable.anyObject retain];


### PR DESCRIPTION
## 问题

在 iOS 上，`PAGAnimator` 的异步动画更新流程存在野指针风险，可能导致崩溃。

原实现中，`onAnimationWillUpdate` 在主线程对 `updaterTable.anyObject` 执行 `retain`，而 `onAnimationUpdate` 结束后通过 `dispatch_async` 到主线程时**重新读取** `updaterTable.anyObject` 再 `release`。由于 `updaterTable` 是 zeroing-weak 哈希表，若 updater 在这期间被释放，release 时读到的可能是不同对象或 nil，造成引用计数错配——要么泄漏，要么过度释放引发野指针崩溃。

## 修改

- 在 `onAnimationUpdate` 取值处直接 `retain`，并在方法结束时对**同一个捕获的指针**执行 `release`，使 retain/release 严格配对，消除错配。
- 该模式与 `onAnimationStart/End/Cancel/Repeat` 等兄弟回调保持一致。
- 移除不再需要的 `onAnimationWillUpdate` 空 override（基类已提供空默认实现）。

## 验证

已通过 `PAGFullTest` 编译验证。

Closes #3376