### PR TITLE
Fix JNI parameter type in nativeReplaceImageByName causing SIGSEGV on armeabi-v7a

### DIFF
--- a/src/platform/android/JPAGFile.cpp
+++ b/src/platform/android/JPAGFile.cpp
@@ -182,7 +182,8 @@ PAG_API void Java_org_libpag_PAGFile_nativeReplaceImage(JNIEnv* env, jobject thi
 }
 
 PAG_API void Java_org_libpag_PAGFile_nativeReplaceImageByName(JNIEnv* env, jobject thiz,
-                                                              jstring layerName, long imageObject) {
+                                                              jstring layerName,
+                                                              jlong imageObject) {
   auto pagFile = getPAGFile(env, thiz);
   if (pagFile == nullptr) {
     return;


### PR DESCRIPTION
## 问题

`Java_org_libpag_PAGFile_nativeReplaceImageByName` 的 `imageObject` 参数在 C++ 侧被声明为原生 `long` 类型，但 Java 侧声明为 `long`（对应 JNI 的 `jlong`，固定 64 位）。

在 armeabi-v7a（32 位 ABI）上，C++ 的 `long` 只有 32 位，与 JNI 期望的 64 位不匹配，导致传入的 `nativeContext` 指针被截断、参数错位，进而 `reinterpret_cast` 得到非法指针，触发 SIGSEGV 崩溃。64 位 ABI 下 `long` 恰好是 64 位，因此问题未暴露。

## 修改

将参数类型由 `long` 改为 `jlong`，与同文件中的 `nativeReplaceImage` 保持一致。

修复 #3590