### PR TITLE
Fix Android PAGSurface leak by releasing Surface in finalize

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGSurface.java
+++ b/android/libpag/src/main/java/org/libpag/PAGSurface.java
@@ -196,10 +196,14 @@ public class PAGSurface {
         // Must call freeCache() here, otherwise, the cache may not be freed until the PAGPlayer is
         // garbage collected.
         freeCache();
+        releaseSurface();
+        nativeRelease();
+    }
+
+    private void releaseSurface() {
         if (needsReleaseSurface && surface != null) {
             surface.release();
         }
-        nativeRelease();
     }
 
     private native void nativeRelease();
@@ -209,9 +213,7 @@ public class PAGSurface {
     private native void nativeFinalize();
 
     protected void finalize() {
-        if (needsReleaseSurface && surface != null) {
-            surface.release();
-        }
+        releaseSurface();
         nativeFinalize();
     }
 

--- a/android/libpag/src/main/java/org/libpag/PAGSurface.java
+++ b/android/libpag/src/main/java/org/libpag/PAGSurface.java
@@ -209,6 +209,9 @@ public class PAGSurface {
     private native void nativeFinalize();
 
     protected void finalize() {
+        if (needsReleaseSurface && surface != null) {
+            surface.release();
+        }
         nativeFinalize();
     }
 


### PR DESCRIPTION
Fixes #3563

## 问题背景

在 Android 平台通过 `PAGSurface.FromSurfaceTexture(SurfaceTexture, EGLContext)` 创建 PAGSurface 时，内部会 `new Surface(surfaceTexture)` 并由 PAG 持有该 Surface（`needsReleaseSurface = true`）。此前 `finalize()` 只调用了 `nativeFinalize()`，从未释放这个由 PAG 自建的 Surface。当业务未显式调用 `release()`、仅依赖 GC 回收时，Surface 及其关联的 GraphicBuffer / virtio_gpu DMA buffer 的 fd 无法归零，导致 fd/Surface 泄漏累积，在 monkey 单包测试中触发 kernel HANG_DETECT 并造成系统崩溃。

## 修改内容

- 在 `finalize()` 中补充 Surface 释放逻辑，使 GC 回收路径与显式 `release()` 路径行为一致，从源头释放 PAG 自建的 Surface。
- 将 `release()` 与 `finalize()` 中重复的 Surface 释放守卫提取为私有方法 `releaseSurface()`，消除重复代码。

## 说明

- 仅释放 PAG 自建的 Surface（`FromSurfaceTexture` 路径，`needsReleaseSurface = true`）；调用方自行持有的 Surface（`FromSurface` 路径）不受影响，不会被误释放。
- `android.view.Surface.release()` 幂等，先显式 `release()` 后再经 GC 触发 `finalize()` 二次调用同样安全。