### PR TITLE
Auto refresh repositioned layers on notifyChange layout.

### DIFF
--- a/include/pagx/PAGXDocument.h
+++ b/include/pagx/PAGXDocument.h
@@ -222,13 +222,11 @@ class PAGXDocument : public Node {
    * and content nodes; a content node refreshes its owning Layer. GlyphRun, Font, and Glyph are not
    * supported — edit the Text node with layoutChanged = true instead.
    *
-   * When layoutChanged is true, layout is re-run and any Layer whose layoutBounds changed as a
-   * side effect of the re-layout (for example, a sibling pushed by a flex container when one child
-   * is resized) is auto-refreshed as well — callers do not need to list such repositioned siblings.
-   * Only list nodes directly edited or whose own authored fields / child lists changed: the whole
-   * chain for an "@id" reference change, or the container Layer for a structural child-list edit.
-   * For external compositions, notify the document that owns the nodes; foreign nodes are skipped
-   * (see ownsNode()).
+   * When layoutChanged is true, only list nodes directly edited or whose child list changed: the
+   * whole chain for an "@id" reference change, or the container Layer for a structural child-list
+   * edit. Any other Layer that auto layout repositions as a side effect is refreshed automatically,
+   * so callers do not need to list such siblings. For external compositions, notify the document
+   * that owns the nodes; foreign nodes are skipped (see ownsNode()).
    *
    * @param dirtyNodes nodes whose fields or child lists changed. Must be owned by this document;
    * null and foreign entries are skipped; an empty list is a no-op.

--- a/include/pagx/PAGXDocument.h
+++ b/include/pagx/PAGXDocument.h
@@ -222,10 +222,13 @@ class PAGXDocument : public Node {
    * and content nodes; a content node refreshes its owning Layer. GlyphRun, Font, and Glyph are not
    * supported — edit the Text node with layoutChanged = true instead.
    *
-   * Only the listed nodes are refreshed, so include every node an edit affects: the whole chain for
-   * an "@id" reference change, and every Layer a layoutChanged re-layout repositions (or pass the
-   * container Layer). For external compositions, notify the document that owns the nodes; foreign
-   * nodes are skipped (see ownsNode()).
+   * When layoutChanged is true, layout is re-run and any Layer whose layoutBounds changed as a
+   * side effect of the re-layout (for example, a sibling pushed by a flex container when one child
+   * is resized) is auto-refreshed as well — callers do not need to list such repositioned siblings.
+   * Only list nodes directly edited or whose own authored fields / child lists changed: the whole
+   * chain for an "@id" reference change, or the container Layer for a structural child-list edit.
+   * For external compositions, notify the document that owns the nodes; foreign nodes are skipped
+   * (see ownsNode()).
    *
    * @param dirtyNodes nodes whose fields or child lists changed. Must be owned by this document;
    * null and foreign entries are skipped; an empty list is a no-op.
@@ -261,8 +264,12 @@ class PAGXDocument : public Node {
 
   // Recursive layout worker. visited holds the documents on the current ancestor path so an
   // externalDoc cycle built directly through the API (bypassing loadFileData's own chain guard)
-  // is detected and stops the recursion instead of overflowing the stack.
-  void applyLayout(const FontConfig* config, std::unordered_set<const PAGXDocument*>& visited);
+  // is detected and stops the recursion instead of overflowing the stack. When changedOut is not
+  // null and the document was already laid out, every Layer whose layoutBounds differ from before
+  // the re-layout is appended to it, so notifyChange can auto-refresh siblings that auto layout
+  // repositioned without the caller having to list them.
+  void applyLayout(const FontConfig* config, std::unordered_set<const PAGXDocument*>& visited,
+                   std::vector<Layer*>* changedOut);
   static void layoutLayers(const std::vector<Layer*>& layers, float containerW, float containerH,
                            LayoutContext* context);
 

--- a/src/pagx/PAGXDocument.cpp
+++ b/src/pagx/PAGXDocument.cpp
@@ -169,11 +169,12 @@ static bool LoadFileDataInChain(
 
 void PAGXDocument::applyLayout(const FontConfig* config) {
   std::unordered_set<const PAGXDocument*> visited = {};
-  applyLayout(config, visited);
+  applyLayout(config, visited, nullptr);
 }
 
 void PAGXDocument::applyLayout(const FontConfig* config,
-                               std::unordered_set<const PAGXDocument*>& visited) {
+                               std::unordered_set<const PAGXDocument*>& visited,
+                               std::vector<Layer*>* changedOut) {
   if (!visited.insert(this).second) {
     errors.push_back("Cyclic external composition reference detected during layout.");
     return;
@@ -184,12 +185,20 @@ void PAGXDocument::applyLayout(const FontConfig* config,
   // Re-running layout on an already-laid-out document (e.g. from notifyChange after an edit) must
   // discard the cached layout outputs first; updateSize() skips re-measuring a node whose preferred
   // size is already set, so without this a size/constraint edit would keep the stale geometry.
+  // When changedOut is requested, snapshot each Layer's layoutBounds here (before resetLayout()
+  // clears them to NAN) so the post-layout pass can detect which Layers auto layout repositioned.
+  std::unordered_map<Layer*, Rect> beforeBounds = {};
   if (layoutApplied) {
     for (auto& node : nodes) {
       switch (node->nodeType()) {
-        case NodeType::Layer:
-          static_cast<Layer*>(node.get())->resetLayout();
+        case NodeType::Layer: {
+          auto* layer = static_cast<Layer*>(node.get());
+          if (changedOut != nullptr) {
+            beforeBounds.emplace(layer, layer->layoutBounds());
+          }
+          layer->resetLayout();
           break;
+        }
         case NodeType::Rectangle:
         case NodeType::Ellipse:
         case NodeType::Path:
@@ -226,7 +235,9 @@ void PAGXDocument::applyLayout(const FontConfig* config,
         // its own layoutApplied flag internally. The host's fontConfig is passed down intentionally
         // so external compositions are measured and rendered with the host's fonts, keeping text
         // consistent across the embedded boundary rather than using the external doc's own config.
-        layer->externalDoc->applyLayout(&fontConfig, visited);
+        // changedOut is intentionally not forwarded: an external document has its own notifyChange
+        // chain, and runtime layers inside it are rebuilt by that document's scenes.
+        layer->externalDoc->applyLayout(&fontConfig, visited, nullptr);
       }
     }
   }
@@ -234,6 +245,16 @@ void PAGXDocument::applyLayout(const FontConfig* config,
   // leave the document flagged as laid out even when a downstream cycle aborts the recursion,
   // letting PAGScene::Make build from an inconsistent tree.
   layoutApplied = true;
+  if (changedOut != nullptr) {
+    // Layout is deterministic, so a Layer that auto layout did not move produces an identical
+    // layoutBounds; only those whose bounds actually changed are appended, so notifyChange can
+    // refresh the repositioned siblings the caller did not list.
+    for (auto& [layer, oldBounds] : beforeBounds) {
+      if (layer->layoutBounds() != oldBounds) {
+        changedOut->push_back(layer);
+      }
+    }
+  }
   visited.erase(this);
 }
 
@@ -579,8 +600,22 @@ void PAGXDocument::notifyChange(const std::vector<Node*>& dirtyNodes, bool layou
   // list changes require a full re-layout, since layout is resolved top-down and a single node
   // cannot be re-measured in isolation. applyLayout() discards the cached layout outputs first when
   // the document is already laid out (see its reset branch). Pure render edits skip this entirely.
+  // Auto layout can reposition siblings the caller did not list (e.g. a flex container pushing
+  // other children when one child is resized); applyLayout collects every Layer whose layoutBounds
+  // changed, and those are merged into ownedDirty below so refreshNodes re-syncs their runtime
+  // transform too.
   if (layoutChanged) {
-    applyLayout();
+    std::unordered_set<const PAGXDocument*> visited = {};
+    std::vector<Layer*> layoutRepositioned = {};
+    applyLayout(nullptr, visited, &layoutRepositioned);
+    if (!layoutRepositioned.empty()) {
+      ownedDirty.reserve(ownedDirty.size() + layoutRepositioned.size());
+      for (auto* layer : layoutRepositioned) {
+        ownedDirty.push_back(layer);
+      }
+      std::sort(ownedDirty.begin(), ownedDirty.end());
+      ownedDirty.erase(std::unique(ownedDirty.begin(), ownedDirty.end()), ownedDirty.end());
+    }
   }
   for (auto& weakScene : liveScenes) {
     auto scene = weakScene.lock();

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -10909,6 +10909,73 @@ PAGX_TEST(PAGXTest, NotifyChangeDocumentSizeConstraints) {
   EXPECT_TRUE(Baseline::Compare(surface, "PAGXTest/NotifyChangeDocumentSize_after"));
 }
 
+/**
+ * Test case: when a flex child is resized and only that child is notified, sibling layers that
+ * auto-layout repositioned are auto-refreshed by the engine (their runtime transform is re-synced)
+ * without the caller having to list them in dirtyNodes.
+ */
+PAGX_TEST(PAGXTest, NotifyChangeAutoLayoutRepositionsSiblings) {
+  auto doc = pagx::PAGXDocument::Make(400, 600);
+
+  auto parent = doc->makeNode<pagx::Layer>("parent");
+  parent->width = 400;
+  parent->height = 600;
+  parent->layout = pagx::LayoutMode::Vertical;
+  parent->gap = 10;
+  doc->layers = {parent};
+
+  auto child1 = doc->makeNode<pagx::Layer>("child1");
+  child1->width = 100;
+  child1->height = 100;
+  auto rect1 = doc->makeNode<pagx::Rectangle>();
+  rect1->size.width = 100;
+  rect1->size.height = 100;
+  auto fill1 = doc->makeNode<pagx::Fill>();
+  auto solid1 = doc->makeNode<pagx::SolidColor>();
+  solid1->color = {1, 0, 0, 1};
+  fill1->color = solid1;
+  child1->contents = {rect1, fill1};
+
+  auto child2 = doc->makeNode<pagx::Layer>("child2");
+  child2->width = 100;
+  child2->height = 150;
+  auto rect2 = doc->makeNode<pagx::Rectangle>();
+  rect2->size.width = 100;
+  rect2->size.height = 150;
+  auto fill2 = doc->makeNode<pagx::Fill>();
+  auto solid2 = doc->makeNode<pagx::SolidColor>();
+  solid2->color = {0, 0, 1, 1};
+  fill2->color = solid2;
+  child2->contents = {rect2, fill2};
+
+  parent->children = {child1, child2};
+
+  auto scene = pagx::PAGScene::Make(doc);
+  ASSERT_TRUE(scene != nullptr);
+
+  ASSERT_EQ(scene->rootComposition()->children.size(), 1u);
+  auto& parentChildren = scene->rootComposition()->children[0]->children;
+  ASSERT_EQ(parentChildren.size(), 2u);
+  auto child2Handle = parentChildren[1];
+
+  // child1 at y=0 (first flex child), child2 at y=110 (100 + 10 gap).
+  EXPECT_NEAR(child1->renderPosition().y, 0.0f, 1.0e-3f);
+  EXPECT_NEAR(child2->renderPosition().y, 110.0f, 1.0e-3f);
+  auto bounds = scene->getGlobalBounds(child2Handle);
+  EXPECT_NEAR(bounds.y, 110.0f, 1.0e-3f);
+
+  // Resize child1 only and notify ONLY child1. Auto layout pushes child2 down to y=210.
+  child1->height = 200;
+  rect1->size.height = 200;
+  doc->notifyChange({child1}, /*layoutChanged=*/true);
+
+  // Data model: child2 moved to y=210 (200 + 10 gap).
+  EXPECT_NEAR(child2->renderPosition().y, 210.0f, 1.0e-3f);
+  // Runtime: child2's transform must also reflect the new position without notifying it.
+  bounds = scene->getGlobalBounds(child2Handle);
+  EXPECT_NEAR(bounds.y, 210.0f, 1.0e-3f);
+}
+
 PAGX_TEST(PAGXTest, GetRequiredFonts) {
   auto doc = pagx::PAGXDocument::Make(200, 200);
   // No fonts yet.


### PR DESCRIPTION
修复 notifyChange(layoutChanged=true) 时被自动布局重新定位的兄弟 Layer 不刷新的问题。

之前只刷新调用者明确列出的节点，flex 等自动布局推动的兄弟 Layer 数据模型位置已变但 runtime 渲染未同步。现在这类被重新定位的 Layer 会自动刷新，调用者无需逐个列出。