### PR TITLE
Preserve filePath in loadFileData and prefer it in export

### DIFF
--- a/src/pagx/PAGXDocument.cpp
+++ b/src/pagx/PAGXDocument.cpp
@@ -131,7 +131,6 @@ static bool LoadFileDataInChain(
       auto* image = static_cast<Image*>(node.get());
       if (image->filePath == filePath) {
         image->data = data;
-        image->filePath = {};
         docDirtyNodes[document].push_back(image);
         found = true;
       }

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -443,12 +443,12 @@ static void WriteColorSource(XMLBuilder& xml, const ColorSource* node) {
       if (pattern->image != nullptr) {
         if (!pattern->image->id.empty()) {
           xml.addAttribute("image", "@" + pattern->image->id);
+        } else if (!pattern->image->filePath.empty()) {
+          xml.addAttribute("image", pattern->image->filePath);
         } else if (pattern->image->data) {
           xml.addAttribute("image",
                            "data:image/png;base64," + Base64Encode(pattern->image->data->bytes(),
                                                                    pattern->image->data->size()));
-        } else if (!pattern->image->filePath.empty()) {
-          xml.addAttribute("image", pattern->image->filePath);
         }
       }
       if (pattern->tileModeX != Default<ImagePattern>().tileModeX) {
@@ -1209,11 +1209,11 @@ static void WriteResource(XMLBuilder& xml, const Node* node, const Options& opti
       auto image = static_cast<const Image*>(node);
       xml.openElement("Image");
       xml.addAttribute("id", image->id);
-      if (image->data) {
+      if (!image->filePath.empty()) {
+        xml.addAttribute("source", image->filePath);
+      } else if (image->data) {
         xml.addAttribute("source", "data:image/png;base64," +
                                        Base64Encode(image->data->bytes(), image->data->size()));
-      } else {
-        xml.addAttribute("source", image->filePath);
       }
       WriteCustomData(xml, node);
       xml.closeElementSelfClosing();
@@ -1276,12 +1276,12 @@ static void WriteResource(XMLBuilder& xml, const Node* node, const Options& opti
           if (glyph->image != nullptr) {
             if (!glyph->image->id.empty()) {
               xml.addAttribute("image", "@" + glyph->image->id);
+            } else if (!glyph->image->filePath.empty()) {
+              xml.addAttribute("image", glyph->image->filePath);
             } else if (glyph->image->data) {
               xml.addAttribute("image",
                                "data:image/png;base64," + Base64Encode(glyph->image->data->bytes(),
                                                                        glyph->image->data->size()));
-            } else if (!glyph->image->filePath.empty()) {
-              xml.addAttribute("image", glyph->image->filePath);
             }
           }
           if (glyph->offset != Default<Glyph>().offset) {

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -4522,6 +4522,47 @@ PAGX_TEST(PAGXTest, LoadFileDataWithDecodedImage) {
   EXPECT_EQ(tgfxPattern2->image()->height(), expectedTgfx2->height());
 }
 
+/**
+ * Test case: loadFileData(path, Data) preserves filePath so that export writes the original
+ * external reference (e.g. "hash:abc123") instead of inlining the image as base64.
+ */
+PAGX_TEST(PAGXTest, LoadFileDataPreservesFilePathInExport) {
+  std::string xml = R"(<?xml version="1.0" encoding="UTF-8"?>
+<pagx width="100" height="100">
+  <Layer id="L">
+    <Rectangle width="100" height="100"/>
+    <Fill>
+      <ImagePattern id="pat" image="hash:abc123"/>
+    </Fill>
+  </Layer>
+</pagx>)";
+  auto doc = pagx::PAGXImporter::FromXML(xml);
+  ASSERT_TRUE(doc != nullptr);
+  doc->applyLayout();
+  auto* pattern = doc->findNode<pagx::ImagePattern>("pat");
+  ASSERT_TRUE(pattern != nullptr);
+  ASSERT_TRUE(pattern->image != nullptr);
+  EXPECT_EQ(pattern->image->filePath, "hash:abc123");
+  EXPECT_TRUE(pattern->image->data == nullptr);
+
+  // Load image data via the Data overload — filePath must be preserved.
+  auto tgfxData =
+      tgfx::Data::MakeFromFile(ProjectPath::Absolute("resources/apitest/imageReplacement.png"));
+  ASSERT_TRUE(tgfxData != nullptr);
+  auto imageData = pagx::Data::MakeWithCopy(tgfxData->data(), tgfxData->size());
+  ASSERT_TRUE(imageData != nullptr);
+  EXPECT_TRUE(doc->loadFileData("hash:abc123", imageData));
+
+  // filePath is kept as the serialization anchor; data is the runtime cache.
+  EXPECT_EQ(pattern->image->filePath, "hash:abc123");
+  EXPECT_TRUE(pattern->image->data != nullptr);
+
+  // Export must write the original filePath, not base64.
+  auto exportedXml = pagx::PAGXExporter::ToXML(*doc);
+  EXPECT_NE(exportedXml.find("hash:abc123"), std::string::npos);
+  EXPECT_EQ(exportedXml.find("base64"), std::string::npos);
+}
+
 // =====================================================================================
 // ClipToBounds
 // =====================================================================================

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -7429,7 +7429,8 @@ PAGX_TEST(PAGXTest, LoadFileDataExternalCompositionAfterSceneCreation) {
 
 /**
  * Test case: loading image data via loadFileData AFTER PAGScene::Make() sets the Image node data
- * and notifies existing scenes without crashing. Verifies both node-level state and scene integrity.
+ * and notifies existing scenes without crashing. Verifies node-level state (data set, filePath
+ * preserved as the serialization anchor) and scene integrity.
  */
 PAGX_TEST(PAGXTest, LoadFileDataImageAfterSceneCreation) {
   auto doc = pagx::PAGXDocument::Make(100, 100);
@@ -7469,7 +7470,8 @@ PAGX_TEST(PAGXTest, LoadFileDataImageAfterSceneCreation) {
 
 /**
  * Test case: loadFileData is a no-op on notifyChange when called before any PAGScene exists.
- * Verifies that empty dirtyNodes or no liveScenes path is handled correctly.
+ * Verifies that empty dirtyNodes or no liveScenes path is handled correctly, and that node-level
+ * state (data set, filePath preserved as the serialization anchor) is still updated.
  */
 PAGX_TEST(PAGXTest, LoadFileDataNoSceneNotifyChangeNoOp) {
   auto doc = pagx::PAGXDocument::Make(100, 100);
@@ -7480,6 +7482,7 @@ PAGX_TEST(PAGXTest, LoadFileDataNoSceneNotifyChangeNoOp) {
   auto imageData = pagx::Data::MakeWithCopy(bytes, sizeof(bytes));
   EXPECT_TRUE(doc->loadFileData("test.png", imageData));
 
+  // data is set and filePath is preserved even without any live scene to notify.
   EXPECT_EQ(img->filePath, "test.png");
   ASSERT_TRUE(img->data != nullptr);
 }

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -7458,8 +7458,8 @@ PAGX_TEST(PAGXTest, LoadFileDataImageAfterSceneCreation) {
   auto imageData = pagx::Data::MakeWithCopy(bytes, sizeof(bytes));
   EXPECT_TRUE(doc->loadFileData("test.png", imageData));
 
-  // After loading, image data is set and filePath is cleared.
-  EXPECT_TRUE(img->filePath.empty());
+  // After loading, image data is set and filePath is preserved as the serialization anchor.
+  EXPECT_EQ(img->filePath, "test.png");
   ASSERT_TRUE(img->data != nullptr);
   EXPECT_EQ(img->data->size(), sizeof(bytes));
 
@@ -7480,7 +7480,7 @@ PAGX_TEST(PAGXTest, LoadFileDataNoSceneNotifyChangeNoOp) {
   auto imageData = pagx::Data::MakeWithCopy(bytes, sizeof(bytes));
   EXPECT_TRUE(doc->loadFileData("test.png", imageData));
 
-  EXPECT_TRUE(img->filePath.empty());
+  EXPECT_EQ(img->filePath, "test.png");
   ASSERT_TRUE(img->data != nullptr);
 }
 


### PR DESCRIPTION
## 问题

`loadFileData(filePath, Data)` 在嵌入图像字节后会清掉 `filePath`,导致导出时 `source` 从原始引用(如 `hash:abc123`)变成 `data:image/png;base64,...`。

## 修复

1. **`PAGXDocument.cpp`** — `LoadFileDataInChain` 不再清 `filePath`，`filePath` 始终作为序列化锚点，`data` 降为运行时缓存
2. **`PAGXExporter.cpp`** — Image 资源、ImagePattern 内联、GlyphRun 内联三处导出改为 `filePath` 非空时优先写 `filePath`，只有 `filePath` 为空且 `data` 非空时才写 base64

## 测试

新增 `LoadFileDataPreservesFilePathInExport` 测试：验证 `loadFileData(path, Data)` 后 `filePath` 保留，且导出 XML 中 `source` 仍为原始引用而非 base64。

## 基于

`origin/main` (0be6f1670)，trunk-based。