### PR TITLE
Fix repeated bitmap composition freezing on last frame

### DIFF
--- a/exporter/src/export/PAGExport.cpp
+++ b/exporter/src/export/PAGExport.cpp
@@ -171,7 +171,12 @@ static void AdjustmentPreComposeLayerForVideoComposition(std::shared_ptr<PAGExpo
       preComposeLayer->composition->uniqueID == videoComposition->uniqueID) {
     if (session->videoCompositionStartTime.find(videoComposition->uniqueID) !=
         session->videoCompositionStartTime.end()) {
-      preComposeLayer->compositionStartTime =
+      // The video sequence is encoded starting from its first visible frame
+      // (videoCompositionStartTime), so sequence frame 0 corresponds to that composition frame.
+      // Accumulate this trim offset onto the layer's own composition start time instead of
+      // overwriting it, otherwise multiple references to the same composition would all collapse
+      // to the same start time and every reference except the first would freeze (discussion #3548).
+      preComposeLayer->compositionStartTime +=
           session->videoCompositionStartTime[videoComposition->uniqueID];
     }
   }


### PR DESCRIPTION
## 问题背景

修复 #3548：在主合成中重复引用同一段 BMP / Video 序列合成时，导出的 .pag 在播放时第二段（及后续）相同合成停在某一帧、无法正常播放。第一段正常。

## 根因

问题出在**导出器**，而非运行时帧映射。

序列合成为节省空间，只编码从「首个可见帧」（`videoCompositionStartTime`，即序列裁剪偏移）开始的帧，序列内部帧号从 0 重新计。因此运行时需要把每个引用的 `compositionStartTime` 叠加这个裁剪偏移，才能让 `layerFrame - compositionStartTime` 正确对齐到裁剪后的序列帧。

`AdjustmentPreComposeLayerForVideoComposition`（`exporter/src/export/PAGExport.cpp`）原本用**赋值**的方式，把该合成的裁剪偏移直接**覆盖**到所有引用实例的 `compositionStartTime` 上：

```cpp
preComposeLayer->compositionStartTime =
    session->videoCompositionStartTime[videoComposition->uniqueID];
```

当同一合成被多次引用时，每个引用实例本应有各自不同的 `compositionStartTime`（`CreatePreComposeLayer` 已按 AE layer offset 正确计算），但覆盖操作把它们全部冲成同一个值。结果除第一段外，其余引用的起始偏移丢失，映射出的合成帧越界，被下游钳制到末帧 → 停帧。

实测数据（同一 BMP 合成被引用两次）：

| 引用 | 覆盖前 compositionStartTime | 裁剪偏移 | 覆盖后（错误） | 累加后（修复） |
|------|------------------------------|----------|----------------|----------------|
| 第一段 | 0 | 0 | 0 | 0 |
| 第二段 | 31 | 0 | **0（丢失）** | 31 |

## 修改内容

将覆盖改为**累加**，在每个引用实例各自的 `compositionStartTime` 基础上叠加序列裁剪偏移：

```cpp
preComposeLayer->compositionStartTime +=
    session->videoCompositionStartTime[videoComposition->uniqueID];
```

- 单引用场景：原始 `compositionStartTime` 与裁剪偏移的相对关系不变，行为与修改前一致，无回归。
- 多引用场景：每个引用保留各自的起始偏移，第二段及后续引用不再停帧。

## 影响范围

- 仅改动导出器 `PAGExport.cpp` 一处赋值逻辑，运行时代码未改动。
- 不影响单引用合成的导出结果。

## 测试

已用复现文件在 AE 中重新导出，播放确认第二段序列合成恢复正常循环播放。