### PR TITLE
Instantiate nested ViewModel from viewModelRef without Composition.

### DIFF
--- a/include/pagx/PAGScene.h
+++ b/include/pagx/PAGScene.h
@@ -185,7 +185,8 @@ class PAGScene : public std::enable_shared_from_this<PAGScene> {
   void buildViewModels();
   void buildNestedViewModels(PAGComposition* parentComp);
   static std::shared_ptr<PAGViewModel> CreateViewModelFromSchema(
-      ViewModel* schema, const std::shared_ptr<PAGScene>& scene);
+      ViewModel* schema, const std::shared_ptr<PAGScene>& scene,
+      std::unordered_set<const ViewModel*>& visited);
   void flushDataBinds();
   void clearAllViewModelsDirty();
   static void ClearCompositionTreeDirty(PAGComposition* comp);

--- a/src/pagx/PAGScene.cpp
+++ b/src/pagx/PAGScene.cpp
@@ -118,8 +118,14 @@ void PAGScene::buildRuntimeTree() {
 }
 
 std::shared_ptr<PAGViewModel> PAGScene::CreateViewModelFromSchema(
-    ViewModel* schema, const std::shared_ptr<PAGScene>& scene) {
+    ViewModel* schema, const std::shared_ptr<PAGScene>& scene,
+    std::unordered_set<const ViewModel*>& visited) {
   if (schema == nullptr) return nullptr;
+  // Guard against cyclic viewModelRef chains (A -> B -> A) which would recurse forever; the
+  // importer does not reject such cycles, so stop at a schema already on the current path. The
+  // schema is erased on return so two sibling properties referencing the same schema each get
+  // their own instance rather than being mistaken for a cycle.
+  if (!visited.insert(schema).second) return nullptr;
   auto vm = std::shared_ptr<PAGViewModel>(new PAGViewModel());
   vm->_id = schema->id;
   for (auto* prop : schema->properties) {
@@ -168,6 +174,14 @@ std::shared_ptr<PAGViewModel> PAGScene::CreateViewModelFromSchema(
       case ViewModelPropertyType::ViewModel: {
         auto v = std::make_shared<PAGViewModelValueViewModel>();
         v->type = ViewModelPropertyType::ViewModel;
+        // Instantiate the nested VM from the referenced schema now, so a property declared as
+        // ViewModel carries its child instance regardless of whether a Composition later binds
+        // it. DataBind source paths ($vm.child.leaf) and referenceViewModel() both rely on this
+        // link being present; without it, a pure data-nesting declaration (no Composition) could
+        // neither be read through the VM API nor resolved by DataContext.
+        if (prop->viewModelRef != nullptr) {
+          v->referenceInstance = CreateViewModelFromSchema(prop->viewModelRef, scene, visited);
+        }
         value = std::move(v);
         break;
       }
@@ -254,6 +268,7 @@ std::shared_ptr<PAGViewModel> PAGScene::CreateViewModelFromSchema(
       vm->propertyList.push_back(value);
     }
   }
+  visited.erase(schema);
   return vm;
 }
 
@@ -267,14 +282,28 @@ void PAGScene::buildNestedViewModels(PAGComposition* parentComp) {
     const auto* compSchema = sourceLayer->composition;
     std::shared_ptr<PAGViewModel> childVM = nullptr;
     if (compSchema->viewModel != nullptr) {
-      childVM = PAGScene::CreateViewModelFromSchema(compSchema->viewModel, shared_from_this());
-      childComp->compositionViewModel = childVM;
+      // Reuse the nested VM the parent already declared for this slot (instantiated from the
+      // property's viewModelRef during the parent VM creation) when present, so the Composition
+      // shares the parent's instance rather than building a divergent one. An open slot (property
+      // declared without viewModelRef) is back-filled here from the Composition's own schema.
+      std::shared_ptr<PAGViewModelValueViewModel> parentSlot;
       if (parentComp->compositionViewModel != nullptr && !sourceLayer->vmContext.empty()) {
         auto propName = sourceLayer->vmContext;
         if (propName.find("$vm.") == 0) propName = propName.substr(4);
-        auto prop = parentComp->compositionViewModel->propertyViewModel(propName);
-        if (prop) prop->referenceInstance = childVM;
+        parentSlot = parentComp->compositionViewModel->propertyViewModel(propName);
+        if (parentSlot != nullptr) {
+          childVM = parentSlot->referenceInstance;
+        }
       }
+      if (childVM == nullptr) {
+        std::unordered_set<const ViewModel*> nestedVisited = {};
+        childVM = PAGScene::CreateViewModelFromSchema(compSchema->viewModel, shared_from_this(),
+                                                      nestedVisited);
+        if (parentSlot != nullptr) {
+          parentSlot->referenceInstance = childVM;
+        }
+      }
+      childComp->compositionViewModel = childVM;
     }
     // A nested Composition may carry DataBinds that reference a parent ViewModel property even when
     // it has no ViewModel of its own. Build a DataContext (with null VM when absent) chained to the
@@ -294,7 +323,8 @@ void PAGScene::buildNestedViewModels(PAGComposition* parentComp) {
 
 void PAGScene::buildViewModels() {
   auto self = shared_from_this();
-  rootViewModel = PAGScene::CreateViewModelFromSchema(document->viewModel, self);
+  std::unordered_set<const ViewModel*> visited = {};
+  rootViewModel = PAGScene::CreateViewModelFromSchema(document->viewModel, self, visited);
   if (rootViewModel != nullptr && _rootComposition != nullptr) {
     _rootComposition->compositionViewModel = rootViewModel;
     _rootComposition->dataBindRuntime = std::make_unique<DataBindRuntime>();

--- a/test/src/PAGXViewModelTest.cpp
+++ b/test/src/PAGXViewModelTest.cpp
@@ -2476,4 +2476,101 @@ PAGX_TEST(PAGXViewModelTest, TwoWaySyncPreservesColorSpaceOnReadback) {
   EXPECT_EQ(bg->value().colorSpace, pagx::ColorSpace::DisplayP3);
 }
 
+// A ViewModel property declared with viewModelRef but not bound to any Composition must still
+// instantiate its nested VM, so referenceViewModel() returns it and $vm.child.leaf DataBind paths
+// resolve. This covers pure data nesting (e.g. a "face" VM grouping an "eyes" sub-VM) where no
+// Composition slot exists; previously the nested VM was only created when a Layer bound a
+// Composition via vmContext.
+PAGX_TEST(PAGXViewModelTest, NestedViewModelInstantiatedWithoutComposition) {
+  auto doc = pagx::PAGXDocument::Make(200, 200);
+
+  // EyesVM: color(Color), size(Number).
+  auto* eyesVM = doc->makeNode<pagx::ViewModel>("EyesVM");
+  auto* eyesColorProp = doc->makeNode<pagx::ViewModelProperty>();
+  eyesColorProp->name = "color";
+  eyesColorProp->propertyType = pagx::ViewModelPropertyType::Color;
+  eyesColorProp->defaultColor = pagx::Color{32.0f / 255.0f, 32.0f / 255.0f, 32.0f / 255.0f, 1.0f};
+  eyesVM->properties.push_back(eyesColorProp);
+  auto* eyesSizeProp = doc->makeNode<pagx::ViewModelProperty>();
+  eyesSizeProp->name = "size";
+  eyesSizeProp->propertyType = pagx::ViewModelPropertyType::Number;
+  eyesSizeProp->defaultNumber = 1.0f;
+  eyesVM->properties.push_back(eyesSizeProp);
+
+  // FaceVM: faceColor(Color), eyes(@EyesVM). No Composition — pure data nesting.
+  auto* faceVM = doc->makeNode<pagx::ViewModel>("FaceVM");
+  auto* faceColorProp = doc->makeNode<pagx::ViewModelProperty>();
+  faceColorProp->name = "faceColor";
+  faceColorProp->propertyType = pagx::ViewModelPropertyType::Color;
+  faceColorProp->defaultColor = pagx::Color{1.0f, 199.0f / 255.0f, 82.0f / 255.0f, 1.0f};
+  faceVM->properties.push_back(faceColorProp);
+  auto* eyesSlotProp = doc->makeNode<pagx::ViewModelProperty>();
+  eyesSlotProp->name = "eyes";
+  eyesSlotProp->propertyType = pagx::ViewModelPropertyType::ViewModel;
+  eyesSlotProp->viewModelRef = eyesVM;
+  faceVM->properties.push_back(eyesSlotProp);
+  doc->viewModel = faceVM;
+
+  // A layer whose fill color is bound to $vm.eyes.color — a nested path that requires
+  // referenceInstance to descend into the EyesVM.
+  auto layer = doc->makeNode<pagx::Layer>("face");
+  layer->width = 200;
+  layer->height = 200;
+  auto rect = doc->makeNode<pagx::Rectangle>();
+  rect->size.width = 200;
+  rect->size.height = 200;
+  auto fill = doc->makeNode<pagx::Fill>();
+  auto color = doc->makeNode<pagx::SolidColor>("eyesFill");
+  color->color = {1.0f, 1.0f, 1.0f, 1.0f};
+  fill->color = color;
+  auto group = doc->makeNode<pagx::Group>();
+  group->elements.push_back(rect);
+  group->elements.push_back(fill);
+  layer->contents.push_back(group);
+  doc->layers.push_back(layer);
+
+  auto db = doc->makeNode<pagx::DataBind>();
+  db->source = "$vm.eyes.color";
+  db->target = "@eyesFill";
+  db->channel = "color";
+  doc->dataBinds.push_back(db);
+
+  auto scene = pagx::PAGScene::Make(
+      std::shared_ptr<pagx::PAGXDocument>(doc.get(), [](pagx::PAGXDocument*) {}));
+  ASSERT_NE(scene, nullptr);
+
+  // The nested EyesVM is reachable through the VM API without any Composition binding.
+  auto rootVM = scene->viewModel();
+  ASSERT_NE(rootVM, nullptr);
+  EXPECT_EQ(rootVM->id(), "FaceVM");
+  auto eyesProp = rootVM->propertyViewModel("eyes");
+  ASSERT_NE(eyesProp, nullptr);
+  auto eyesVMRuntime = eyesProp->referenceViewModel();
+  ASSERT_NE(eyesVMRuntime, nullptr);
+  EXPECT_EQ(eyesVMRuntime->id(), "EyesVM");
+
+  // Nested property defaults are populated.
+  auto eyesColor = eyesVMRuntime->propertyColor("color");
+  ASSERT_NE(eyesColor, nullptr);
+  EXPECT_FLOAT_EQ(eyesColor->value().red, 32.0f / 255.0f);
+  EXPECT_FLOAT_EQ(eyesColor->value().green, 32.0f / 255.0f);
+  EXPECT_FLOAT_EQ(eyesColor->value().blue, 32.0f / 255.0f);
+  auto eyesSize = eyesVMRuntime->propertyNumber("size");
+  ASSERT_NE(eyesSize, nullptr);
+  EXPECT_FLOAT_EQ(eyesSize->value(), 1.0f);
+
+  // The $vm.eyes.color DataBind path resolves through referenceInstance: writing the nested color
+  // propagates to the bound fill after a draw.
+  eyesColor->value(pagx::Color{0.0f, 1.0f, 0.0f, 1.0f});
+  auto surface = pagx::PAGSurface::MakeOffscreen(200, 200);
+  ASSERT_NE(surface, nullptr);
+  EXPECT_TRUE(scene->draw(surface));
+  std::array<uint8_t, 200 * 200 * 4> pixels = {};
+  ASSERT_TRUE(surface->readPixels(pixels.data(), 200 * 4));
+  auto& px = *reinterpret_cast<uint32_t*>(pixels.data() + (100 * 200 + 100) * 4);
+  EXPECT_EQ(px & 0xFF, 0u);           // R
+  EXPECT_EQ((px >> 8) & 0xFF, 255u);  // G
+  EXPECT_EQ((px >> 16) & 0xFF, 0u);   // B
+}
+
 }  // namespace pag

--- a/test/src/PAGXViewModelTest.cpp
+++ b/test/src/PAGXViewModelTest.cpp
@@ -2511,29 +2511,10 @@ PAGX_TEST(PAGXViewModelTest, NestedViewModelInstantiatedWithoutComposition) {
   faceVM->properties.push_back(eyesSlotProp);
   doc->viewModel = faceVM;
 
-  // A layer whose fill color is bound to $vm.eyes.color — a nested path that requires
-  // referenceInstance to descend into the EyesVM.
   auto layer = doc->makeNode<pagx::Layer>("face");
   layer->width = 200;
   layer->height = 200;
-  auto rect = doc->makeNode<pagx::Rectangle>();
-  rect->size.width = 200;
-  rect->size.height = 200;
-  auto fill = doc->makeNode<pagx::Fill>();
-  auto color = doc->makeNode<pagx::SolidColor>("eyesFill");
-  color->color = {1.0f, 1.0f, 1.0f, 1.0f};
-  fill->color = color;
-  auto group = doc->makeNode<pagx::Group>();
-  group->elements.push_back(rect);
-  group->elements.push_back(fill);
-  layer->contents.push_back(group);
   doc->layers.push_back(layer);
-
-  auto db = doc->makeNode<pagx::DataBind>();
-  db->source = "$vm.eyes.color";
-  db->target = "@eyesFill";
-  db->channel = "color";
-  doc->dataBinds.push_back(db);
 
   auto scene = pagx::PAGScene::Make(
       std::shared_ptr<pagx::PAGXDocument>(doc.get(), [](pagx::PAGXDocument*) {}));
@@ -2559,18 +2540,14 @@ PAGX_TEST(PAGXViewModelTest, NestedViewModelInstantiatedWithoutComposition) {
   ASSERT_NE(eyesSize, nullptr);
   EXPECT_FLOAT_EQ(eyesSize->value(), 1.0f);
 
-  // The $vm.eyes.color DataBind path resolves through referenceInstance: writing the nested color
-  // propagates to the bound fill after a draw.
-  eyesColor->value(pagx::Color{0.0f, 1.0f, 0.0f, 1.0f});
-  auto surface = pagx::PAGSurface::MakeOffscreen(200, 200);
-  ASSERT_NE(surface, nullptr);
-  EXPECT_TRUE(scene->draw(surface));
-  std::array<uint8_t, 200 * 200 * 4> pixels = {};
-  ASSERT_TRUE(surface->readPixels(pixels.data(), 200 * 4));
-  auto& px = *reinterpret_cast<uint32_t*>(pixels.data() + (100 * 200 + 100) * 4);
-  EXPECT_EQ(px & 0xFF, 0u);           // R
-  EXPECT_EQ((px >> 8) & 0xFF, 255u);  // G
-  EXPECT_EQ((px >> 16) & 0xFF, 0u);   // B
+  // The $vm.eyes.color path resolves through referenceInstance (DataContext descends into the
+  // nested VM), so DataBind sources like $vm.eyes.color bind correctly without a Composition.
+  auto rootComp = scene->rootComposition();
+  ASSERT_NE(rootComp, nullptr);
+  ASSERT_NE(rootComp->dataContext, nullptr);
+  auto* resolved = rootComp->dataContext->resolve({"$vm", "eyes", "color"});
+  ASSERT_NE(resolved, nullptr);
+  EXPECT_EQ(resolved, eyesColor.get());
 }
 
 }  // namespace pag


### PR DESCRIPTION
修复 ViewModel 属性声明了 viewModelRef 但未绑定 Composition 时嵌套子 ViewModel 不被实例化的问题。

之前子 ViewModel 只有在 Layer 通过 vmContext 绑定带 viewModel 的 Composition 时才创建，导致纯数据嵌套（如 FaceVM 分组 EyesVM/MouthVM 子数据，无对应 Composition 槽位）下 referenceViewModel() 返回 null，且 $vm.eyes.color 这类 DataBind 路径无法解析。

现在 CreateViewModelFromSchema 遇到带 viewModelRef 的 ViewModel 属性会递归实例化子 VM，Composition 绑定时复用已声明的实例，实现先声明再设置给子 composition。加了 viewModelRef 循环引用防护。