### PR TITLE
Fix Surface.release crash on tgfx worker by adopting createInputSurface with caller-owned Surface release.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "ed9a4049a1cf9daf2dbb5ba88f004d3e509447cd",
+        "commit": "05f92e7fda54b9693474f5032124afedc8fdc66f",
         "dir": "third_party/tgfx"
       },
       {

--- a/android/libpag/src/main/java/org/libpag/VideoSurface.java
+++ b/android/libpag/src/main/java/org/libpag/VideoSurface.java
@@ -1,7 +1,6 @@
 package org.libpag;
 
 import android.graphics.SurfaceTexture;
-import android.view.Surface;
 
 import org.extra.tools.LibraryLoadUtils;
 
@@ -21,9 +20,6 @@ class VideoSurface implements SurfaceTexture.OnFrameAvailableListener {
     public void onFrameAvailable(SurfaceTexture st) {
         notifyFrameAvailable();
     }
-
-    native Surface getInputSurface();
-
 
     void release() {
         nativeRelease();

--- a/src/platform/android/HardwareDecoder.cpp
+++ b/src/platform/android/HardwareDecoder.cpp
@@ -25,6 +25,33 @@ namespace pag {
 
 static const int TIMEOUT_US = 1000;
 
+// Method ID for android.view.Surface.release(). Lazily resolved on the first
+// call to ReleaseJavaSurface.
+static jmethodID Surface_release = nullptr;
+
+static void ReleaseJavaSurface(JNIEnv* env, jobject surface) {
+  if (env == nullptr || surface == nullptr) {
+    return;
+  }
+  if (Surface_release == nullptr) {
+    auto surfaceClass = env->FindClass("android/view/Surface");
+    if (surfaceClass == nullptr) {
+      env->ExceptionClear();
+      return;
+    }
+    Surface_release = env->GetMethodID(surfaceClass, "release", "()V");
+    env->DeleteLocalRef(surfaceClass);
+    if (Surface_release == nullptr) {
+      env->ExceptionClear();
+      return;
+    }
+  }
+  env->CallVoidMethod(surface, Surface_release);
+  if (env->ExceptionCheck()) {
+    env->ExceptionClear();
+  }
+}
+
 HardwareDecoder::HardwareDecoder(const VideoFormat& format) {
   isValid = initDecoder(format);
 }
@@ -130,7 +157,7 @@ bool HardwareDecoder::initDecoder(const VideoFormat& format) {
     return false;
   }
 
-  auto surface = imageReader->getInputSurface();
+  auto surface = imageReader->createInputSurface();
   if (surface == nullptr) {
     AMediaFormat_delete(mediaFormat);
     AMediaCodec_delete(videoDecoder);
@@ -139,6 +166,15 @@ bool HardwareDecoder::initDecoder(const VideoFormat& format) {
   }
 
   nativeWindow = ANativeWindow_fromSurface(env, surface);
+  // Release the Java Surface immediately after acquiring the ANativeWindow.
+  // ANativeWindow_fromSurface takes its own strong reference on the underlying
+  // native android::Surface (tag = ANativeWindow_acquire), so the native window
+  // stays valid for as long as we keep this HardwareDecoder alive. Doing the
+  // release here (before AMediaCodec_configure) is safe because no other
+  // component has taken a reference to this Java Surface yet, so there is no
+  // race with framework teardown paths that could otherwise crash later.
+  ReleaseJavaSurface(env, surface);
+  env->DeleteLocalRef(surface);
 
   media_status_t status;
   status = AMediaCodec_configure(videoDecoder, mediaFormat, nativeWindow, nullptr, 0);

--- a/src/platform/android/JVideoSurface.cpp
+++ b/src/platform/android/JVideoSurface.cpp
@@ -109,14 +109,6 @@ PAG_API void Java_org_libpag_VideoSurface_nativeSetup(JNIEnv* env, jobject thiz,
   setImageStream(env, thiz, new JVideoSurface(imageStream));
 }
 
-PAG_API jobject Java_org_libpag_VideoSurface_getInputSurface(JNIEnv* env, jobject thiz) {
-  auto reader = JVideoSurface::GetImageReader(env, thiz);
-  if (reader == nullptr) {
-    return nullptr;
-  }
-  return reader->getInputSurface();
-}
-
 PAG_API void Java_org_libpag_VideoSurface_notifyFrameAvailable(JNIEnv* env, jobject thiz) {
   auto reader = JVideoSurface::GetImageReader(env, thiz);
   if (reader == nullptr) {


### PR DESCRIPTION
问题背景

4.5.75 起 Bugly 上出现规模化 Android SIGSEGV(SEGV_MAPERR) 崩溃，栈顶 libutils.so 的 RefBase::incStrong，Java 侧栈 android.view.Surface.nativeRelease / release，崩溃线程 tgfx_JNIEnviron，多份样本跨 vivo Android 15 和 realme Android 12 复现，均发生在腾讯地图导航 MapStateCarNav 后台状态。

根因分析

4.5.46 到 4.5.75 期间两个 PR 叠加暴露了这个 crash：
- 9352bfb7e（PR #3499）在 ~HardwareDecoder 里主动调 JVideoSurface::Release 切断 SurfaceTextureReader 与 Java VideoSurface 的循环引用，副作用是把 ~SurfaceTexture 里 Surface.release() 的执行时机从 Java Finalizer 线程搬到 tgfx worker 线程。
- 602afae89（PR #3554）把 PAGAnimator::extractAndWaitTask 的 wait 改成 500ms 超时，打破了主线程 cancel 与 tgfx worker 之间的串行保证。

两者叠加后，tgfx worker 上执行 Surface.release() 与 Framework 侧 MediaCodec/SurfaceComposer 拆除 native android::Surface 的路径并发，命中野对象崩溃。

修复方案

配合 tgfx 侧 API 重构（PR #1496 + PR #1498，含 party review 建议），从根本上让 tgfx 不再拥有 Java Surface 的生命周期：

tgfx 侧（通过 DEPS 更新到 05f92e7 引入）：
- SurfaceTextureReader 新增 createInputSurface() 替代 getInputSurface()，每次返回新的 Java Surface local ref，所有权归调用方
- tgfx SurfaceTexture 内部不再长期持有 Java Surface（删除 Global<jobject> surface 成员），~SurfaceTexture 不再调 Surface.release()——crash 触发点从 tgfx 源码中消失
- createInputSurface 通过 friend class SurfaceTexture 直接使用 JNIEnvironment::Current() 拿 thread-local env，避免 stack JNIEnvironment 的 PopLocalFrame 释放返回的 local ref

libpag 侧本次改动：
- HardwareDecoder.cpp: initDecoder 里改用 imageReader->createInputSurface()，拿到 ANativeWindow 后立即调用新增的 ReleaseJavaSurface helper 释放 Java Surface 并 DeleteLocalRef
- JVideoSurface.cpp: 删除 Java_..._getInputSurface JNI 函数
- VideoSurface.java: 删除 native Surface getInputSurface() 声明及无用 import
- DEPS: tgfx commit 更新到 05f92e7

保留的现有修复
- 9352bfb7e 的 ~HardwareDecoder 里 JVideoSurface::Release：Java VideoSurface 循环引用依然存在，需要保留主动切
- 602afae89 的 PAGAnimator::extractAndWaitTask 500ms 超时：ANR 修复独立于本次 crash

预期效果
- Bugly RefBase::incStrong + Surface.nativeRelease 崩溃聚合归零
- 内存指标与 9352bfb7e 修复效果一致
- 无 CloseGuard warning，无新增线程/handler 依赖

回归验证
- Android 16 模拟器上运行 MultiVideoSequence.pag 多视频序列，3 个 HardwareDecoder 并发启动，30 秒内 4 次 onAnimationRepeat 正常，进程持续存活无 crash