### PR TITLE
Fix iOS PAGImageView crash on dealloc by serializing reset with flush

### DIFF
--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -126,8 +126,11 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
 - (void)dealloc {
   [animator cancel];
   [animator release];
-  [self reset];
-  pagComposition = nullptr;
+  {
+    std::lock_guard<std::mutex> autoLock(imageViewLock);
+    [self reset];
+    pagComposition = nullptr;
+  }
   if (_currentUIImage) {
     [_currentUIImage release];
   }

--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -124,11 +124,13 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
 }
 
 // Thread safety note: [animator cancel] / [animator release] are intentionally called BEFORE
-// acquiring imageViewLock. cancel() blocks up to 500ms waiting for an in-flight async flush task,
-// and that flush also needs imageViewLock; taking the lock first would self-deadlock. Once the
-// animator is cancelled no flush can re-enter, and [self reset] is itself lock-free, so acquiring
-// the non-recursive imageViewLock here is safe and simply serializes reset against any lingering
-// flush.
+// acquiring imageViewLock. cancel() blocks up to 500ms waiting for an in-flight background flush
+// task, and that flush also needs imageViewLock. Acquiring the lock first would create a
+// cross-thread lock-order inversion: this thread would hold imageViewLock while cancel() waits on
+// the background flush that needs it, then time out and abandon the task, reintroducing the
+// flush-vs-reset race. After cancel() no new flush can be scheduled, and [self reset] is itself
+// lock-free, so acquiring the non-recursive imageViewLock here is safe and simply serializes reset
+// against any lingering flush.
 - (void)dealloc {
   [animator cancel];
   [animator release];

--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -123,6 +123,12 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
                                              object:nil];
 }
 
+// Thread safety note: [animator cancel] / [animator release] are intentionally called BEFORE
+// acquiring imageViewLock. cancel() blocks up to 500ms waiting for an in-flight async flush task,
+// and that flush also needs imageViewLock; taking the lock first would self-deadlock. Once the
+// animator is cancelled no flush can re-enter, and [self reset] is itself lock-free, so acquiring
+// the non-recursive imageViewLock here is safe and simply serializes reset against any lingering
+// flush.
 - (void)dealloc {
   [animator cancel];
   [animator release];


### PR DESCRIPTION
## 概述
修复 iOS 上 `PAGImageView` 的一个崩溃问题:当仍有进行中的 flush 正在访问其状态时,视图可能被析构。现在 `-dealloc` 在执行 `[self reset]` 和清空 `pagComposition` 时会持有 `imageViewLock`,从而将析构与任何残留的 flush 串行化。`[animator cancel]` / `[animator release]` 特意在加锁之前调用,以避免与后台 flush 任务产生跨线程的锁序反转。

## 改动
- 在 `-dealloc` 中用 `imageViewLock` 保护 `[self reset]` 和 `pagComposition = nullptr`。
- 新增线程安全注释,说明为何在取消 animator 之后再加锁。

## 测试
- 成功编译 `PAGFullTest`(Debug)。

Fixes #2849