### PR TITLE
Add export warning for unsupported text superscript and subscript

### DIFF
--- a/exporter/assets/translation/Chinese.ts
+++ b/exporter/assets/translation/Chinese.ts
@@ -862,72 +862,82 @@
         <translation>建议去掉文本路径或去掉文本动画。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="412"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="413"/>
+        <source>Some characters of the text layer use superscript or subscript, which is not supported by PAG.</source>
+        <translation>文本图层中的部分字符使用了上标或下标，PAG 不支持该属性。</translation>
+    </message>
+    <message>
+        <location filename="../../src/utils/AlertInfo.cpp" line="415"/>
+        <source>Recommend disabling superscript/subscript in the Character panel and adjusting the font size manually.</source>
+        <translation>建议在字符面板中取消上标/下标设置，并手动调整字体大小。</translation>
+    </message>
+    <message>
+        <location filename="../../src/utils/AlertInfo.cpp" line="423"/>
         <source>There are overlapping time intervals for references to video composition &quot;%1&quot;.</source>
         <translation>对视频合成“%1”的引用存在时间重叠。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="414"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="425"/>
         <source>Recommend adjusting the start time and duration of the layers referencing video composition &quot;%1&quot;.</source>
         <translation>建议调整视频合成“%1”的引用图层的起始时间和持续时间。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="430"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="441"/>
         <source>AE export error.</source>
         <translation>AE导出错误。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="435"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="446"/>
         <source>Bitmap sequence export error.</source>
         <translation>位图序列帧导出错误。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="440"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="451"/>
         <source>Video sequence export error.</source>
         <translation>视频序列帧导出错误。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="445"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="456"/>
         <source>Audio export error.</source>
         <translation>音频导出错误。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="450"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="461"/>
         <source>WebP encoding error.</source>
         <translation>Webp编码错误。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="455"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="466"/>
         <source>Export rendering error.</source>
         <translation>导出渲染错误。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="460"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="471"/>
         <source>Composition handle not found: The AE project handle for this composition (ID: %1) is not registered. This may occur if the composition was added after export initialization or if the project structure changed.</source>
         <translation>找不到合成句柄：此合成(ID: %1)的AE项目句柄未注册。这可能发生在导出初始化后添加了合成，或项目结构发生了变化。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="464"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="475"/>
         <source>Try re-exporting the project. If the issue persists, restart After Effects and try again.</source>
         <translation>请尝试重新导出项目。如果问题持续存在，请重启 After Effects 后重试。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="471"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="482"/>
         <source>DisplacementMap does not support referencing its own layer.</source>
         <translation>置换图DisplacementMap暂不支持指向自身图层。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="472"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="483"/>
         <source>Recommend removing this effect or redirecting the displacement layer to another layer.</source>
         <translation>建议去掉该效果，或修改该置换图层指向其它图层。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="479"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="490"/>
         <source>[Text Animation - Selector] export error.</source>
         <translation>[文本动画-选择器]导出错误。</translation>
     </message>
     <message>
-        <location filename="../../src/utils/AlertInfo.cpp" line="484"/>
+        <location filename="../../src/utils/AlertInfo.cpp" line="495"/>
         <source>PAG file verification error.</source>
         <translation>PAG文件校验错误。</translation>
     </message>

--- a/exporter/src/export/stream/StreamValue.cpp
+++ b/exporter/src/export/stream/StreamValue.cpp
@@ -260,6 +260,11 @@ static pag::TextDocumentHandle ParseTextDocument(const AEGP_StreamVal2&, const Q
     }
   }
 
+  if (obj.value("superscript").toBool(false) || obj.value("subscript").toBool(false)) {
+    PAGExportSessionManager::GetInstance()->recordWarning(
+        AlertInfoType::TextSuperscriptOrSubscript);
+  }
+
   return {textDocument};
 }
 

--- a/exporter/src/utils/AlertInfo.cpp
+++ b/exporter/src/utils/AlertInfo.cpp
@@ -409,9 +409,9 @@ DEFINE_GETINFO(TextPathAnimator) {
 }
 
 DEFINE_GETINFO(TextSuperscriptOrSubscript) {
-  auto infoData =
-      QObject::tr("Some characters of the text layer use superscript or subscript, which is not "
-                  "supported by PAG.");
+  auto infoData = QObject::tr(
+      "Some characters of the text layer use superscript or subscript, which is not "
+      "supported by PAG.");
   auto suggestData = QObject::tr(
       "Recommend disabling superscript/subscript in the Character panel and adjusting the font "
       "size manually.");

--- a/exporter/src/utils/AlertInfo.cpp
+++ b/exporter/src/utils/AlertInfo.cpp
@@ -408,6 +408,17 @@ DEFINE_GETINFO(TextPathAnimator) {
   suggest = suggestData.toStdString();
 }
 
+DEFINE_GETINFO(TextSuperscriptOrSubscript) {
+  auto infoData =
+      QObject::tr("Some characters of the text layer use superscript or subscript, which is not "
+                  "supported by PAG.");
+  auto suggestData = QObject::tr(
+      "Recommend disabling superscript/subscript in the Character panel and adjusting the font "
+      "size manually.");
+  info = infoData.toStdString();
+  suggest = suggestData.toStdString();
+}
+
 DEFINE_GETINFO(VideoCompositionOverlap) {
   auto infoData = QObject::tr(
       "There are overlapping time intervals for references to video composition \"%1\".");
@@ -545,6 +556,7 @@ static const std::unordered_map<AlertInfoType, std::function<GetInfoHandler>, pa
                         LINE_GETINFO(TextPathVertial),
                         LINE_GETINFO(TextPathBoxText),
                         LINE_GETINFO(TextPathAnimator),
+                        LINE_GETINFO(TextSuperscriptOrSubscript),
                         LINE_GETINFO(VideoCompositionOverlap),
                         LINE_GETINFO(OtherWarning),
                         LINE_GETINFO(UnknownError),

--- a/exporter/src/utils/AlertInfo.h
+++ b/exporter/src/utils/AlertInfo.h
@@ -75,6 +75,7 @@ enum class AlertInfoType {
   TextPathVertial,              // Text path does not support vertical text
   TextPathBoxText,          // Text path does not support box text (already supported, abandoned)
   TextPathAnimator,         // Text path and text animation are not compatible
+  TextSuperscriptOrSubscript,  // Text has superscript or subscript which is not supported
   VideoCompositionOverlap,  // The references of videoComposition have duplicate time intervals
 
   OtherWarning,  // Other warnings

--- a/exporter/src/utils/AlertInfo.h
+++ b/exporter/src/utils/AlertInfo.h
@@ -73,10 +73,10 @@ enum class AlertInfoType {
   TextPathParamPerpendicularToPath,  // Text path parameter "perpendicular to path" only supports the default value true
   TextPathParamForceAlignment,  // Text path parameter "force alignment" only supports the default value false
   TextPathVertial,              // Text path does not support vertical text
-  TextPathBoxText,          // Text path does not support box text (already supported, abandoned)
-  TextPathAnimator,         // Text path and text animation are not compatible
+  TextPathBoxText,             // Text path does not support box text (already supported, abandoned)
+  TextPathAnimator,            // Text path and text animation are not compatible
   TextSuperscriptOrSubscript,  // Text has superscript or subscript which is not supported
-  VideoCompositionOverlap,  // The references of videoComposition have duplicate time intervals
+  VideoCompositionOverlap,     // The references of videoComposition have duplicate time intervals
 
   OtherWarning,  // Other warnings
 


### PR DESCRIPTION
## 背景

PAG 不支持文字图层的上标（superscript）/下标（subscript）效果。此前导出含上标/下标的文字时没有任何提示，用户难以察觉导出结果与 AE 中不一致。

## 修改内容

在文字解析阶段增加检测：当文字图层使用了上标或下标时，记录一条导出警告，提示用户该效果不被 PAG 支持。

- `exporter/src/export/stream/StreamValue.cpp`：`ParseTextDocument` 中检测 `superscript` / `subscript` 属性，命中时通过 `recordWarning` 记录 `AlertInfoType::TextSuperscriptOrSubscript`，与同函数内 `FontFileTooBig` 等既有警告写法一致。
- `exporter/src/utils/AlertInfo.h`：新增枚举值 `TextSuperscriptOrSubscript`，置于警告区间（`OtherWarning` 之前），确保被正确归类为警告而非错误。
- `exporter/src/utils/AlertInfo.cpp`：新增 `DEFINE_GETINFO` 提供说明与建议文案，并在处理器映射中注册 `LINE_GETINFO`。
- `exporter/assets/translation/Chinese.ts`：补充对应中文翻译。

## 警告文案

- 说明：Some characters of the text layer use superscript or subscript, which is not supported by PAG.
- 建议：Recommend disabling superscript/subscript in the Character panel and adjusting the font size manually.

## 测试

已在 AE 中导出含上标/下标字符的文字图层，确认警告能正常检测并弹出。