### PR TITLE
Update tgfx dependency to fix CVE-2026-22184

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "2cc1eb6efcf89204a8fa7045e57284efa9f1fa58",
+        "commit": "f6cd2542c6c123942b8ba1e7c3b7e617af2cc641",
         "dir": "third_party/tgfx"
       },
       {


### PR DESCRIPTION
更新 tgfx 依赖以修复 zlib CVE-2026-22184 安全漏洞：

- tgfx DEPS 中 zlib 从 1.3.1 升级到 1.3.2
- 对应 CVE-2026-22184（TGZfname 全局缓冲区溢出漏洞）

Fixes #3230