### PR TITLE
Add a wait timeout on the pending flush task to prevent main thread ANR when the hardware video decoder hangs.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "0b338ead7e866633a6033ca4a51e96022339ca3f",
+        "commit": "2cc1eb6efcf89204a8fa7045e57284efa9f1fa58",
         "dir": "third_party/tgfx"
       },
       {

--- a/src/rendering/PAGAnimator.cpp
+++ b/src/rendering/PAGAnimator.cpp
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "PAGAnimator.h"
+#include "base/utils/Log.h"
 #include "base/utils/TimeUtil.h"
 #include "platform/Platform.h"
 #include "rendering/utils/DisplayLinkWrapper.h"
@@ -220,8 +221,18 @@ void PAGAnimator::extractAndWaitTask(std::unique_lock<std::mutex>& lock) {
   auto pendingTask = std::move(task);
   task = nullptr;
   lock.unlock();
-  if (pendingTask) {
-    pendingTask->wait();
+  if (pendingTask == nullptr) {
+    return;
+  }
+  // Wait with a timeout to avoid blocking the caller thread indefinitely when the async flush task
+  // is stuck (for example, when the hardware video decoder hangs inside the system layer). If the
+  // timeout fires, the pending task is left running in the background and will release itself on
+  // completion.
+  static constexpr uint64_t TASK_WAIT_TIMEOUT_MS = 500;
+  if (!pendingTask->wait(TASK_WAIT_TIMEOUT_MS)) {
+    LOGE(
+        "PAGAnimator::extractAndWaitTask(): timed out waiting for the flush task, the task will "
+        "be abandoned in the background.");
   }
 }
 


### PR DESCRIPTION
When the hardware video decoder hangs inside the system layer, the async flush task may block indefinitely, causing the caller thread (often the main thread) to freeze and trigger ANR.

This change adds a 500ms timeout when waiting for the pending flush task in PAGAnimator::extractAndWaitTask. If the wait times out, the pending task is abandoned in the background and will release itself upon completion, allowing the caller thread to return promptly. An error log is emitted when a timeout occurs to aid diagnostics.