### PR TITLE
Fix Android Surface.release crash by using a weakly referencing OnFrameAvailableListener to break the VideoSurface reference cycle.

### DIFF
--- a/android/libpag/src/main/java/org/libpag/VideoSurface.java
+++ b/android/libpag/src/main/java/org/libpag/VideoSurface.java
@@ -3,9 +3,34 @@ package org.libpag;
 import android.graphics.SurfaceTexture;
 import android.view.Surface;
 
+import java.lang.ref.WeakReference;
+
 import org.extra.tools.LibraryLoadUtils;
 
-class VideoSurface implements SurfaceTexture.OnFrameAvailableListener {
+class VideoSurface {
+    // WeakFrameListener holds VideoSurface via a WeakReference to break the
+    // circular reference between the native SurfaceTexture (which holds a
+    // global reference to the Java SurfaceTexture) and the Java VideoSurface
+    // (registered as the OnFrameAvailableListener on the Java SurfaceTexture).
+    // Without this, the Java VideoSurface can never be reclaimed by GC, and
+    // the underlying SurfaceTextureReader (along with its GPU resources) stays
+    // alive indefinitely.
+    private static class WeakFrameListener implements SurfaceTexture.OnFrameAvailableListener {
+        private final WeakReference<VideoSurface> target;
+
+        WeakFrameListener(VideoSurface target) {
+            this.target = new WeakReference<>(target);
+        }
+
+        @Override
+        public void onFrameAvailable(SurfaceTexture surfaceTexture) {
+            VideoSurface videoSurface = target.get();
+            if (videoSurface != null) {
+                videoSurface.notifyFrameAvailable();
+            }
+        }
+    }
+
     static VideoSurface Make(int width, int height) {
         VideoSurface videoSurface = new VideoSurface(width, height);
         if (videoSurface.nativeContext == 0) {
@@ -14,12 +39,15 @@ class VideoSurface implements SurfaceTexture.OnFrameAvailableListener {
         return videoSurface;
     }
 
-    private VideoSurface(int width, int height) {
-        nativeSetup(width, height);
-    }
+    // Hold a strong reference to the listener so it lives as long as this
+    // VideoSurface. The native SurfaceTexture also holds a global reference
+    // to the same listener via SurfaceTexture.setOnFrameAvailableListener,
+    // which keeps it alive during frame delivery.
+    private final WeakFrameListener frameListener;
 
-    public void onFrameAvailable(SurfaceTexture st) {
-        notifyFrameAvailable();
+    private VideoSurface(int width, int height) {
+        frameListener = new WeakFrameListener(this);
+        nativeSetup(width, height, frameListener);
     }
 
     native Surface getInputSurface();
@@ -41,7 +69,7 @@ class VideoSurface implements SurfaceTexture.OnFrameAvailableListener {
 
     private static native void nativeInit();
 
-    private native void nativeSetup(int width, int height);
+    private native void nativeSetup(int width, int height, Object listener);
 
     private native void notifyFrameAvailable();
 

--- a/src/platform/android/HardwareDecoder.cpp
+++ b/src/platform/android/HardwareDecoder.cpp
@@ -53,13 +53,15 @@ HardwareDecoder::~HardwareDecoder() {
     delete bufferInfo;
     bufferInfo = nullptr;
   }
-  if (videoSurface.get() != nullptr) {
-    JNIEnvironment environment;
-    auto env = environment.current();
-    if (env != nullptr) {
-      JVideoSurface::Release(env, videoSurface.get());
-    }
-  }
+  // No need to explicitly break the SurfaceTextureReader <-> Java VideoSurface
+  // circular reference here: the Java VideoSurface now registers a weakly
+  // referencing OnFrameAvailableListener on the native SurfaceTexture (see
+  // VideoSurface.java), so once our GlobalRef to the Java VideoSurface is
+  // dropped (below, when this function returns), the Java VideoSurface loses
+  // all strong references and becomes eligible for GC. Its finalize() then
+  // releases the underlying SurfaceTextureReader on the Java Finalizer thread,
+  // which avoids the Surface.release() vs framework teardown race that used
+  // to crash tgfx worker threads at RefBase::incStrong.
 }
 
 bool HardwareDecoder::initDecoder(const VideoFormat& format) {

--- a/src/platform/android/JVideoSurface.cpp
+++ b/src/platform/android/JVideoSurface.cpp
@@ -101,8 +101,14 @@ PAG_API void Java_org_libpag_VideoSurface_nativeFinalize(JNIEnv* env, jobject th
 }
 
 PAG_API void Java_org_libpag_VideoSurface_nativeSetup(JNIEnv* env, jobject thiz, jint width,
-                                                      jint height) {
-  auto imageStream = tgfx::SurfaceTextureReader::Make(width, height, thiz);
+                                                      jint height, jobject listener) {
+  // Pass the weak-referencing listener (instead of `thiz`) to the native
+  // SurfaceTexture. This breaks the circular strong reference chain
+  // (native SurfaceTexture -> Java SurfaceTexture -> OnFrameAvailableListener
+  // -> Java VideoSurface -> JVideoSurface -> SurfaceTextureReader ->
+  // native SurfaceTexture) so that the Java VideoSurface can be reclaimed by
+  // GC after its owning HardwareDecoder releases its GlobalRef.
+  auto imageStream = tgfx::SurfaceTextureReader::Make(width, height, listener);
   if (imageStream == nullptr) {
     return;
   }


### PR DESCRIPTION
问题背景

4.5.75 起，Bugly 上出现规模化 Android SIGSEGV(SEGV_MAPERR) 崩溃，栈顶为 libutils.so 的 RefBase::incStrong+20，Java 侧栈是 android.view.Surface.release / nativeRelease，崩溃线程为 tgfx_JNIEnviron，多份样本跨 vivo Android 15 和 realme Android 12 复现，均发生在导航 MapStateCarNav 后台状态。

根因分析

从 4.5.46 到 4.5.75 期间，两个提交叠加引发该 crash：
- 9352bfb7e（PR #3499）在 ~HardwareDecoder 里主动调用 JVideoSurface::Release 切断 SurfaceTextureReader 与 Java VideoSurface 之间的循环引用，修的是原本的内存泄漏，但副作用是把 ~SurfaceTexture 里的 Surface.release() 的执行时机从 Java Finalizer 线程搬到了 tgfx worker 线程。
- 602afae89（PR #3554）把 PAGAnimator::extractAndWaitTask 里的 wait 改成 500ms 超时，修的是主线程 ANR，但打破了主线程 cancel 与 tgfx worker 之间的串行保证。

两个 commit 叠加后，Surface.release() 在 tgfx worker 上执行时会与 Framework 侧的 native android::Surface 拆除路径并发（后台状态下 MediaCodec/SurfaceComposer 更激进），导致命中已释放对象崩溃。

修复方案

从根本上消除循环引用，让 Java VideoSurface 能被正常 GC 回收，不再需要 ~HardwareDecoder 里主动切循环，从而让 Surface.release() 回到 Java Finalizer 线程执行。

具体改动：
1. VideoSurface.java 新增 WeakFrameListener 内部类，通过 WeakReference 弱引用 VideoSurface。VideoSurface 构造时创建 listener 并传给 nativeSetup，作为 SurfaceTexture 的 OnFrameAvailableListener。原本 VideoSurface 自己实现 OnFrameAvailableListener 被 SurfaceTexture 强引用，改为通过弱引用 wrapper 间接注册，打破循环。
2. JVideoSurface.cpp 的 nativeSetup 签名增加 listener 参数，把弱引用 wrapper 传给 SurfaceTextureReader::Make 使用。
3. HardwareDecoder.cpp 移除 ~HardwareDecoder 里主动调用 JVideoSurface::Release 的逻辑。循环引用已由 WeakFrameListener 打破，无需再主动切。

预期效果
- 消除 tgfx_JNIEnviron 线程上 Surface.release 崩溃
- 保留 9352bfb7e 修的内存泄漏（Java VideoSurface 现在能被 GC，只是释放时机依赖 GC 触发，与 4.5.46 时代永久泄漏相比大幅改善）
- 保留 602afae89 修的 ANR

回归验证
- 视频合成 PAG 播放正常
- 反复切换含视频合成的 PAG 文件，观察内存回收
- 后台/前台切换、导航场景压测