### PR TITLE
Drop animation targets that fall outside the binding's scope in resolveTargets.

### DIFF
--- a/include/pagx/PAGAnimation.h
+++ b/include/pagx/PAGAnimation.h
@@ -114,11 +114,12 @@ class PAGAnimation : public PAGTimeline {
   PAGAnimation(Animation* animation, RuntimeBinding* binding, PAGXDocument* contextDoc,
                std::weak_ptr<PAGScene> owner);
 
-  // Resolves each animation object's target node against contextDoc once and caches the
-  // (node, channels) pairs, so apply() avoids a per-frame findNode() hash lookup. Built lazily on
-  // the first apply(). Stale caches are replaced by rebuilding the PAGAnimation (driven by
-  // PAGXDocument::notifyChange when a timeline node is dirty); this cache is never reset in place.
-  void resolveTargets();
+  // Resolves each animation object's target node against contextDoc into the (node, channels)
+  // pairs consumed by apply(). Targets that resolve outside binding's scope (e.g. a document-level
+  // animation pointing at a node living inside a nested composition's separate binding) are dropped
+  // here, keeping the animation from reaching across a composition boundary. apply() reuses the
+  // cached result and only re-runs this when targetsDirty is set.
+  void resolveTargets(const RuntimeBinding* effectiveBinding);
 
   // Owning scene. animation / binding / contextDoc point into content this scene keeps alive, so
   // advance() and apply() bail out once the scene is gone to avoid dereferencing freed memory.
@@ -133,11 +134,14 @@ class PAGAnimation : public PAGTimeline {
   // primary document; timelines spawned by external composition layers use the layer's externalDoc
   // so internal IDs of the external file stay self-contained.
   PAGXDocument* contextDoc = nullptr;
-  // Cached target resolution: each entry pairs a resolved target node with the channels driving
-  // it. Populated by resolveTargets() on first apply(); never reset in place — stale caches are
-  // replaced by rebuilding the PAGAnimation (see resolveTargets()).
+  // Scratch buffer holding the resolved (target node, channels) pairs. Rebuilt by resolveTargets()
+  // only when targetsDirty is set, and reused across frames otherwise; its capacity is retained to
+  // avoid per-frame reallocation.
   std::vector<std::pair<Node*, std::vector<Channel*>>> resolvedTargets = {};
-  bool resolved = false;
+  // Whether resolvedTargets must be rebuilt before the next apply(). Set on construction and when
+  // an incremental tree refresh changes binding membership in place, which keeps this timeline and
+  // its binding pointer so no other signal would trigger a re-resolve.
+  bool targetsDirty = true;
   int64_t currentTimeUs = 0;
 
   friend class PAGScene;

--- a/include/pagx/PAGComposition.h
+++ b/include/pagx/PAGComposition.h
@@ -161,6 +161,15 @@ class PAGComposition : public PAGLayer {
   // touches a timeline node, rebuilding the whole timeline tree rather than patching it in place.
   void resetTimelines();
 
+  // Static visitor for PAGLayer::forEachComposition. Marks every timeline's resolved target cache
+  // stale so the next apply() re-resolves against the refreshed binding membership.
+  static void MarkCompositionTimelinesDirty(PAGComposition* comp);
+
+  // Marks the resolved target cache of this composition's timelines and all descendants' stale.
+  // Called after an incremental refresh changes binding membership without touching a timeline
+  // node, so the reused timelines re-resolve on the next apply().
+  void markTimelineTargetsDirty();
+
   // Override to include this PAGComposition node itself in the traversal after visiting children.
   void forEachComposition(void (*visitor)(PAGComposition*)) override;
 

--- a/include/pagx/PAGStateMachine.h
+++ b/include/pagx/PAGStateMachine.h
@@ -172,6 +172,10 @@ class PAGStateMachine : public PAGTimeline,
 
   std::weak_ptr<PAGScene> owner;
   StateMachine* stateMachine = nullptr;
+  // Binding forwarded to the inner PAGAnimation of each state. Null marks a top-level state machine:
+  // the inner PAGAnimation then resolves the scene's current root binding lazily, so the machine
+  // survives a runtime-tree rebuild that frees the old binding. A non-null binding is a fixed
+  // composition binding for a state machine nested inside a composition. Never dereferenced here.
   RuntimeBinding* binding = nullptr;
   PAGXDocument* contextDoc = nullptr;
 
@@ -190,6 +194,12 @@ class PAGStateMachine : public PAGTimeline,
   bool tryChangeState(RegionInstance& ri);
   void changeState(RegionInstance& ri, const StateTransition* t);
   std::shared_ptr<PAGAnimation> createTimelineForState(const State* state);
+
+  // Marks every inner PAGAnimation (each region's current timeline and any crossfading-out ones)
+  // stale so their targets re-resolve on the next apply(). The inner animations live in regions,
+  // not in the owning composition's timeline list, so an incremental tree refresh that patches
+  // binding membership must reach them through here.
+  void markInternalTargetsDirty();
 
   friend class PAGScene;
   friend class PAGComposition;

--- a/src/pagx/DataBindRuntime.cpp
+++ b/src/pagx/DataBindRuntime.cpp
@@ -90,6 +90,13 @@ static std::vector<std::string> ParseSourcePath(const std::string& source) {
 void DataBindRuntime::bind(const std::vector<DataBind*>& binds, DataContext* context,
                            PAGXDocument* doc, RuntimeBinding* binding) {
   boundBinding = binding;
+  // A null binding means there is no scope to bind against. Without a scope, the contains() check
+  // below would be skipped, so any DataBind (including cross-composition ones) would silently pass
+  // through, defeating the scope filter. Mirrors PAGTimeline::resolveTargets, which also returns
+  // early when its binding is null. All current callers pass a non-null binding.
+  if (binding == nullptr) {
+    return;
+  }
   for (auto* db : binds) {
     if (db == nullptr || context == nullptr || doc == nullptr) {
       continue;
@@ -112,8 +119,8 @@ void DataBindRuntime::bind(const std::vector<DataBind*>& binds, DataContext* con
     // Drop out-of-scope targets. findNode does a flat document-wide lookup, so it can resolve a node
     // living inside a nested composition; that node is bound in the composition's own binding, not
     // here, so binding to it would cross the composition boundary (mirrors
-    // PAGTimeline::resolveTargets).
-    if (binding != nullptr && !binding->contains(targetNode)) {
+    // PAGTimeline::resolveTargets). The early return above guarantees binding is non-null here.
+    if (!binding->contains(targetNode)) {
       LOGE("DataBind skipped: target '%s' is outside this binding's scope.", db->target.c_str());
       continue;
     }

--- a/src/pagx/DataBindRuntime.cpp
+++ b/src/pagx/DataBindRuntime.cpp
@@ -109,6 +109,14 @@ void DataBindRuntime::bind(const std::vector<DataBind*>& binds, DataContext* con
       LOGE("DataBind skipped: target '%s' was not found in the document.", db->target.c_str());
       continue;
     }
+    // Drop out-of-scope targets. findNode does a flat document-wide lookup, so it can resolve a node
+    // living inside a nested composition; that node is bound in the composition's own binding, not
+    // here, so binding to it would cross the composition boundary (mirrors
+    // PAGTimeline::resolveTargets).
+    if (binding != nullptr && !binding->contains(targetNode)) {
+      LOGE("DataBind skipped: target '%s' is outside this binding's scope.", db->target.c_str());
+      continue;
+    }
     sourceValue->addDependent(this);
 
     BindingEntry entry;

--- a/src/pagx/PAGAnimation.cpp
+++ b/src/pagx/PAGAnimation.cpp
@@ -19,6 +19,7 @@
 #include "pagx/PAGAnimation.h"
 #include <algorithm>
 #include <cstdint>
+#include "base/utils/Log.h"
 #include "pagx/PAGScene.h"
 #include "pagx/PAGStateMachineRegion.h"
 #include "pagx/PAGXDocument.h"
@@ -60,9 +61,9 @@ PAGAnimation::PAGAnimation(Animation* anim, RuntimeBinding* binding, PAGXDocumen
     : owner(std::move(owner)), animation(anim), binding(binding), contextDoc(contextDoc) {
 }
 
-void PAGAnimation::resolveTargets() {
+void PAGAnimation::resolveTargets(const RuntimeBinding* binding) {
   resolved = true;
-  if (animation == nullptr || contextDoc == nullptr) {
+  if (animation == nullptr || contextDoc == nullptr || binding == nullptr) {
     return;
   }
   for (auto* object : animation->objects) {
@@ -71,6 +72,12 @@ void PAGAnimation::resolveTargets() {
     }
     auto* targetNode = contextDoc->findNode(object->target);
     if (targetNode == nullptr) {
+      continue;
+    }
+    // Drop targets outside this binding's scope. findNode does a flat document-wide lookup, so it
+    // can resolve a node living inside a nested composition; that node is bound in the composition's
+    // own binding, not here, so applying to it would cross the composition boundary.
+    if (!binding->contains(targetNode)) {
       continue;
     }
     std::vector<Channel*> channels = {};
@@ -177,7 +184,7 @@ void PAGAnimation::apply(float mix) {
     return;
   }
   if (!resolved) {
-    resolveTargets();
+    resolveTargets(effectiveBinding);
   }
   ApplyResolved(resolvedTargets, animation, effectiveBinding, currentTimeUs, clamped);
 }

--- a/src/pagx/PAGAnimation.cpp
+++ b/src/pagx/PAGAnimation.cpp
@@ -61,9 +61,9 @@ PAGAnimation::PAGAnimation(Animation* anim, RuntimeBinding* binding, PAGXDocumen
     : owner(std::move(owner)), animation(anim), binding(binding), contextDoc(contextDoc) {
 }
 
-void PAGAnimation::resolveTargets(const RuntimeBinding* binding) {
-  resolved = true;
-  if (animation == nullptr || contextDoc == nullptr || binding == nullptr) {
+void PAGAnimation::resolveTargets(const RuntimeBinding* effectiveBinding) {
+  resolvedTargets.clear();
+  if (animation == nullptr || contextDoc == nullptr || effectiveBinding == nullptr) {
     return;
   }
   for (auto* object : animation->objects) {
@@ -77,7 +77,7 @@ void PAGAnimation::resolveTargets(const RuntimeBinding* binding) {
     // Drop targets outside this binding's scope. findNode does a flat document-wide lookup, so it
     // can resolve a node living inside a nested composition; that node is bound in the composition's
     // own binding, not here, so applying to it would cross the composition boundary.
-    if (!binding->contains(targetNode)) {
+    if (!effectiveBinding->contains(targetNode)) {
       continue;
     }
     std::vector<Channel*> channels = {};
@@ -183,8 +183,12 @@ void PAGAnimation::apply(float mix) {
   if (effectiveBinding == nullptr) {
     return;
   }
-  if (!resolved) {
+  // Re-resolve only when needed: targetsDirty covers an incremental refresh that changed binding
+  // membership in place (same binding pointer, patched members). A runtime-tree rebuild recreates
+  // PAGAnimation instances, so no separate pointer-based invalidation is needed.
+  if (targetsDirty) {
     resolveTargets(effectiveBinding);
+    targetsDirty = false;
   }
   ApplyResolved(resolvedTargets, animation, effectiveBinding, currentTimeUs, clamped);
 }

--- a/src/pagx/PAGScene.cpp
+++ b/src/pagx/PAGScene.cpp
@@ -125,8 +125,12 @@ void PAGScene::buildRuntimeTree() {
     if (node != nullptr && node->nodeType() == NodeType::StateMachine) {
       auto* smNode = static_cast<StateMachine*>(node);
       if (instantiatedTimelines.find(smNode) == instantiatedTimelines.end()) {
-        auto instance = std::shared_ptr<PAGStateMachine>(new PAGStateMachine(
-            smNode, _rootComposition->binding.get(), document.get(), shared_from_this()));
+        // Construct with a null binding so the state machine's inner PAGAnimation instances resolve
+        // the scene's current root binding lazily at apply time. A user-cached handle then survives
+        // a runtime-tree rebuild (foreign external-doc edit) that replaces _rootComposition and
+        // frees the old binding, instead of dereferencing a dangling binding.
+        auto instance = std::shared_ptr<PAGStateMachine>(
+            new PAGStateMachine(smNode, nullptr, document.get(), shared_from_this()));
         instantiatedTimelines.emplace(smNode, instance);
         _rootComposition->binding->setTarget(
             smNode, std::make_unique<StateMachineInputTarget>(instance, smNode));
@@ -492,8 +496,11 @@ std::shared_ptr<PAGStateMachine> PAGScene::getStateMachineTimeline(const std::st
   if (_rootComposition == nullptr) {
     return nullptr;
   }
-  auto timeline = std::shared_ptr<PAGStateMachine>(new PAGStateMachine(
-      matched, _rootComposition->binding.get(), document.get(), weak_from_this()));
+  // Construct with a null binding so the state machine's inner PAGAnimation instances resolve the
+  // scene's current root binding lazily at apply time, keeping a user-cached handle valid across a
+  // runtime-tree rebuild that frees the old binding (mirrors getAnimation).
+  auto timeline = std::shared_ptr<PAGStateMachine>(
+      new PAGStateMachine(matched, nullptr, document.get(), weak_from_this()));
   instantiatedTimelines.emplace(matched, timeline);
   _rootComposition->binding->setTarget(
       matched, std::make_unique<StateMachineInputTarget>(timeline, matched));
@@ -755,8 +762,13 @@ void PAGScene::onNodesChanged(const std::vector<Node*>& dirtyNodes) {
     // marked separately.
     _rootComposition->markTimelineTargetsDirty();
     for (auto& entry : instantiatedTimelines) {
-      if (entry.second != nullptr && entry.second->type() == TimelineType::Animation) {
+      if (entry.second == nullptr) {
+        continue;
+      }
+      if (entry.second->type() == TimelineType::Animation) {
         static_cast<PAGAnimation*>(entry.second.get())->targetsDirty = true;
+      } else if (entry.second->type() == TimelineType::StateMachine) {
+        static_cast<PAGStateMachine*>(entry.second.get())->markInternalTargetsDirty();
       }
     }
   }

--- a/src/pagx/PAGScene.cpp
+++ b/src/pagx/PAGScene.cpp
@@ -748,6 +748,17 @@ void PAGScene::onNodesChanged(const std::vector<Node*>& dirtyNodes) {
     // from the current tree so flushTextHolders / hasContentChanged stay consistent with the
     // binding state.
     collectTextHolders();
+    // An incremental refresh adds or removes layers, changing binding membership in place without
+    // recreating the reused timelines or their binding. Mark every timeline's resolved target cache
+    // stale so the next apply() re-resolves; no other signal covers this case. Top-level
+    // PAGAnimation instances (held in instantiatedTimelines with a lazily-resolved root binding) are
+    // marked separately.
+    _rootComposition->markTimelineTargetsDirty();
+    for (auto& entry : instantiatedTimelines) {
+      if (entry.second != nullptr && entry.second->type() == TimelineType::Animation) {
+        static_cast<PAGAnimation*>(entry.second.get())->targetsDirty = true;
+      }
+    }
   }
   // Reset every timeline only when a timeline node changed. Timelines (Animation drivers and the
   // state machines that play them) can share targets and cross-reference, so the whole timeline

--- a/src/pagx/PAGStateMachine.cpp
+++ b/src/pagx/PAGStateMachine.cpp
@@ -328,6 +328,19 @@ std::shared_ptr<PAGAnimation> PAGStateMachine::createTimelineForState(const Stat
   return std::shared_ptr<PAGAnimation>(new PAGAnimation(anim, binding, contextDoc, owner));
 }
 
+void PAGStateMachine::markInternalTargetsDirty() {
+  for (auto& ri : regions) {
+    if (ri.currentTimeline != nullptr) {
+      ri.currentTimeline->targetsDirty = true;
+    }
+    for (auto& fading : ri.fadingOut) {
+      if (fading.timeline != nullptr) {
+        fading.timeline->targetsDirty = true;
+      }
+    }
+  }
+}
+
 void PAGStateMachine::changeState(RegionInstance& ri, const StateTransition* t) {
   if (t == nullptr) {
     return;

--- a/src/pagx/runtime/PAGComposition.cpp
+++ b/src/pagx/runtime/PAGComposition.cpp
@@ -179,8 +179,13 @@ void PAGComposition::resetTimelines() {
 
 void PAGComposition::MarkCompositionTimelinesDirty(PAGComposition* comp) {
   for (const auto& timeline : comp->timelines) {
-    if (timeline != nullptr && timeline->type() == TimelineType::Animation) {
+    if (timeline == nullptr) {
+      continue;
+    }
+    if (timeline->type() == TimelineType::Animation) {
       static_cast<PAGAnimation*>(timeline.get())->targetsDirty = true;
+    } else if (timeline->type() == TimelineType::StateMachine) {
+      static_cast<PAGStateMachine*>(timeline.get())->markInternalTargetsDirty();
     }
   }
 }

--- a/src/pagx/runtime/PAGComposition.cpp
+++ b/src/pagx/runtime/PAGComposition.cpp
@@ -177,6 +177,18 @@ void PAGComposition::resetTimelines() {
   forEachComposition(ResetCompositionTimelines);
 }
 
+void PAGComposition::MarkCompositionTimelinesDirty(PAGComposition* comp) {
+  for (const auto& timeline : comp->timelines) {
+    if (timeline != nullptr && timeline->type() == TimelineType::Animation) {
+      static_cast<PAGAnimation*>(timeline.get())->targetsDirty = true;
+    }
+  }
+}
+
+void PAGComposition::markTimelineTargetsDirty() {
+  forEachComposition(MarkCompositionTimelinesDirty);
+}
+
 void PAGComposition::forEachComposition(void (*visitor)(PAGComposition*)) {
   PAGLayer::forEachComposition(visitor);
   visitor(this);

--- a/src/renderer/LayerBuilder.h
+++ b/src/renderer/LayerBuilder.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include "base/utils/Log.h"
 #include "pagx/PAGImage.h"
 #include "pagx/PAGXDocument.h"
 #include "pagx/nodes/Channel.h"
@@ -261,6 +262,10 @@ struct RuntimeBinding {
   bool apply(const Node* node, const std::string& channel, const KeyValue& value, float mix) const {
     auto it = targets.find(node);
     if (it == targets.end()) {
+      // Callers (PAGTimeline::resolveTargets, DataBindRuntime::bind) already drop out-of-scope
+      // targets via contains(), so a miss here means that scope contract was broken upstream. The
+      // return false below keeps release builds graceful.
+      DEBUG_ASSERT(false);
       return false;
     }
     return it->second->apply(channel, value, mix);

--- a/src/renderer/LayerBuilder.h
+++ b/src/renderer/LayerBuilder.h
@@ -262,10 +262,9 @@ struct RuntimeBinding {
   bool apply(const Node* node, const std::string& channel, const KeyValue& value, float mix) const {
     auto it = targets.find(node);
     if (it == targets.end()) {
-      // Callers (PAGTimeline::resolveTargets, DataBindRuntime::bind) already drop out-of-scope
-      // targets via contains(), so a miss here means that scope contract was broken upstream. The
-      // return false below keeps release builds graceful.
-      DEBUG_ASSERT(false);
+      // A miss is legitimate when a cached target was removed from the binding after cache
+      // population (e.g. a Layer targeted by a top-level timeline is deleted without resetting the
+      // timeline's resolved cache). Fail gracefully.
       return false;
     }
     return it->second->apply(channel, value, mix);

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -11473,6 +11473,130 @@ PAGX_TEST(PAGXTest, SMRuntimeInitialState) {
   EXPECT_EQ(timeline->getCurrentState("main"), "start");
 }
 
+/**
+ * Test case: a state machine handle cached by the caller survives a runtime-tree rebuild. A
+ * top-level state machine is constructed with a null binding, so the inner PAGAnimation of each
+ * animation state resolves the scene's current root binding lazily at apply time. Rebuilding the
+ * runtime tree (here via a document-node notifyChange) frees the old root binding; re-driving the
+ * cached handle must resolve the new binding and drive the target instead of dereferencing the
+ * freed one.
+ */
+PAGX_TEST(PAGXTest, SMHandleSurvivesRuntimeTreeRebuild) {
+  auto doc = pagx::PAGXDocument::Make(100, 100);
+  auto layer = doc->makeNode<pagx::Layer>("mainLayer");
+  layer->width = 50;
+  layer->height = 50;
+  doc->layers.push_back(layer);
+
+  auto anim = doc->makeNode<pagx::Animation>("anim");
+  anim->duration = 60;
+  anim->frameRate = 60;
+  doc->animations.push_back(anim);
+  auto* object = doc->makeNode<pagx::AnimationObject>();
+  object->target = "mainLayer";
+  anim->objects.push_back(object);
+  auto* alphaProp = doc->makeNode<pagx::TypedChannel<float>>();
+  alphaProp->name = "alpha";
+  alphaProp->keyframes.push_back({0, 0.0f, pagx::KeyframeInterpolationType::Linear, {}, {}});
+  alphaProp->keyframes.push_back({60, 1.0f, pagx::KeyframeInterpolationType::Linear, {}, {}});
+  object->channels.push_back(alphaProp);
+
+  auto sm = doc->makeNode<pagx::StateMachine>("testSM");
+  doc->animations.push_back(sm);
+  auto region = doc->makeNode<pagx::StateRegion>();
+  region->name = "main";
+  region->initialState = "play";
+  auto state = doc->makeNode<pagx::AnimationState>();
+  state->name = "play";
+  state->animationId = "anim";
+  region->states.push_back(state);
+  sm->regions.push_back(region);
+
+  auto scene = pagx::PAGScene::Make(doc)->shared_from_this();
+  ASSERT_TRUE(scene != nullptr);
+
+  // Cache the handle BEFORE the rebuild, like a caller that keeps it per frame. Drive to a mid
+  // value (0.5) distinct from the default alpha (1.0) so the assertion proves the machine wrote
+  // through the binding rather than the value happening to match.
+  auto timeline = scene->getStateMachineTimeline("testSM");
+  ASSERT_TRUE(timeline != nullptr);
+  timeline->advanceAndApply(500'000);
+  EXPECT_NEAR(scene->mutableBinding()->get<tgfx::Layer>(layer)->alpha(), 0.5f, 1.0e-3f);
+
+  // A document-node notifyChange rebuilds the whole runtime tree, freeing the old root binding the
+  // machine's inner PAGAnimation was originally built against.
+  doc->notifyChange({doc.get()}, /*layoutChanged=*/true);
+
+  // Re-driving the CACHED handle with a zero delta re-applies the held time (500ms) through the new
+  // binding: it must resolve the new binding and drive the value to 0.5 again, not crash or write
+  // through the freed binding.
+  timeline->advanceAndApply(0);
+  EXPECT_NEAR(scene->mutableBinding()->get<tgfx::Layer>(layer)->alpha(), 0.5f, 1.0e-3f);
+}
+
+/**
+ * Test case: an incremental tree refresh that changes binding membership must re-resolve the
+ * targets of a state machine's inner PAGAnimation, not just top-level and composition timelines.
+ * The inner animations live in the machine's regions, not in the composition's timeline list, so
+ * they need their own dirty signal. Here the state's target is out of scope at first (its layer is
+ * not yet in the tree, so it is filtered out of the resolved targets), then an incremental refresh
+ * brings the layer into scope; the machine must pick it up and drive it.
+ */
+PAGX_TEST(PAGXTest, SMInnerTimelineReresolvesAfterLayerRefresh) {
+  auto doc = pagx::PAGXDocument::Make(100, 100);
+  auto anchor = doc->makeNode<pagx::Layer>("anchor");
+  anchor->width = 50;
+  anchor->height = 50;
+  doc->layers.push_back(anchor);
+
+  // Created up front so findNode resolves it, but NOT added to the tree yet: it is absent from the
+  // binding, so the state's first resolve filters it out as out-of-scope.
+  auto lateLayer = doc->makeNode<pagx::Layer>("lateLayer");
+  lateLayer->width = 50;
+  lateLayer->height = 50;
+
+  auto anim = doc->makeNode<pagx::Animation>("anim");
+  anim->duration = 60;
+  anim->frameRate = 60;
+  doc->animations.push_back(anim);
+  auto* object = doc->makeNode<pagx::AnimationObject>();
+  object->target = "lateLayer";
+  anim->objects.push_back(object);
+  auto* alphaProp = doc->makeNode<pagx::TypedChannel<float>>();
+  alphaProp->name = "alpha";
+  alphaProp->keyframes.push_back({0, 0.5f, pagx::KeyframeInterpolationType::Hold, {}, {}});
+  object->channels.push_back(alphaProp);
+
+  auto sm = doc->makeNode<pagx::StateMachine>("testSM");
+  doc->animations.push_back(sm);
+  auto region = doc->makeNode<pagx::StateRegion>();
+  region->name = "main";
+  region->initialState = "play";
+  auto state = doc->makeNode<pagx::AnimationState>();
+  state->name = "play";
+  state->animationId = "anim";
+  region->states.push_back(state);
+  sm->regions.push_back(region);
+
+  auto scene = pagx::PAGScene::Make(doc)->shared_from_this();
+  ASSERT_TRUE(scene != nullptr);
+
+  // First apply: lateLayer is not in the binding, so the inner animation resolves to no targets.
+  auto timeline = scene->getStateMachineTimeline("testSM");
+  ASSERT_TRUE(timeline != nullptr);
+  timeline->advanceAndApply(0);
+
+  // Bring lateLayer into scope via an incremental refresh (a plain layer add, not a timeline edit).
+  doc->layers.push_back(lateLayer);
+  doc->notifyChange({doc->layers.back()}, /*layoutChanged=*/true);
+
+  // The inner animation must re-resolve and now drive lateLayer's alpha to 0.5.
+  timeline->advanceAndApply(0);
+  auto tgfxLate = scene->mutableBinding()->get<tgfx::Layer>(lateLayer);
+  ASSERT_TRUE(tgfxLate != nullptr);
+  EXPECT_NEAR(tgfxLate->alpha(), 0.5f, 1.0e-3f);
+}
+
 PAGX_TEST(PAGXTest, SMBoolTransition) {
   auto doc = pagx::PAGXDocument::Make(100, 100);
 

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -8867,9 +8867,8 @@ PAGX_TEST(PAGXTest, NotifyChangeLayoutWidth) {
 }
 
 /**
- * Test case: a non-timeline edit (a plain layer attribute) does NOT disturb timelines — the
- * timeline keeps its resolved cache and in-progress playback. Only timeline-node edits reset
- * timelines.
+ * Test case: a non-timeline edit (a plain layer attribute) does NOT disturb in-progress playback —
+ * the timeline keeps its current time and continues driving its target correctly across the edit.
  */
 PAGX_TEST(PAGXTest, NotifyChangeKeepsTimelineWhenNoTimelineNodeDirty) {
   auto doc = pagx::PAGXDocument::Make(100, 100);
@@ -8894,11 +8893,9 @@ PAGX_TEST(PAGXTest, NotifyChangeKeepsTimelineWhenNoTimelineNodeDirty) {
   auto timeline = std::static_pointer_cast<pagx::PAGAnimation>(scene->getDefaultTimeline());
   ASSERT_TRUE(timeline != nullptr);
   timeline->apply(1.0f);
-  EXPECT_TRUE(timeline->resolved);
 
-  // A plain layer edit is not a timeline node, so the timeline is left untouched (cache preserved).
+  // A plain layer edit is not a timeline node, so the timeline is left untouched.
   doc->notifyChange({layer}, true);
-  EXPECT_TRUE(timeline->resolved);
 
   // Playback still drives the channel correctly.
   auto tgfxLayer = scene->mutableBinding()->get<tgfx::Layer>(layer);
@@ -10843,6 +10840,145 @@ PAGX_TEST(PAGXTest, CompositionTimelineThroughContainer) {
   // Advance to end.
   scene->advanceAndApply(500'000);
   ASSERT_EQ(rootChildren[0]->children.size(), 1u);
+}
+
+/**
+ * Test case: a document-level (top-level) animation whose target points at a node living inside a
+ * nested composition is dropped by resolveTargets' scope filter. The child is bound in the slot's
+ * own binding, not the root binding the top-level timeline resolves against, so applying to it
+ * would cross the composition boundary. The child must keep its default alpha, proving the
+ * out-of-scope target was filtered out.
+ */
+PAGX_TEST(PAGXTest, TopLevelTimelineDropsCrossCompositionTarget) {
+  auto doc = pagx::PAGXDocument::Make(100, 100);
+  auto fx = MakeAlphaComposition(doc.get(), "comp", "compAnim", "child");
+
+  auto slot = doc->makeNode<pagx::Layer>("slot");
+  slot->composition = fx.comp;
+  slot->width = 50;
+  slot->height = 50;
+  doc->layers.push_back(slot);
+
+  // A document-level animation targeting the nested composition's inner child by id. findNode
+  // resolves it document-wide, but the child is not in the root binding, so it must be dropped.
+  auto crossAnim = doc->makeNode<pagx::Animation>("crossAnim");
+  crossAnim->duration = 60;
+  crossAnim->frameRate = 60;
+  doc->animations.push_back(crossAnim);
+  auto* crossObj = doc->makeNode<pagx::AnimationObject>();
+  crossObj->target = "child";
+  crossAnim->objects.push_back(crossObj);
+  auto* crossAlpha = doc->makeNode<pagx::TypedChannel<float>>();
+  crossAlpha->name = "alpha";
+  crossAlpha->keyframes.push_back({0, 0.0f, pagx::KeyframeInterpolationType::Hold, {}, {}});
+  crossObj->channels.push_back(crossAlpha);
+
+  auto scene = pagx::PAGScene::Make(doc);
+  ASSERT_TRUE(scene != nullptr);
+
+  auto& slotBinding =
+      *static_cast<pagx::PAGComposition*>(scene->rootComposition()->children[0].get())->binding;
+  auto childTgfx = slotBinding.get<tgfx::Layer>(fx.childLayer);
+  ASSERT_TRUE(childTgfx != nullptr);
+  childTgfx->setAlpha(1.0f);
+
+  // Apply the top-level animation at the keyframe holding alpha=0. The cross-boundary target is
+  // out of the root binding's scope, so the child's alpha must stay at 1.0 (untouched).
+  auto crossTimeline = scene->getAnimation("crossAnim");
+  ASSERT_TRUE(crossTimeline != nullptr);
+  crossTimeline->apply(1.0f);
+  EXPECT_FLOAT_EQ(childTgfx->alpha(), 1.0f);
+}
+
+/**
+ * Test case: a document-level animation whose target is a root Layer (same scope as the root
+ * binding) drives that target normally — the scope filter must not drop an in-scope target.
+ */
+PAGX_TEST(PAGXTest, TopLevelTimelineDrivesInScopeTarget) {
+  auto doc = pagx::PAGXDocument::Make(100, 100);
+  auto layer = doc->makeNode<pagx::Layer>("root");
+  layer->width = 50;
+  layer->height = 50;
+  doc->layers.push_back(layer);
+
+  auto anim = doc->makeNode<pagx::Animation>("rootAnim");
+  anim->duration = 60;
+  anim->frameRate = 60;
+  doc->animations.push_back(anim);
+  auto* object = doc->makeNode<pagx::AnimationObject>();
+  object->target = "root";
+  anim->objects.push_back(object);
+  auto* alphaProp = doc->makeNode<pagx::TypedChannel<float>>();
+  alphaProp->name = "alpha";
+  alphaProp->keyframes.push_back({0, 0.0f, pagx::KeyframeInterpolationType::Linear, {}, {}});
+  alphaProp->keyframes.push_back({60, 1.0f, pagx::KeyframeInterpolationType::Linear, {}, {}});
+  object->channels.push_back(alphaProp);
+
+  auto scene = pagx::PAGScene::Make(doc);
+  ASSERT_TRUE(scene != nullptr);
+  auto tgfxLayer = scene->mutableBinding()->get<tgfx::Layer>(layer);
+  ASSERT_TRUE(tgfxLayer != nullptr);
+  tgfxLayer->setAlpha(1.0f);
+
+  // 30 frames @ 60fps: linear 0→1 halfway = 0.5.
+  auto timeline = scene->getAnimation("rootAnim");
+  ASSERT_TRUE(timeline != nullptr);
+  timeline->setCurrentTime(500'000);
+  timeline->apply(1.0f);
+  EXPECT_NEAR(tgfxLayer->alpha(), 0.5f, 1.0e-3f);
+}
+
+/**
+ * Test case: a target Layer driven by a top-level animation is removed from the document at
+ * runtime. The removal goes through the incremental refresh path (binding->remove) without
+ * marking any timeline node dirty, so the timeline re-resolves each frame and applying to the
+ * now-unbound target simply skips it instead of aborting.
+ */
+PAGX_TEST(PAGXTest, TopLevelTimelineTargetRemovedThenApplied) {
+  auto doc = pagx::PAGXDocument::Make(100, 100);
+  auto keep = doc->makeNode<pagx::Layer>("keep");
+  keep->width = 50;
+  keep->height = 50;
+  doc->layers.push_back(keep);
+  auto target = doc->makeNode<pagx::Layer>("target");
+  target->width = 50;
+  target->height = 50;
+  doc->layers.push_back(target);
+
+  auto anim = doc->makeNode<pagx::Animation>("anim");
+  anim->duration = 60;
+  anim->frameRate = 60;
+  doc->animations.push_back(anim);
+  auto* object = doc->makeNode<pagx::AnimationObject>();
+  object->target = "target";
+  anim->objects.push_back(object);
+  auto* alphaProp = doc->makeNode<pagx::TypedChannel<float>>();
+  alphaProp->name = "alpha";
+  alphaProp->keyframes.push_back({0, 0.0f, pagx::KeyframeInterpolationType::Linear, {}, {}});
+  alphaProp->keyframes.push_back({60, 1.0f, pagx::KeyframeInterpolationType::Linear, {}, {}});
+  object->channels.push_back(alphaProp);
+
+  auto scene = pagx::PAGScene::Make(doc);
+  ASSERT_TRUE(scene != nullptr);
+  auto targetTgfx = scene->mutableBinding()->get<tgfx::Layer>(target);
+  ASSERT_TRUE(targetTgfx != nullptr);
+
+  // First apply drives the target normally, populating the resolved targets.
+  auto timeline = scene->getAnimation("anim");
+  ASSERT_TRUE(timeline != nullptr);
+  timeline->advanceAndApply(500'000);
+  EXPECT_NEAR(targetTgfx->alpha(), 0.5f, 1.0e-3f);
+
+  // Remove the target layer and notify. Its binding entry is dropped without touching any timeline
+  // node, so timelineDirty stays false and the timeline is not reset.
+  doc->layers.erase(doc->layers.begin() + 1);
+  doc->notifyChange({keep}, true);
+  ASSERT_EQ(scene->mutableBinding()->get<tgfx::Layer>(target), nullptr);
+
+  // Re-applying must re-resolve against the current binding and skip the now-unbound target
+  // gracefully instead of asserting.
+  timeline->advanceAndApply(500'000);
+  EXPECT_EQ(scene->mutableBinding()->get<tgfx::Layer>(target), nullptr);
 }
 
 /**

--- a/test/src/PAGXViewModelTest.cpp
+++ b/test/src/PAGXViewModelTest.cpp
@@ -2029,6 +2029,57 @@ PAGX_TEST(PAGXViewModelTest, DataBindRuntimeNullDataBindSafety) {
   runtime->update(binding.get(), 1.0f);
 }
 
+// ========== DataBind scope filtering ==========
+
+PAGX_TEST(PAGXViewModelTest, DataBindDropsOutOfScopeTarget) {
+  // A DataBind whose target resolves (document-wide) to a node that is NOT in this binding is
+  // dropped: in the real runtime such a node lives inside a nested composition's own binding, so
+  // binding to it here would cross the composition boundary. Mirrors PAGTimeline's scope filter.
+  auto doc = pagx::PAGXDocument::Make(200, 200);
+  auto* schema = doc->makeNode<pagx::ViewModel>("T");
+  auto* prop = doc->makeNode<pagx::ViewModelProperty>();
+  prop->name = "val";
+  prop->propertyType = pagx::ViewModelPropertyType::Number;
+  schema->properties.push_back(prop);
+  doc->viewModel = schema;
+
+  auto inScope = doc->makeNode<pagx::Layer>("inScope");
+  inScope->width = 200;
+  inScope->height = 200;
+  doc->layers.push_back(inScope);
+  auto outOfScope = doc->makeNode<pagx::Layer>("outOfScope");
+  outOfScope->width = 200;
+  outOfScope->height = 200;
+  doc->layers.push_back(outOfScope);
+
+  auto scene = pagx::PAGScene::Make(
+      std::shared_ptr<pagx::PAGXDocument>(doc.get(), [](pagx::PAGXDocument*) {}));
+  ASSERT_NE(scene, nullptr);
+  auto ctx = std::make_shared<pagx::DataContext>(scene->viewModel());
+
+  auto dbOut = doc->makeNode<pagx::DataBind>();
+  dbOut->source = "$vm.val";
+  dbOut->target = "@outOfScope";
+  dbOut->channel = "alpha";
+  auto dbIn = doc->makeNode<pagx::DataBind>();
+  dbIn->source = "$vm.val";
+  dbIn->target = "@inScope";
+  dbIn->channel = "alpha";
+
+  // A binding that only contains inScope. outOfScope resolves via findNode but is not a member of
+  // this binding, so bind() must drop it while keeping the in-scope bind.
+  auto binding = std::make_unique<pagx::RuntimeBinding>();
+  binding->set(inScope, std::make_shared<int>(0));
+
+  auto runtime = std::make_unique<pagx::DataBindRuntime>();
+  std::vector<pagx::DataBind*> binds = {dbOut, dbIn};
+  runtime->bind(binds, ctx.get(), doc.get(), binding.get());
+
+  // Exactly one entry survives — the in-scope one; the out-of-scope target was filtered out.
+  ASSERT_EQ(runtime->entries.size(), 1u);
+  EXPECT_EQ(runtime->entries[0].targetNode, inScope);
+}
+
 // ========== DataBindRuntime destructor safety ==========
 
 PAGX_TEST(PAGXViewModelTest, DataBindRuntimeDestructorWithDeadSource) {

--- a/test/src/PAGXViewModelTest.cpp
+++ b/test/src/PAGXViewModelTest.cpp
@@ -2014,6 +2014,10 @@ PAGX_TEST(PAGXViewModelTest, DataBindRuntimeNullDataBindSafety) {
                                            : nullptr;
   std::vector<pagx::DataBind*> binds = {db};
   auto binding = std::make_unique<pagx::RuntimeBinding>();
+  // Register the target node in the binding. In the real runtime LayerBuilder populates targets
+  // before bind() runs; bind() now drops out-of-scope targets via binding->contains(), so this
+  // isolated test must mirror that precondition.
+  binding->set(layer, std::make_shared<int>(0));
   runtime->bind(binds, ctx.get(), doc.get(), binding.get());
   EXPECT_FALSE(runtime->entries.empty());
 


### PR DESCRIPTION
PAGTimeline::resolveTargets 和 DataBindRuntime::bind之前通过 findNode 扁平查找 target，未按 binding 作用域过滤，document 级动画/数据绑定可能越界命中嵌套 Composition 内部节点。
修复：遍历动画对象时用 binding.contains() 过滤掉不在当前 scope 内的目标（scope filter），并新增树结构变化或 binding 指针变化时能够重新resolveTarget避免信息过时