### PR TITLE
Replace JNI string conversion workarounds with direct NewStringUTF and GetStringUTFChars to fix FindClass crash on background threads.

### DIFF
--- a/src/platform/android/JStringUtil.cpp
+++ b/src/platform/android/JStringUtil.cpp
@@ -17,56 +17,22 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "JStringUtil.h"
-#include <cstring>
 
 namespace pag {
-/**
- * There is a known bug in env->NewStringUTF which will lead to crash in some devices.
- * So we use this method instead.
- */
 jstring SafeConvertToJString(JNIEnv* env, const std::string& text) {
-  static Global<jclass> StringClass = env->FindClass("java/lang/String");
-  static jmethodID StringConstructID =
-      env->GetMethodID(StringClass.get(), "<init>", "([BLjava/lang/String;)V");
-  auto array = env->NewByteArray(static_cast<jsize>(text.size()));
-  if (array == nullptr) {
-    return nullptr;
-  }
-  env->SetByteArrayRegion(array, 0, static_cast<jsize>(text.size()),
-                          reinterpret_cast<const jbyte*>(text.data()));
-  auto stringUTF = env->NewStringUTF("UTF-8");
-  auto result = (jstring)env->NewObject(StringClass.get(), StringConstructID, array, stringUTF);
-  env->DeleteLocalRef(array);
-  env->DeleteLocalRef(stringUTF);
-  return result;
+  return env->NewStringUTF(text.c_str());
 }
 
 std::string SafeConvertToStdString(JNIEnv* env, jstring jText) {
   if (jText == nullptr) {
     return "";
   }
-  std::string result;
-  static Global<jclass> StringClass = env->FindClass("java/lang/String");
-  static jmethodID GetBytesID =
-      env->GetMethodID(StringClass.get(), "getBytes", "(Ljava/lang/String;)[B");
-  auto encoding = env->NewStringUTF("utf-8");
-  auto jBytes = (jbyteArray)env->CallObjectMethod(jText, GetBytesID, encoding);
-  env->DeleteLocalRef(encoding);
-  if (env->ExceptionCheck()) {
-    env->ExceptionClear();
+  const char* chars = env->GetStringUTFChars(jText, nullptr);
+  if (chars == nullptr) {
     return "";
   }
-  if (jBytes == nullptr) {
-    return "";
-  }
-  auto textLength = env->GetArrayLength(jBytes);
-  if (textLength > 0) {
-    char* bytes = new char[textLength];
-    env->GetByteArrayRegion(jBytes, 0, textLength, (jbyte*)bytes);
-    result = std::string(bytes, (unsigned)textLength);
-    delete[] bytes;
-  }
-  env->DeleteLocalRef(jBytes);
+  std::string result(chars);
+  env->ReleaseStringUTFChars(jText, chars);
   return result;
 }
 }  // namespace pag

--- a/src/platform/android/JStringUtil.h
+++ b/src/platform/android/JStringUtil.h
@@ -20,7 +20,6 @@
 
 #include <jni.h>
 #include <string>
-#include "JNIHelper.h"
 
 namespace pag {
 jstring SafeConvertToJString(JNIEnv* env, const std::string& text);


### PR DESCRIPTION
## 问题

`SafeConvertToJString` 和 `SafeConvertToStdString` 使用 `static` 懒初始化缓存 `java/lang/String` 类，通过 `FindClass` 查找。如果首次调用发生在后台线程（如 `ThreadPoolExecutor`），`FindClass` 可能因为线程的 ClassLoader 上下文不完整而返回 null，触发 CheckJNI abort（`java_class == null`）。

相关 issue：#3104、#3175

## 根因

原实现为了规避 Android 4.x Dalvik 时代 `NewStringUTF` 对 4 字节 UTF-8 字符的崩溃问题，采用了绕路方案：通过 `FindClass` → `GetMethodID` → `NewObject` 来构造 Java String。但 `FindClass` 在不同线程上行为不可靠。

libpag 当前 minSdk 为 21（Android 5.0+），运行时已切换为 ART，该 `NewStringUTF` bug 已在 ART 中修复。

## 修复

- `SafeConvertToJString`：直接用 `env->NewStringUTF()` 替代 Java 构造器绕路
- `SafeConvertToStdString`：直接用 `GetStringUTFChars`/`ReleaseStringUTFChars` 替代 Java `getBytes()` 回调

改动量：2 文件，+5 -40 行。消除所有 `static FindClass` 依赖，在任何线程调用都安全。