### PR TITLE
Add a global mutex to serialize PAGDecoder frame rendering across shared EGL contexts.

### DIFF
--- a/src/rendering/PAGDecoder.cpp
+++ b/src/rendering/PAGDecoder.cpp
@@ -30,6 +30,8 @@
 
 namespace pag {
 
+static std::mutex renderLocker = {};
+
 static std::string DefaultCacheKeyGeneratorFunc(PAGDecoder* decoder,
                                                 std::shared_ptr<PAGComposition> composition) {
   if (!composition->isPAGFile() || pag::ContentVersion::Get(composition) > 0) {
@@ -196,6 +198,7 @@ bool PAGDecoder::readFrameInternal(int index, std::shared_ptr<BitmapBuffer> bitm
   }
   auto success = sequenceFile->readFrame(index, bitmap);
   if (!success) {
+    std::lock_guard<std::mutex> autoLock(renderLocker);
     success = renderFrame(composition, index, bitmap);
     if (success) {
       success = sequenceFile->writeFrame(index, bitmap);


### PR DESCRIPTION
## 问题

使用多个 PAGImageView 同时播放时，首次渲染（无缓存）会出现帧错乱。例如视图 A 渲染出视图 B 的某一帧，且错误帧被写入磁盘缓存后重启也无法恢复。

低端设备（小米 Note8 Pro、华为 P20）偶现，详见 #3540。

## 根因

多个 PAGDecoder 在创建时通过 `GLDevice::CurrentNativeHandle()` 获取到同一个 EGLContext 作为 sharedContext。各自的 `BitmapDrawable` 又通过 `GLDevice::Make(sharedContext)` 创建了共享同一 EGL display 和 GL 对象命名空间的新 EGLContext。

在 PAGAnimator 异步渲染模式下（`_isSync = false`），`tgfx::Task::Run()` 将不同 PAGImageView 的 `onAnimationUpdate` 回调分发到线程池的不同线程上执行，导致多个 Decoder 的 `renderFrame()` 在不同线程上并发执行 GL 命令。低端设备的 GPU 驱动无法正确处理共享 EGL 上下文的并发访问，导致渲染目标混乱。

## 修复

在 `PAGDecoder::readFrameInternal()` 中新增静态全局互斥锁 `renderLocker`，包裹 `renderFrame()` 和 `writeFrame()` 调用。缓存命中时不进入锁区，仅首次 GPU 渲染时串行化，确保不同线程的 GL 命令不会交错执行。

改动量：3 行代码，无公开 API 变更。