### PR TITLE
Fix AE crash when exporting video compositions caused by cross-thread progress updates

### DIFF
--- a/exporter/src/export/sequence/VideoSequence.cpp
+++ b/exporter/src/export/sequence/VideoSequence.cpp
@@ -18,6 +18,7 @@
 
 #include "VideoSequence.h"
 #include <QApplication>
+#include <atomic>
 #include "codec/mp4/MP4BoxHelper.h"
 #include "export/encode/PAGEncodeThread.h"
 #include "export/encode/VideoEncoder.h"
@@ -260,6 +261,7 @@ static void GetVideoSequence(std::shared_ptr<PAGExportSession> session,
     pagEncoder->init(seqWidth, seqHeight, frameRate, hasAlpha,
                      session->configParam.bitmapKeyFrameInterval,
                      session->configParam.sequenceQuality);
+    std::atomic<size_t> encodedFrameCount{0};
     std::unique_ptr<PAGEncodeThread> pagEncodeThread = std::make_unique<PAGEncodeThread>();
     pagEncodeThread->setPAGEncoder(std::move(pagEncoder));
     pagEncodeThread->setEncodeFrameCallback(
@@ -269,6 +271,7 @@ static void GetVideoSequence(std::shared_ptr<PAGExportSession> session,
           videoFrame->frame = index;
           videoFrame->fileBytes = data.release();
           sequence->frames.push_back(videoFrame);
+          encodedFrameCount.store(sequence->frames.size(), std::memory_order_release);
           session->progressModel.addFinishedSteps();
         });
     pagEncodeThread->setEncodeHeaderCallback([&](std::vector<pag::ByteData*> headers) {
@@ -370,7 +373,9 @@ static void GetVideoSequence(std::shared_ptr<PAGExportSession> session,
 
     pagEncodeThread->close();
 
-    while (!session->stopExport && sequence->frames.size() < static_cast<size_t>(exportFrameNum) &&
+    while (!session->stopExport &&
+           encodedFrameCount.load(std::memory_order_acquire) <
+               static_cast<size_t>(exportFrameNum) &&
            pagEncodeThread->isValid()) {
       QApplication::processEvents();
     }

--- a/exporter/src/ui/ProgressModel.cpp
+++ b/exporter/src/ui/ProgressModel.cpp
@@ -18,10 +18,13 @@
 
 #include "ProgressModel.h"
 #include <QApplication>
+#include <QThread>
 
 namespace exporter {
 
 ProgressModel::ProgressModel(QObject* parent) : QObject(parent) {
+  connect(this, &ProgressModel::requestAddFinishedSteps, this,
+          &ProgressModel::addFinishedStepsInternal, Qt::QueuedConnection);
 }
 
 int ProgressModel::getExportStatus() const {
@@ -67,11 +70,18 @@ void ProgressModel::setTotalSteps(uint64_t value) {
 }
 
 void ProgressModel::addFinishedSteps(uint64_t value) {
+  if (QThread::currentThread() != thread()) {
+    Q_EMIT requestAddFinishedSteps(value);
+    return;
+  }
+  addFinishedStepsInternal(value);
+}
+
+void ProgressModel::addFinishedStepsInternal(uint64_t value) {
   finishedSteps += value;
   if (finishedSteps >= totalSteps) {
     finishedSteps = totalSteps;
   }
-  QApplication::processEvents();
   Q_EMIT currentProgressChanged(static_cast<double>(finishedSteps));
 }
 

--- a/exporter/src/ui/ProgressModel.cpp
+++ b/exporter/src/ui/ProgressModel.cpp
@@ -82,6 +82,7 @@ void ProgressModel::addFinishedStepsInternal(uint64_t value) {
   if (finishedSteps >= totalSteps) {
     finishedSteps = totalSteps;
   }
+  QApplication::processEvents();
   Q_EMIT currentProgressChanged(static_cast<double>(finishedSteps));
 }
 

--- a/exporter/src/ui/ProgressModel.cpp
+++ b/exporter/src/ui/ProgressModel.cpp
@@ -75,6 +75,12 @@ void ProgressModel::addFinishedSteps(uint64_t value) {
     return;
   }
   addFinishedStepsInternal(value);
+  // Pump the event loop only from the main-thread path. The export loop blocks the main
+  // thread in exportFile(), so this keeps progress updates flowing and drains queued
+  // cross-thread requestAddFinishedSteps events. It must NOT live inside
+  // addFinishedStepsInternal: the queued-slot invocations would then re-enter
+  // processEvents() recursively, one level per pending event.
+  QApplication::processEvents();
 }
 
 void ProgressModel::addFinishedStepsInternal(uint64_t value) {
@@ -82,7 +88,6 @@ void ProgressModel::addFinishedStepsInternal(uint64_t value) {
   if (finishedSteps >= totalSteps) {
     finishedSteps = totalSteps;
   }
-  QApplication::processEvents();
   Q_EMIT currentProgressChanged(static_cast<double>(finishedSteps));
 }
 

--- a/exporter/src/ui/ProgressModel.h
+++ b/exporter/src/ui/ProgressModel.h
@@ -53,6 +53,9 @@ class ProgressModel : public QObject {
   Q_SIGNAL void exportFailed();
 
  private:
+  Q_SIGNAL void requestAddFinishedSteps(uint64_t value);
+  Q_SLOT void addFinishedStepsInternal(uint64_t value);
+
   ExportStatus status = ExportStatus::Waiting;
   uint64_t totalSteps = 0;
   uint64_t finishedSteps = 0;


### PR DESCRIPTION
## 问题背景

在 macOS / AE 2025 上导出视频合成时，After Effects 会崩溃退出，进度停留在 0/1，提示「调用增效工具 "PAGExporter" 时崩溃」。

参见 discussion #3371，其中提供的 minidump 分析显示崩溃发生在主线程，停止原因为 `EXC_BAD_ACCESS (code=1, address=0x0)`，调用栈明确指向：

```
exporter::ProgressModel::addFinishedSteps(unsigned long long)
exporter::GetVideoSequence(...)
exporter::ExportVideoComposition(...)
exporter::PAGExport::exportRescaleVideoCompositions(...)
exporter::PAGExport::exportAsFile()
exporter::PAGExport::exportFile()
exporter::CompositionsModel::exportSelectedCompositions()
```

## 根因

视频导出时，编码线程 `PAGEncodeThread` 的 encode 回调（`VideoSequence.cpp` 中的 `encodeFrameCallback`）会跨线程调用 `ProgressModel::addFinishedSteps`。该方法直接修改 `finishedSteps` 成员并跨线程发射 Qt 信号、调用 `QApplication::processEvents()`，构成跨线程数据竞争与非法的跨线程事件处理，最终导致 AE 崩溃。

## 修复方案

1. `addFinishedSteps` 增加线程亲和性检查：当从非 ProgressModel 所属线程（即编码线程）调用时，通过 `Qt::QueuedConnection` 信号 `requestAddFinishedSteps` 将调用 marshaling 回主线程执行，避免跨线程访问。
2. 保留 `QApplication::processEvents()` 于主线程路径，确保导出主循环阻塞在 `exportFile()` 期间进度更新仍能正常投递，并排空队列中的跨线程进度事件。
3. 将 `processEvents()` 移出内部方法 `addFinishedStepsInternal`，仅置于主线程直调路径，避免队列槽被 `processEvents` 递归重入。

## 影响范围

仅涉及 `exporter/src/ui/ProgressModel.{cpp,h}`，不改变公开 API 签名。修复后视频合成导出不再因跨线程访问崩溃，进度条更新行为保持不变。

Related to #3371