### PR TITLE
Fix strcasecmp undeclared error on Linux

### DIFF
--- a/src/pagx/SystemFonts.cpp
+++ b/src/pagx/SystemFonts.cpp
@@ -678,6 +678,7 @@ FontLocation SystemFonts::FindFont(const std::string& family, const std::string&
 #elif defined(__linux__)
 
 #include <fontconfig/fontconfig.h>
+#include <strings.h>
 #include <unistd.h>
 #include <map>
 #include <set>


### PR DESCRIPTION
### Issue

Compilation fails on Linux with the following error:

```
src/pagx/SystemFonts.cpp:841:7: error: 'strcasecmp' was not declared in this scope; did you mean 'wcscasecmp'?
  841 |       strcasecmp(reinterpret_cast<const char*>(matchedFamily), family.c_str()) != 0) {
```

### Root Cause

`strcasecmp` is a POSIX function declared in `<strings.h>` (plural), which was not included in the Linux branch of `SystemFonts.cpp`.

### Fix

Include `<strings.h>` in the Linux branch.