### PR TITLE
Fix PAGImageView unable to play PAG files from remote URLs on iOS

### DIFF
--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -594,9 +594,14 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
     filePath = nil;
   }
   filePath = [path retain];
-  auto file = pag::PAGFile::Load([path UTF8String]);
-  [self setCompositionInternal:file maxFrameRate:maxFrameRate];
-  return file != nullptr;
+  PAGFile* pagFile = [PAGFile Load:path];
+  std::shared_ptr<pag::PAGComposition> composition = nullptr;
+  if (pagFile != nil) {
+    auto layer = [[pagFile impl] pagLayer];
+    composition = std::static_pointer_cast<pag::PAGComposition>(layer);
+  }
+  [self setCompositionInternal:composition maxFrameRate:maxFrameRate];
+  return composition != nullptr;
 }
 
 - (void)setPathAsync:(NSString*)path completionBlock:(void (^)(PAGFile*))callback {
@@ -634,7 +639,7 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
 
 - (PAGComposition*)getComposition {
   std::lock_guard<std::mutex> autoLock(imageViewLock);
-  if (filePath || pagComposition == nullptr) {
+  if (filePath == nil && pagComposition == nullptr) {
     return nil;
   }
   return (PAGComposition*)[PAGLayerImpl ToPAGLayer:pagComposition];

--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -237,8 +237,12 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
     if (pagComposition) {
       pagDecoder = pag::PAGDecoder::MakeFrom(pagComposition, self.maxFrameRate, scaleFactor);
     } else if (filePath) {
-      auto file = pag::PAGFile::Load([filePath UTF8String]);
-      pagDecoder = pag::PAGDecoder::MakeFrom(file, self.maxFrameRate, scaleFactor);
+      PAGFile* pagFile = [PAGFile Load:filePath];
+      if (pagFile != nil) {
+        auto layer = [[pagFile impl] pagLayer];
+        auto composition = std::static_pointer_cast<pag::PAGComposition>(layer);
+        pagDecoder = pag::PAGDecoder::MakeFrom(composition, self.maxFrameRate, scaleFactor);
+      }
     }
     if (pagDecoder) {
       width = pagDecoder->width();
@@ -639,7 +643,7 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
 
 - (PAGComposition*)getComposition {
   std::lock_guard<std::mutex> autoLock(imageViewLock);
-  if (filePath == nil && pagComposition == nullptr) {
+  if (filePath || pagComposition == nullptr) {
     return nil;
   }
   return (PAGComposition*)[PAGLayerImpl ToPAGLayer:pagComposition];


### PR DESCRIPTION
## 问题背景

修复 iOS 端 `PAGImageView` 从 4.4.36 之后无法播放远程 URL（http/https/ftp）PAG 资源的问题。

Fixes #3311

## 根本原因

此前的提交 fdb634f8（#3169，"改用 C++ 接口避免引用计数崩溃"）将 `PAGImageView` 的加载入口从支持 URL 的 Objective-C 接口 `[PAGFile Load:]` 换成了原生 C++ 接口 `pag::PAGFile::Load(std::string)`。C++ 接口只能读取本地文件路径（`ByteData::FromPath`），无法拉取网络 URL，导致远程 URL 资源加载失败、无法渲染。

其中真正决定渲染的加载点在 `updatePAGDecoder`：由于 `setCompositionInternal` 在 `filePath` 非空时不会缓存 `pagComposition`，解码器始终走 `else if (filePath)` 分支，而该分支调用的正是不支持 URL 的 C++ 加载器。

## 修改内容

- **`updatePAGDecoder`**：`else if (filePath)` 分支改回支持 URL 的 `[PAGFile Load:filePath]`（内部处理 http/https/ftp 下载 + 磁盘缓存），再取出底层 C++ 对象交给 `PAGDecoder::MakeFrom`。这是恢复 URL 渲染能力的关键修复。
- **`setPath:maxFrameRate:`**：同样改用 `[PAGFile Load:path]` 加载，用于获取正确的文件尺寸/时长并返回加载结果。
- **`getComposition`**：guard 恢复为 `if (filePath || pagComposition == nullptr)`，与 fdb634f8 之前语义一致，避免在 `setComposition` 后再调 `setPath` 时返回过期的 composition。

以上改动在保留 fdb634f8 引入的 `std::shared_ptr` 引用计数安全架构的前提下，恢复了历史上正常的 URL 加载行为。

## 影响范围

仅影响 iOS 平台 `src/platform/ios/PAGImageView.mm`，正常本地文件加载路径行为不变。