### PR TITLE
Fix dash pattern exported with offset incorrectly appended as a dash value

### DIFF
--- a/exporter/src/export/data/Shape.cpp
+++ b/exporter/src/export/data/Shape.cpp
@@ -213,7 +213,9 @@ static void GetDashes(const AEGP_StreamRefH& streamHandle, pag::ShapeElement* el
     auto& dashes = strokeElement != nullptr ? strokeElement->dashes : gradientStrokeElement->dashes;
     auto& dashOffset =
         strokeElement != nullptr ? strokeElement->dashOffset : gradientStrokeElement->dashOffset;
-    for (A_long index = 0; index < numStreams; index++) {
+    // The dashes group contains dash values followed by a trailing offset as the last child.
+    // Skip the last child here and read it as dashOffset separately below.
+    for (A_long index = 0; index < numStreams - 1; index++) {
       AEGP_StreamRefH childStreamHandle = nullptr;
       Suites->DynamicStreamSuite4()->AEGP_GetNewStreamRefByIndex(PluginID, dashStreamHandle, index,
                                                                  &childStreamHandle);
@@ -224,10 +226,10 @@ static void GetDashes(const AEGP_StreamRefH& streamHandle, pag::ShapeElement* el
         Suites->StreamSuite4()->AEGP_DisposeStream(childStreamHandle);
         continue;
       }
-      if (!IsStreamHidden(childStreamHandle)) {
-        auto dash = GetProperty(childStreamHandle, index, AEStreamParser::FloatParser);
-        dashes.push_back(dash);
-      }
+      // childStreamHandle is already a single dash value stream, not a group. Use the direct
+      // GetProperty overload without index to avoid calling GetNewStreamRefByIndex on it.
+      auto dash = GetProperty(childStreamHandle, AEStreamParser::FloatParser);
+      dashes.push_back(dash);
       Suites->StreamSuite4()->AEGP_DisposeStream(childStreamHandle);
     }
     if (!dashes.empty()) {


### PR DESCRIPTION
## 问题

导出带有虚线（dashes）的描边时，`GetDashes()` 遍历了 dashes group 的所有子流（包括末尾的 offset 子流），导致 offset 值被错误地追加到 dash 数组中。同时旧代码对已经是叶子流的 childStreamHandle 使用了带 index 参数的 `GetProperty` 重载，该重载会在叶子流上调用 `GetNewStreamRefByIndex`，导致 AE 内部报错。

## 修复

1. 循环上界从 `numStreams` 改为 `numStreams - 1`，跳过末尾的 offset 子流（它由循环后的 `dashOffset` 读取逻辑单独处理）
2. 将 `GetProperty(childStreamHandle, index, parser)` 改为 `GetProperty(childStreamHandle, parser)`，使用直接读取叶子流的重载，避免对非 group 流调用 `GetNewStreamRefByIndex`

Closes #3615