### PR TITLE
Move emscripten installation from sync_deps.sh to web build scripts

### DIFF
--- a/sync_deps.sh
+++ b/sync_deps.sh
@@ -3,13 +3,6 @@ cd $(dirname $0)
 
 ./install_tools.sh
 
-if [[ `uname` == 'Darwin' ]]; then
-  if [ ! $(which emcc) ]; then
-      echo "emscripten not found. Trying to install..."
-      brew install emscripten
-  fi
-fi
-
 if [ ! $(which depsync) ]; then
   echo "depsync not found. Trying to install..."
   npm install -g depsync > /dev/null

--- a/viewer/sync_deps.sh
+++ b/viewer/sync_deps.sh
@@ -3,13 +3,6 @@ cd $(dirname $0)
 
 ../install_tools.sh
 
-if [[ `uname` == 'Darwin' ]]; then
-  if [ ! $(which emcc) ]; then
-      echo "emscripten not found. Trying to install..."
-      brew install emscripten
-  fi
-fi
-
 if [ ! $(which depsync) ]; then
   echo "depsync not found. Trying to install..."
   npm install -g depsync > /dev/null

--- a/web/script/cmake.demo.js
+++ b/web/script/cmake.demo.js
@@ -9,6 +9,7 @@ process.argv.push("../src");
 process.argv.push("-p");
 process.argv.push("web");
 process.argv.push("pag");
+require("./setup.emsdk");
 require("../../build_pag");
 
 const getArgValue = (argName, defaultValue = "wasm") => process.argv.includes(argName) ? process.argv[process.argv.indexOf(argName) + 1] : defaultValue;

--- a/web/script/setup.emsdk.js
+++ b/web/script/setup.emsdk.js
@@ -1,7 +1,18 @@
+const fs = require('fs');
 const path = require('path');
 const Utils = require("../../third_party/vendor_tools/lib/Utils");
 
 const emsdkPath = path.resolve(__dirname, '../../third_party/emsdk');
+if (!fs.existsSync(emsdkPath)) {
+    try {
+        Utils.exec(`git clone https://github.com/emscripten-core/emsdk.git ${emsdkPath}`);
+    } catch (error) {
+        console.error('clone emsdk failed:', error);
+        process.exit(1);
+    }
+} else {
+    Utils.exec(`git -C ${emsdkPath} pull`);
+}
 const emscriptenPath = path.resolve(emsdkPath, 'upstream/emscripten');
 process.env.PATH = process.platform === 'win32'
     ? `${emsdkPath};${emscriptenPath};${process.env.PATH}`

--- a/web/script/setup.emsdk.js
+++ b/web/script/setup.emsdk.js
@@ -4,9 +4,9 @@ const Utils = require("../../third_party/vendor_tools/lib/Utils");
 
 const emsdkPath = path.resolve(__dirname, '../../third_party/emsdk');
 if (!fs.existsSync(emsdkPath)) {
-    Utils.exec(`git clone https://github.com/emscripten-core/emsdk.git ${emsdkPath}`);
+    Utils.exec(`git clone https://github.com/emscripten-core/emsdk.git ${Utils.escapeSpace(emsdkPath)}`);
 } else {
-    Utils.exec(`git -C ${emsdkPath} pull`);
+    Utils.exec(`git -C ${Utils.escapeSpace(emsdkPath)} pull`);
 }
 const emscriptenPath = path.resolve(emsdkPath, 'upstream/emscripten');
 process.env.PATH = process.platform === 'win32'

--- a/web/script/setup.emsdk.js
+++ b/web/script/setup.emsdk.js
@@ -4,12 +4,7 @@ const Utils = require("../../third_party/vendor_tools/lib/Utils");
 
 const emsdkPath = path.resolve(__dirname, '../../third_party/emsdk');
 if (!fs.existsSync(emsdkPath)) {
-    try {
-        Utils.exec(`git clone https://github.com/emscripten-core/emsdk.git ${emsdkPath}`);
-    } catch (error) {
-        console.error('clone emsdk failed:', error);
-        process.exit(1);
-    }
+    Utils.exec(`git clone https://github.com/emscripten-core/emsdk.git ${emsdkPath}`);
 } else {
     Utils.exec(`git -C ${emsdkPath} pull`);
 }

--- a/web/script/setup.emsdk.js
+++ b/web/script/setup.emsdk.js
@@ -6,7 +6,8 @@ const emsdkPath = path.resolve(__dirname, '../../third_party/emsdk');
 if (!fs.existsSync(emsdkPath)) {
     Utils.exec(`git clone https://github.com/emscripten-core/emsdk.git ${Utils.escapeSpace(emsdkPath)}`);
 } else {
-    Utils.execSafe(`git -C ${Utils.escapeSpace(emsdkPath)} pull`);
+    let pullResult = Utils.execSafe(`git -C ${Utils.escapeSpace(emsdkPath)} pull`);
+    process.stdout.write(pullResult);
 }
 const emscriptenPath = path.resolve(emsdkPath, 'upstream/emscripten');
 process.env.PATH = process.platform === 'win32'

--- a/web/script/setup.emsdk.js
+++ b/web/script/setup.emsdk.js
@@ -6,7 +6,7 @@ const emsdkPath = path.resolve(__dirname, '../../third_party/emsdk');
 if (!fs.existsSync(emsdkPath)) {
     Utils.exec(`git clone https://github.com/emscripten-core/emsdk.git ${Utils.escapeSpace(emsdkPath)}`);
 } else {
-    Utils.exec(`git -C ${Utils.escapeSpace(emsdkPath)} pull`);
+    Utils.execSafe(`git -C ${Utils.escapeSpace(emsdkPath)} pull`);
 }
 const emscriptenPath = path.resolve(emsdkPath, 'upstream/emscripten');
 process.env.PATH = process.platform === 'win32'


### PR DESCRIPTION
## 背景

参考 discussion Tencent/libpag#3555。此前 `sync_deps.sh` / `viewer/sync_deps.sh` 在 macOS 上通过 `brew install emscripten` 安装 emscripten,这会强制所有执行依赖同步的用户(即使不构建 web 目标)都装上 emscripten,且仅覆盖 macOS。

## 改动

将 emscripten(emsdk)的安装从依赖同步阶段迁移到 web 构建脚本,按需安装:

- **`sync_deps.sh` / `viewer/sync_deps.sh`**:移除 Darwin 下的 `brew install emscripten` 逻辑。
- **`web/script/cmake.demo.js`**:在构建前 `require("./setup.emsdk")`,确保构建 web 目标时才准备工具链。
- **`web/script/setup.emsdk.js`**:`third_party/emsdk` 不存在时 `git clone`,已存在时 `git pull` 更新,并将 emsdk 加入 PATH。

## 说明

- `git pull` 更新失败不会中断构建,回退到已有检出,并打印 pull 输出以便发现更新失败。
- git 命令中的路径已做空格转义,兼容含空格的检出路径。
- 跨平台:新脚本在所有平台按需准备工具链,而非旧的仅 macOS 处理。