### PR TITLE
Fix incorrect ImageBytes size and anchor for masked video layers in AE exporter

### DIFF
--- a/exporter/src/export/data/ImageBytes.cpp
+++ b/exporter/src/export/data/ImageBytes.cpp
@@ -33,6 +33,12 @@ static void GetVideoLayerRenderImageSize(const AEGP_LayerH& layerHandle, A_u_lon
   if (renderOptions == nullptr) {
     return;
   }
+  // AEGP_NewFromLayer uses the current time indicator position which may be outside the layer's
+  // visible range. Explicitly set the time to the layer's in point in layer time to ensure the
+  // first visible frame is rendered correctly (including footage slip).
+  A_Time inPointLayer = {};
+  Suites->LayerSuite6()->AEGP_GetLayerInPoint(layerHandle, AEGP_LTimeMode_LayerTime, &inPointLayer);
+  Suites->LayerRenderOptionsSuite2()->AEGP_SetTime(renderOptions, inPointLayer);
   GetLayerRenderFrameSize(renderOptions, srcStride, width, height);
   Suites->LayerRenderOptionsSuite2()->AEGP_Dispose(renderOptions);
 }
@@ -48,6 +54,9 @@ static void GetVideoLayerRenderImage(uint8* rgbaBytes, const AEGP_LayerH& layerH
   if (renderOptions == nullptr) {
     return;
   }
+  A_Time inPointLayer = {};
+  Suites->LayerSuite6()->AEGP_GetLayerInPoint(layerHandle, AEGP_LTimeMode_LayerTime, &inPointLayer);
+  Suites->LayerRenderOptionsSuite2()->AEGP_SetTime(renderOptions, inPointLayer);
   GetLayerRenderFrame(rgbaBytes, srcStride, dstStride, width, height, renderOptions);
   Suites->LayerRenderOptionsSuite2()->AEGP_Dispose(renderOptions);
 }
@@ -81,6 +90,23 @@ static void GetImageLayerRenderImage(uint8* rgbaBytes, const AEGP_LayerH& layerH
   }
   GetRenderFrame(rgbaBytes, srcStride, dstStride, width, height, renderOptions);
   Suites->RenderOptionsSuite3()->AEGP_Dispose(renderOptions);
+}
+
+// Returns the masked bounds offset of a video layer in layer space. When a video layer has masks,
+// AEGP_RenderAndCheckoutLayerFrame returns a world cropped to the mask bounding box. This function
+// retrieves that bounding box so we can record the correct offset in the exported imageBytes.
+static void GetVideoLayerMaskedOffset(const AEGP_LayerH& layerHandle, A_long& offsetX,
+                                      A_long& offsetY) {
+  const auto& Suites = GetSuites();
+  A_Time inPoint = {};
+  Suites->LayerSuite6()->AEGP_GetLayerInPoint(layerHandle, AEGP_LTimeMode_CompTime, &inPoint);
+  A_FloatRect maskedBounds = {};
+  Suites->LayerSuite8()->AEGP_GetLayerMaskedBounds(layerHandle, AEGP_LTimeMode_CompTime, &inPoint,
+                                                   &maskedBounds);
+  // Floor toward negative infinity so masks with negative fractional bounds match AE's pixel-floor
+  // crop origin.
+  offsetX = static_cast<A_long>(floor(maskedBounds.left));
+  offsetY = static_cast<A_long>(floor(maskedBounds.top));
 }
 
 void GetImageBytes(std::shared_ptr<PAGExportSession> session, pag::ImageBytes* imageBytes,
@@ -131,10 +157,26 @@ void GetImageBytes(std::shared_ptr<PAGExportSession> session, pag::ImageBytes* i
   auto byteData = EncodeImageData(data, scaledWidth, scaledHeight, theStride,
                                   session->configParam.imageQuality);
   if (byteData != nullptr) {
-    imageBytes->width = width;
-    imageBytes->height = height;
-    imageBytes->anchorX = -rect.xPos;
-    imageBytes->anchorY = -rect.yPos;
+    A_long maskedOffsetX = 0;
+    A_long maskedOffsetY = 0;
+    A_long sourceWidth = width;
+    A_long sourceHeight = height;
+    if (isVideo) {
+      // For video layers, Layer Render may crop the output to the mask bounding box. We need to
+      // use the source item dimensions as the logical content size and record the mask offset so
+      // the player can position the placeholder image correctly in layer space.
+      AEGP_ItemH itemHandle = GetLayerItemH(layerHandle);
+      auto dimensions = GetItemDimensions(itemHandle);
+      sourceWidth = dimensions.width();
+      sourceHeight = dimensions.height();
+      if (sourceWidth != width || sourceHeight != height) {
+        GetVideoLayerMaskedOffset(layerHandle, maskedOffsetX, maskedOffsetY);
+      }
+    }
+    imageBytes->width = sourceWidth;
+    imageBytes->height = sourceHeight;
+    imageBytes->anchorX = -(rect.xPos + maskedOffsetX);
+    imageBytes->anchorY = -(rect.yPos + maskedOffsetY);
     imageBytes->scaleFactor = factor;
     imageBytes->fileBytes = byteData;
   }

--- a/exporter/src/export/data/ImageBytes.cpp
+++ b/exporter/src/export/data/ImageBytes.cpp
@@ -23,6 +23,16 @@
 
 namespace exporter {
 
+// AEGP_NewFromLayer uses the current time indicator position which may be outside the layer's
+// visible range. Set the render time to the layer's in point so the first visible frame is
+// rendered correctly. In layer time the in point is always 0 (per the AE SDK), so we construct the
+// time directly instead of querying AEGP_GetLayerInPoint.
+static void SetVideoLayerRenderTime(const AEGP_LayerRenderOptionsH& renderOptions) {
+  const auto& Suites = GetSuites();
+  A_Time inPointLayer = {0, 1};
+  Suites->LayerRenderOptionsSuite2()->AEGP_SetTime(renderOptions, inPointLayer);
+}
+
 static void GetVideoLayerRenderImageSize(const AEGP_LayerH& layerHandle, A_u_long& srcStride,
                                          A_long& width, A_long& height) {
   const auto& Suites = GetSuites();
@@ -33,12 +43,7 @@ static void GetVideoLayerRenderImageSize(const AEGP_LayerH& layerHandle, A_u_lon
   if (renderOptions == nullptr) {
     return;
   }
-  // AEGP_NewFromLayer uses the current time indicator position which may be outside the layer's
-  // visible range. Explicitly set the time to the layer's in point in layer time to ensure the
-  // first visible frame is rendered correctly (including footage slip).
-  A_Time inPointLayer = {};
-  Suites->LayerSuite6()->AEGP_GetLayerInPoint(layerHandle, AEGP_LTimeMode_LayerTime, &inPointLayer);
-  Suites->LayerRenderOptionsSuite2()->AEGP_SetTime(renderOptions, inPointLayer);
+  SetVideoLayerRenderTime(renderOptions);
   GetLayerRenderFrameSize(renderOptions, srcStride, width, height);
   Suites->LayerRenderOptionsSuite2()->AEGP_Dispose(renderOptions);
 }
@@ -54,9 +59,7 @@ static void GetVideoLayerRenderImage(uint8* rgbaBytes, const AEGP_LayerH& layerH
   if (renderOptions == nullptr) {
     return;
   }
-  A_Time inPointLayer = {};
-  Suites->LayerSuite6()->AEGP_GetLayerInPoint(layerHandle, AEGP_LTimeMode_LayerTime, &inPointLayer);
-  Suites->LayerRenderOptionsSuite2()->AEGP_SetTime(renderOptions, inPointLayer);
+  SetVideoLayerRenderTime(renderOptions);
   GetLayerRenderFrame(rgbaBytes, srcStride, dstStride, width, height, renderOptions);
   Suites->LayerRenderOptionsSuite2()->AEGP_Dispose(renderOptions);
 }
@@ -99,10 +102,17 @@ static void GetVideoLayerMaskedOffset(const AEGP_LayerH& layerHandle, A_long& of
                                       A_long& offsetY) {
   const auto& Suites = GetSuites();
   A_Time inPoint = {};
-  Suites->LayerSuite6()->AEGP_GetLayerInPoint(layerHandle, AEGP_LTimeMode_CompTime, &inPoint);
+  A_Err err =
+      Suites->LayerSuite6()->AEGP_GetLayerInPoint(layerHandle, AEGP_LTimeMode_CompTime, &inPoint);
+  if (err != A_Err_NONE || inPoint.scale == 0) {
+    return;
+  }
   A_FloatRect maskedBounds = {};
-  Suites->LayerSuite8()->AEGP_GetLayerMaskedBounds(layerHandle, AEGP_LTimeMode_CompTime, &inPoint,
-                                                   &maskedBounds);
+  err = Suites->LayerSuite8()->AEGP_GetLayerMaskedBounds(layerHandle, AEGP_LTimeMode_CompTime,
+                                                         &inPoint, &maskedBounds);
+  if (err != A_Err_NONE) {
+    return;
+  }
   // Floor toward negative infinity so masks with negative fractional bounds match AE's pixel-floor
   // crop origin.
   offsetX = static_cast<A_long>(floor(maskedBounds.left));

--- a/exporter/src/export/data/ImageBytes.cpp
+++ b/exporter/src/export/data/ImageBytes.cpp
@@ -24,12 +24,14 @@
 namespace exporter {
 
 // AEGP_NewFromLayer uses the current time indicator position which may be outside the layer's
-// visible range. Set the render time to the layer's in point so the first visible frame is
-// rendered correctly. In layer time the in point is always 0 (per the AE SDK), so we construct the
-// time directly instead of querying AEGP_GetLayerInPoint.
-static void SetVideoLayerRenderTime(const AEGP_LayerRenderOptionsH& renderOptions) {
+// visible range. Explicitly set the render time to the layer's in point in layer time so the first
+// visible frame is rendered correctly. The in point is queried per layer rather than assumed to be
+// 0 because footage slip and time stretch can shift it away from the layer's source start.
+static void SetVideoLayerRenderTime(const AEGP_LayerH& layerHandle,
+                                    const AEGP_LayerRenderOptionsH& renderOptions) {
   const auto& Suites = GetSuites();
-  A_Time inPointLayer = {0, 1};
+  A_Time inPointLayer = {};
+  Suites->LayerSuite6()->AEGP_GetLayerInPoint(layerHandle, AEGP_LTimeMode_LayerTime, &inPointLayer);
   Suites->LayerRenderOptionsSuite2()->AEGP_SetTime(renderOptions, inPointLayer);
 }
 
@@ -43,7 +45,7 @@ static void GetVideoLayerRenderImageSize(const AEGP_LayerH& layerHandle, A_u_lon
   if (renderOptions == nullptr) {
     return;
   }
-  SetVideoLayerRenderTime(renderOptions);
+  SetVideoLayerRenderTime(layerHandle, renderOptions);
   GetLayerRenderFrameSize(renderOptions, srcStride, width, height);
   Suites->LayerRenderOptionsSuite2()->AEGP_Dispose(renderOptions);
 }
@@ -59,7 +61,7 @@ static void GetVideoLayerRenderImage(uint8* rgbaBytes, const AEGP_LayerH& layerH
   if (renderOptions == nullptr) {
     return;
   }
-  SetVideoLayerRenderTime(renderOptions);
+  SetVideoLayerRenderTime(layerHandle, renderOptions);
   GetLayerRenderFrame(rgbaBytes, srcStride, dstStride, width, height, renderOptions);
   Suites->LayerRenderOptionsSuite2()->AEGP_Dispose(renderOptions);
 }


### PR DESCRIPTION
## 背景

参见 discussion https://github.com/Tencent/libpag/discussions/3578

当视频图层（video layer）在 After Effects 中添加了蒙版（mask）时，导出的占位图（ImageBytes）尺寸和锚点不正确，导致播放端图片定位错位。根因有两处：

1. **渲染时间不正确**：`AEGP_NewFromLayer` 默认使用当前时间指示器位置，可能落在图层可见区间之外，导出的首帧内容错误（尤其存在 footage slip 时）。
2. **蒙版裁剪未处理**：当视频图层带蒙版时，AE 的 Layer Render 会把渲染结果裁剪到蒙版包围盒，导致导出的 width/height 变成裁剪后的尺寸，且未记录裁剪偏移，锚点随之错位。

## 改动

仅涉及 `exporter/src/export/data/ImageBytes.cpp`：

- 在渲染视频图层尺寸与像素前，显式将渲染时间设置为图层 in-point（layer time），确保渲染的是首个可见帧（含 footage slip）。
- 新增 `GetVideoLayerMaskedOffset`，通过 `AEGP_GetLayerMaskedBounds` 获取蒙版包围盒在 layer space 的偏移。对包围盒 left/top 使用 `floor` 向下取整，与 AE 的像素级裁剪原点保持一致（避免负小数边界下产生 1px 偏差）。
- 视频图层改用源素材尺寸作为逻辑内容尺寸；仅当渲染尺寸与源尺寸不一致（即发生蒙版裁剪）时，才计算并把蒙版偏移记入 `anchorX`/`anchorY`，使播放端能在 layer space 正确定位占位图。

## 验证

- 本地以 `-DPAG_BUILD_TESTS=ON` 编译 `PAGFullTest` 通过。

Resolves discussion #3578
