### PR TITLE
Reduce PAGImageView ANR on detach/resize/setPath by making DecoderInfo reset non-blocking when the hardware decoder hangs

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGImageView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageView.java
@@ -500,7 +500,8 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
     }
 
     protected void initDecoderInfo() {
-        synchronized (decoderInfo) {
+        decoderInfo.lock();
+        try {
             if (!decoderInfo.isValid()) {
                 if (_composition == null) {
                     _composition = getCompositionFromPath(_pagFilePath);
@@ -516,6 +517,8 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
             }
             refreshMatrixFromScaleMode();
             freezeDraw.set(false);
+        } finally {
+            decoderInfo.unlock();
         }
     }
 

--- a/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
@@ -116,12 +116,9 @@ class PAGImageViewHelper {
         }
 
         boolean isValid() {
-            locker.lock();
-            try {
-                return _width > 0 && _height > 0 && decoderToken == resetToken.get();
-            } finally {
-                locker.unlock();
-            }
+            // Lock-free: all fields are volatile or atomic, so this read is safe without holding
+            // the lock and avoids blocking the main thread when the worker is stuck in readFrame().
+            return _width > 0 && _height > 0 && decoderToken == resetToken.get();
         }
 
         boolean hasPAGDecoder() {
@@ -183,9 +180,20 @@ class PAGImageViewHelper {
                 } else {
                     scaleFactor = height * 1.0f / composition.height();
                 }
-                _pagDecoder = PAGDecoder.Make(composition, maxFrameRate, scaleFactor);
-                _width = _pagDecoder.width();
-                _height = _pagDecoder.height();
+                PAGDecoder decoder = PAGDecoder.Make(composition, maxFrameRate, scaleFactor);
+                if (decoder == null) {
+                    return false;
+                }
+                // Re-check the reset token after the slow Make() call. If reset() was called during
+                // Make(), the token will have been bumped, meaning this decoder is already stale and
+                // should not overwrite the reset state.
+                if (resetToken.get() != token) {
+                    decoder.release();
+                    return false;
+                }
+                _pagDecoder = decoder;
+                _width = decoder.width();
+                _height = decoder.height();
                 duration = composition.duration();
                 decoderToken = token;
                 return true;

--- a/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
@@ -22,6 +22,8 @@ import android.graphics.Bitmap;
 import android.graphics.Matrix;
 import android.hardware.HardwareBuffer;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 class PAGImageViewHelper {
 
     protected static Matrix ApplyScaleMode(int scaleMode, int sourceWidth, int sourceHeight,
@@ -96,63 +98,129 @@ class PAGImageViewHelper {
         int _height;
         long duration;
         private PAGDecoder _pagDecoder;
+        private final ReentrantLock locker = new ReentrantLock();
 
-        synchronized boolean isValid() {
-            return _width > 0 && _height > 0;
+        void lock() {
+            locker.lock();
         }
 
-        synchronized boolean hasPAGDecoder() {
-            return _pagDecoder != null;
+        void unlock() {
+            locker.unlock();
         }
 
-        synchronized boolean checkFrameChanged(int currentFrame) {
-            return _pagDecoder != null && _pagDecoder.checkFrameChanged(currentFrame);
-        }
-
-        synchronized boolean readFrame(int currentFrame, HardwareBuffer hardwareBuffer) {
-            return _pagDecoder != null && hardwareBuffer != null && _pagDecoder.readFrame(currentFrame,
-                    hardwareBuffer);
-        }
-
-        synchronized boolean copyFrameTo(Bitmap bitmap, int currentFrame) {
-            return _pagDecoder != null && bitmap != null && _pagDecoder.copyFrameTo(bitmap,
-                    currentFrame);
-        }
-
-        synchronized boolean initDecoder(PAGComposition composition, int width, int height,
-                                         float maxFrameRate) {
-            if (composition == null || width <= 0 || height <= 0 || maxFrameRate <= 0) {
-                return false;
-            }
-            float scaleFactor;
-            if (composition.width() >= composition.height()) {
-                scaleFactor = width * 1.0f / composition.width();
-            } else {
-                scaleFactor = height * 1.0f / composition.height();
-            }
-            _pagDecoder = PAGDecoder.Make(composition, maxFrameRate, scaleFactor);
-            _width = _pagDecoder.width();
-            _height = _pagDecoder.height();
-            duration = composition.duration();
-            return true;
-        }
-
-        synchronized void releaseDecoder() {
-            if (_pagDecoder != null) {
-                _pagDecoder.release();
-                _pagDecoder = null;
+        boolean isValid() {
+            locker.lock();
+            try {
+                return _width > 0 && _height > 0;
+            } finally {
+                locker.unlock();
             }
         }
 
-        synchronized void reset() {
-            releaseDecoder();
-            _width = 0;
-            _height = 0;
-            duration = 0;
+        boolean hasPAGDecoder() {
+            locker.lock();
+            try {
+                return _pagDecoder != null;
+            } finally {
+                locker.unlock();
+            }
         }
 
-        synchronized int numFrames() {
-            return _pagDecoder == null ? 0 : _pagDecoder.numFrames();
+        boolean checkFrameChanged(int currentFrame) {
+            locker.lock();
+            try {
+                return _pagDecoder != null && _pagDecoder.checkFrameChanged(currentFrame);
+            } finally {
+                locker.unlock();
+            }
+        }
+
+        boolean readFrame(int currentFrame, HardwareBuffer hardwareBuffer) {
+            locker.lock();
+            try {
+                return _pagDecoder != null && hardwareBuffer != null && _pagDecoder.readFrame(
+                        currentFrame, hardwareBuffer);
+            } finally {
+                locker.unlock();
+            }
+        }
+
+        boolean copyFrameTo(Bitmap bitmap, int currentFrame) {
+            locker.lock();
+            try {
+                return _pagDecoder != null && bitmap != null && _pagDecoder.copyFrameTo(bitmap,
+                        currentFrame);
+            } finally {
+                locker.unlock();
+            }
+        }
+
+        boolean initDecoder(PAGComposition composition, int width, int height,
+                            float maxFrameRate) {
+            locker.lock();
+            try {
+                if (composition == null || width <= 0 || height <= 0 || maxFrameRate <= 0) {
+                    return false;
+                }
+                // Release the previous decoder before creating a new one to avoid leaking native
+                // resources when the DecoderInfo is reused, for example on a detach-then-reattach in
+                // a RecyclerView, or when reset() skipped the release on a busy lock.
+                releaseDecoder();
+                float scaleFactor;
+                if (composition.width() >= composition.height()) {
+                    scaleFactor = width * 1.0f / composition.width();
+                } else {
+                    scaleFactor = height * 1.0f / composition.height();
+                }
+                _pagDecoder = PAGDecoder.Make(composition, maxFrameRate, scaleFactor);
+                _width = _pagDecoder.width();
+                _height = _pagDecoder.height();
+                duration = composition.duration();
+                return true;
+            } finally {
+                locker.unlock();
+            }
+        }
+
+        void releaseDecoder() {
+            locker.lock();
+            try {
+                if (_pagDecoder != null) {
+                    _pagDecoder.release();
+                    _pagDecoder = null;
+                }
+            } finally {
+                locker.unlock();
+            }
+        }
+
+        void reset() {
+            // Use tryLock instead of a blocking lock: when the worker thread is stuck inside
+            // readFrame() (for example when the hardware video decoder hangs in the system layer), a
+            // blocking reset() on the main thread would wait for the lock and trigger an ANR. If the
+            // lock cannot be acquired immediately, skip the synchronous release; the decoder will be
+            // released later by initDecoder() on reuse or by PAGDecoder.finalize() on garbage
+            // collection.
+            if (!locker.tryLock()) {
+                return;
+            }
+            try {
+                releaseDecoder();
+                _width = 0;
+                _height = 0;
+                duration = 0;
+            } finally {
+                locker.unlock();
+            }
+        }
+
+        int numFrames() {
+            locker.lock();
+            try {
+                return _pagDecoder == null ? 0 : _pagDecoder.numFrames();
+            } finally {
+                locker.unlock();
+            }
         }
     }
 }

--- a/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
@@ -94,9 +94,9 @@ class PAGImageViewHelper {
     }
 
     static class DecoderInfo {
-        int _width;
-        int _height;
-        long duration;
+        volatile int _width;
+        volatile int _height;
+        volatile long duration;
         private PAGDecoder _pagDecoder;
         private final ReentrantLock locker = new ReentrantLock();
 
@@ -199,10 +199,10 @@ class PAGImageViewHelper {
             // readFrame() (for example when the hardware video decoder hangs in the system layer), a
             // blocking reset() on the main thread would wait for the lock and trigger an ANR. If the
             // lock cannot be acquired immediately, skip only the native decoder release (the blocking
-            // part) but still invalidate the size fields so isValid() turns false right away. This lets
-            // the render path re-enter initDecoderInfo() to clear freezeDraw, and reclaim the stale
-            // decoder via initDecoder()'s upfront releaseDecoder() on reuse (or PAGDecoder.finalize()
-            // on garbage collection).
+            // part) but still invalidate the volatile size fields without the lock as a best-effort
+            // signal so isValid() turns false and the render path re-enters initDecoderInfo() to clear
+            // freezeDraw. The stale decoder is reclaimed via initDecoder()'s upfront releaseDecoder() on
+            // reuse (or PAGDecoder.finalize() on garbage collection).
             if (!locker.tryLock()) {
                 _width = 0;
                 _height = 0;

--- a/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
@@ -198,10 +198,15 @@ class PAGImageViewHelper {
             // Use tryLock instead of a blocking lock: when the worker thread is stuck inside
             // readFrame() (for example when the hardware video decoder hangs in the system layer), a
             // blocking reset() on the main thread would wait for the lock and trigger an ANR. If the
-            // lock cannot be acquired immediately, skip the synchronous release; the decoder will be
-            // released later by initDecoder() on reuse or by PAGDecoder.finalize() on garbage
-            // collection.
+            // lock cannot be acquired immediately, skip only the native decoder release (the blocking
+            // part) but still invalidate the size fields so isValid() turns false right away. This lets
+            // the render path re-enter initDecoderInfo() to clear freezeDraw, and reclaim the stale
+            // decoder via initDecoder()'s upfront releaseDecoder() on reuse (or PAGDecoder.finalize()
+            // on garbage collection).
             if (!locker.tryLock()) {
+                _width = 0;
+                _height = 0;
+                duration = 0;
                 return;
             }
             try {

--- a/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
@@ -195,14 +195,11 @@ class PAGImageViewHelper {
         }
 
         void reset() {
-            // Use tryLock instead of a blocking lock: when the worker thread is stuck inside
-            // readFrame() (for example when the hardware video decoder hangs in the system layer), a
-            // blocking reset() on the main thread would wait for the lock and trigger an ANR. If the
-            // lock cannot be acquired immediately, skip only the native decoder release (the blocking
-            // part) but still invalidate the volatile size fields without the lock as a best-effort
-            // signal so isValid() turns false and the render path re-enters initDecoderInfo() to clear
-            // freezeDraw. The stale decoder is reclaimed via initDecoder()'s upfront releaseDecoder() on
-            // reuse (or PAGDecoder.finalize() on garbage collection).
+            // tryLock avoids an ANR: a blocking reset() on the main thread would stall if the worker
+            // thread is stuck in readFrame() (e.g. the hardware decoder hangs). On a failed lock, skip
+            // the native release but still clear the volatile size fields so isValid() turns false and
+            // the render path re-initializes; the stale decoder is reclaimed by initDecoder() on reuse
+            // or PAGDecoder.finalize() on GC.
             if (!locker.tryLock()) {
                 _width = 0;
                 _height = 0;

--- a/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
@@ -106,6 +106,10 @@ class PAGImageViewHelper {
         // always wins without having to block on the lock.
         private final AtomicInteger resetToken = new AtomicInteger(0);
         private volatile int decoderToken = 0;
+        // Cached snapshots so the main thread can query decoder state without taking the lock,
+        // which would block whenever the worker thread is stuck in readFrame() on a hung decoder.
+        private volatile boolean hasDecoder = false;
+        private volatile int frameCount = 0;
 
         void lock() {
             locker.lock();
@@ -122,16 +126,19 @@ class PAGImageViewHelper {
         }
 
         boolean hasPAGDecoder() {
-            locker.lock();
-            try {
-                return _pagDecoder != null;
-            } finally {
-                locker.unlock();
-            }
+            // Lock-free read of a volatile snapshot; see isValid() for why the main thread must not
+            // block on the lock here.
+            return hasDecoder;
         }
 
         boolean checkFrameChanged(int currentFrame) {
-            locker.lock();
+            // tryLock instead of lock: this is reachable from the main thread via handleFrame(), and
+            // a blocking lock would ANR when the worker holds the lock inside a hung readFrame().
+            // On a failed lock, report changed=true so the caller falls through to a real decode
+            // attempt rather than skipping the frame based on stale state.
+            if (!locker.tryLock()) {
+                return true;
+            }
             try {
                 return _pagDecoder != null && _pagDecoder.checkFrameChanged(currentFrame);
             } finally {
@@ -194,8 +201,10 @@ class PAGImageViewHelper {
                 _pagDecoder = decoder;
                 _width = decoder.width();
                 _height = decoder.height();
+                frameCount = decoder.numFrames();
                 duration = composition.duration();
                 decoderToken = token;
+                hasDecoder = true;
                 return true;
             } finally {
                 locker.unlock();
@@ -209,6 +218,7 @@ class PAGImageViewHelper {
                     _pagDecoder.release();
                     _pagDecoder = null;
                 }
+                hasDecoder = false;
             } finally {
                 locker.unlock();
             }
@@ -219,13 +229,20 @@ class PAGImageViewHelper {
             // thread is stuck in readFrame() (e.g. the hardware decoder hangs). Bump the reset token
             // first so that any initDecoder() building concurrently on the worker thread is marked
             // stale by isValid(); this wins the race even though the field writes below are lock-free.
-            // On a failed lock, skip the native release but still clear the size fields; the stale
-            // decoder is reclaimed by initDecoder() on reuse or PAGDecoder.finalize() on GC.
             resetToken.incrementAndGet();
+            hasDecoder = false;
+            frameCount = 0;
             if (!locker.tryLock()) {
+                // On a failed lock, skip the native release but still clear the size fields; the stale
+                // decoder is reclaimed by initDecoder() on reuse or PAGDecoder.finalize() on GC.
                 _width = 0;
                 _height = 0;
                 duration = 0;
+                // Bump the token a second time after clearing the fields. This closes the reverse race
+                // where an in-flight initDecoder() captured the token after our first increment: its
+                // post-Make() recheck (or the final isValid() comparison) now sees a newer resetToken
+                // than the token it recorded, so its stale decoder can never be judged valid.
+                resetToken.incrementAndGet();
                 return;
             }
             try {
@@ -239,12 +256,9 @@ class PAGImageViewHelper {
         }
 
         int numFrames() {
-            locker.lock();
-            try {
-                return _pagDecoder == null ? 0 : _pagDecoder.numFrames();
-            } finally {
-                locker.unlock();
-            }
+            // Lock-free read of the cached frame count; see isValid() for why the main thread must
+            // not block on the lock here.
+            return frameCount;
         }
     }
 }

--- a/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageViewHelper.java
@@ -22,6 +22,7 @@ import android.graphics.Bitmap;
 import android.graphics.Matrix;
 import android.hardware.HardwareBuffer;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
 class PAGImageViewHelper {
@@ -99,6 +100,12 @@ class PAGImageViewHelper {
         volatile long duration;
         private PAGDecoder _pagDecoder;
         private final ReentrantLock locker = new ReentrantLock();
+        // resetToken is bumped by every reset(); decoderToken records the resetToken value captured
+        // when the current decoder was built. isValid() treats the decoder as invalid once a reset()
+        // has happened since it was built, so a lock-free reset() that races an in-flight initDecoder()
+        // always wins without having to block on the lock.
+        private final AtomicInteger resetToken = new AtomicInteger(0);
+        private volatile int decoderToken = 0;
 
         void lock() {
             locker.lock();
@@ -111,7 +118,7 @@ class PAGImageViewHelper {
         boolean isValid() {
             locker.lock();
             try {
-                return _width > 0 && _height > 0;
+                return _width > 0 && _height > 0 && decoderToken == resetToken.get();
             } finally {
                 locker.unlock();
             }
@@ -166,6 +173,10 @@ class PAGImageViewHelper {
                 // resources when the DecoderInfo is reused, for example on a detach-then-reattach in
                 // a RecyclerView, or when reset() skipped the release on a busy lock.
                 releaseDecoder();
+                // Capture the reset token before the slow Make() call. If a reset() bumps the token
+                // while we build, decoderToken will no longer match and isValid() reports this decoder
+                // as stale, so the racing reset() wins instead of being silently overwritten.
+                int token = resetToken.get();
                 float scaleFactor;
                 if (composition.width() >= composition.height()) {
                     scaleFactor = width * 1.0f / composition.width();
@@ -176,6 +187,7 @@ class PAGImageViewHelper {
                 _width = _pagDecoder.width();
                 _height = _pagDecoder.height();
                 duration = composition.duration();
+                decoderToken = token;
                 return true;
             } finally {
                 locker.unlock();
@@ -196,10 +208,12 @@ class PAGImageViewHelper {
 
         void reset() {
             // tryLock avoids an ANR: a blocking reset() on the main thread would stall if the worker
-            // thread is stuck in readFrame() (e.g. the hardware decoder hangs). On a failed lock, skip
-            // the native release but still clear the volatile size fields so isValid() turns false and
-            // the render path re-initializes; the stale decoder is reclaimed by initDecoder() on reuse
-            // or PAGDecoder.finalize() on GC.
+            // thread is stuck in readFrame() (e.g. the hardware decoder hangs). Bump the reset token
+            // first so that any initDecoder() building concurrently on the worker thread is marked
+            // stale by isValid(); this wins the race even though the field writes below are lock-free.
+            // On a failed lock, skip the native release but still clear the size fields; the stale
+            // decoder is reclaimed by initDecoder() on reuse or PAGDecoder.finalize() on GC.
+            resetToken.incrementAndGet();
             if (!locker.tryLock()) {
                 _width = 0;
                 _height = 0;


### PR DESCRIPTION
## 背景

Related to #3240

`PAGImageView` 的 `PAGImageViewHelper.DecoderInfo` 此前使用 `synchronized` 方法。当工作线程卡在 native `readFrame()` 内（例如硬件视频解码器在系统层挂起）时，任何持同一把锁的主线程调用都会一直阻塞等待。本 PR 聚焦**显著降低而非根除** `PAGImageView` 的 ANR：消除 `reset()`（detach / 尺寸变化 / setPath 触发）这条路径的阻塞，并让主线程可达的状态查询全部改为非阻塞。

## 改动

将 `DecoderInfo` 的锁从 `synchronized` 迁移到显式 `ReentrantLock`，让 `reset()` 使用 `tryLock()`，并将主线程可达的状态查询改为无锁/非阻塞。围绕这一改动，逐步修复了引入的连锁问题：

1. **缓解 reset 路径 ANR**：`reset()` 改用 `tryLock()`，拿不到锁时跳过阻塞的 native 释放，避免主线程在 detach / 尺寸变化 / setPath 时等待挂起的解码器。
2. **修复画面冻结**：`tryLock()` 失败时仍清零 `_width/_height/duration`，使 `isValid()` 立即变为 false，渲染路径可重新初始化并清除 `freezeDraw`，避免视图永久空白/冻结。
3. **可见性 + 主线程状态查询全部无锁化**：`_width/_height/duration` 声明为 `volatile`；`isValid()`、`hasPAGDecoder()`、`numFrames()` 改为无锁读取 volatile 快照（新增 `volatile boolean hasDecoder` 与 `volatile int frameCount`，在 `initDecoder()` 成功时写入、`reset()`/`releaseDecoder()` 清零）；`checkFrameChanged()` 因必须调 native，改为 `tryLock()`，失败时返回 true 让调用方走真正的解码尝试而非基于陈旧状态跳帧。至此主线程经 `flush()` / `refreshNumFrames()` / `handleFrame()` 可达的状态查询不再阻塞在 `lock()` 上。
4. **消除写-写竞争（token 机制）**：引入单调递增的 `resetToken`（AtomicInteger）与 `decoderToken`。`initDecoder()` 在 `Make()` 前捕获 token、`Make()` 后二次校验、提交后记录 token，`isValid()` 校验二者一致。`reset()` 无条件自增 token；在 `tryLock()` 失败路径清零字段后**再次自增 token**，以关闭"in-flight `initDecoder()` 捕获点晚于 reset 首次自增"的反向时序——任何捕获了旧 token 的 `initDecoder()` 都会在 `Make()` 后复校验或最终 `isValid()` 比较时被判为 stale，从而释放并返回 false，不覆盖 reset 状态。这样 `reset()` 与工作线程正在进行的 `initDecoder()` 竞争时始终胜出且无需阻塞，避免旧内容解码器被误判有效而画面冻结。
5. **NPE 健壮性**：`PAGDecoder.Make()` 返回 null 时（native context 为 0，如内存不足/解码器初始化失败）立即 `return false`。此时 `_width/_height` 保持 0，`isValid()` 自然为 false，状态干净，避免后续 `width()` 触发 NPE 抛到渲染线程。

## 影响

- 缓解了 detach / 尺寸变化 / setPath 路径上的主线程 ANR（这些路径走 `reset()`），并使主线程可达的状态查询不再阻塞在解码锁上。
- 迁移后锁获取/释放全部 try/finally 配对，无残留 `synchronized`，重入安全，无死锁；跳过释放的解码器由 `initDecoder()` 复用时前置释放或 GC finalize 兜底回收，无资源泄漏。

## 已知残留（非本次范围）

本 PR **不宣称彻底消除 ANR**。当前仍持阻塞 `lock()` 的只剩 `readFrame()` / `copyFrameTo()`，二者仅在工作线程调用，不构成主线程 ANR。根因——native 解码在临界区内长时间执行——尚未消除，彻底关闭需将 native 解码移出临界区，或改为单工作线程串行化，属架构级改动，建议单独跟进。

## 测试

- Android demo 手动验证：20 宫格 PAGImageView 视频列表，反复切换 / detach / 高频 setPath，确认不卡死、无画面冻结。
- 压测场景（本地脚手架，未并入本 PR）：12 个 PAGImageView，后台线程每 5ms 高频 `setPathAsync` 切换 + 每 50ms 周期性 detach/reattach + 主线程持续渲染三方对撞，运行期间未复现 ANR / 崩溃 / 画面冻结。需说明：token 竞态属极低概率的指令交错，压测不足以充分证明该窗口被覆盖，其正确性以第 4 条的代码逻辑为主。
