### PR TITLE
Bypass glTexSubImage2D for software-decoded video via a HardwareBuffer to fix cross-view frame corruption on Mali GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,11 @@ elseif (ANDROID)
         list(APPEND PAG_INCLUDES vendor/ffavc/include)
     endif ()
 
+    # libyuv provides SIMD-accelerated I420 to RGBA conversion used by SoftwareDecoderWrapper on
+    # Android to bypass glTexSubImage2D uploads. See issue #3540.
+    list(APPEND PAG_STATIC_VENDORS libyuv)
+    list(APPEND PAG_INCLUDES third_party/libyuv/include)
+
     # optimizes the output size
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/android/libpag/export.def")
     list(APPEND PAG_COMPILE_OPTIONS -ffunction-sections -fdata-sections -Os -fno-exceptions -fno-rtti)

--- a/DEPS
+++ b/DEPS
@@ -51,6 +51,11 @@
         "dir": "third_party/libxml2"
       },
       {
+        "url": "https://chromium.googlesource.com/libyuv/libyuv",
+        "commit": "644251f252a84bf8ce91ff0aca86a9b16b069ab8",
+        "dir": "third_party/libyuv"
+      },
+      {
         "url": "https://github.com/google/woff2.git",
         "commit": "1c69169e9e1811dccd6c54c532fedda300233968",
         "dir": "third_party/woff2"

--- a/src/rendering/video/SoftwareDecoderWrapper.cpp
+++ b/src/rendering/video/SoftwareDecoderWrapper.cpp
@@ -20,9 +20,80 @@
 #include "platform/Platform.h"
 #include "rendering/video/SoftwareData.h"
 
+#if defined(__ANDROID__) || defined(ANDROID)
+#include <atomic>
+#include "base/utils/Log.h"
+#include "libyuv/convert_argb.h"
+#include "tgfx/core/ColorSpace.h"
+#include "tgfx/platform/HardwareBuffer.h"
+#endif
+
 namespace pag {
 
 #define I420_PLANE_COUNT 3
+
+#if defined(__ANDROID__) || defined(ANDROID)
+// libyuv writes ABGR into memory as R,G,B,A byte order, matching Android's
+// AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM used by tgfx::HardwareBufferAllocate. Returns 0 on
+// success, -1 when the color space has no matching libyuv routine so the caller can fall back to
+// the plain YUV upload path.
+static int ConvertI420ToRGBA(tgfx::YUVColorSpace colorSpace, const uint8_t* srcY, int strideY,
+                             const uint8_t* srcU, int strideU, const uint8_t* srcV, int strideV,
+                             uint8_t* dst, int dstStride, int width, int height) {
+  switch (colorSpace) {
+    case tgfx::YUVColorSpace::BT601_LIMITED:
+      return libyuv::I420ToABGR(srcY, strideY, srcU, strideU, srcV, strideV, dst, dstStride, width,
+                                height);
+    case tgfx::YUVColorSpace::BT601_FULL:
+    case tgfx::YUVColorSpace::JPEG_FULL:
+      return libyuv::J420ToABGR(srcY, strideY, srcU, strideU, srcV, strideV, dst, dstStride, width,
+                                height);
+    case tgfx::YUVColorSpace::BT709_LIMITED:
+      return libyuv::H420ToABGR(srcY, strideY, srcU, strideU, srcV, strideV, dst, dstStride, width,
+                                height);
+    case tgfx::YUVColorSpace::BT2020_LIMITED:
+      return libyuv::U420ToABGR(srcY, strideY, srcU, strideU, srcV, strideV, dst, dstStride, width,
+                                height);
+    default:
+      // BT709_FULL / BT2020_FULL have no matching libyuv routine; the caller falls back to the
+      // plain YUV upload path.
+      return -1;
+  }
+}
+
+// Converts a software-decoded I420 frame into a RGBA HardwareBuffer-backed ImageBuffer. Returns
+// nullptr if the HardwareBuffer path is unavailable, allocation fails, or the frame's color space
+// has no matching libyuv routine, in which case the caller falls back to the plain YUV upload
+// path.
+static std::shared_ptr<tgfx::ImageBuffer> MakeHardwareBufferFrame(const YUVBuffer* frame,
+                                                                  const VideoFormat& videoFormat) {
+  if (!tgfx::HardwareBufferAvailable()) {
+    return nullptr;
+  }
+  auto hardwareBuffer = tgfx::HardwareBufferAllocate(videoFormat.width, videoFormat.height, false);
+  if (hardwareBuffer == nullptr) {
+    return nullptr;
+  }
+  auto info = tgfx::HardwareBufferGetInfo(hardwareBuffer);
+  auto* dst = static_cast<uint8_t*>(tgfx::HardwareBufferLock(hardwareBuffer));
+  if (dst == nullptr) {
+    tgfx::HardwareBufferRelease(hardwareBuffer);
+    return nullptr;
+  }
+  int ret =
+      ConvertI420ToRGBA(videoFormat.colorSpace, frame->data[0], frame->lineSize[0], frame->data[1],
+                        frame->lineSize[1], frame->data[2], frame->lineSize[2], dst,
+                        static_cast<int>(info.rowBytes), videoFormat.width, videoFormat.height);
+  tgfx::HardwareBufferUnlock(hardwareBuffer);
+  if (ret != 0) {
+    tgfx::HardwareBufferRelease(hardwareBuffer);
+    return nullptr;
+  }
+  auto imageBuffer = tgfx::ImageBuffer::MakeFrom(hardwareBuffer, tgfx::ColorSpace::SRGB());
+  tgfx::HardwareBufferRelease(hardwareBuffer);
+  return imageBuffer;
+}
+#endif
 
 std::unique_ptr<VideoDecoder> SoftwareDecoderWrapper::Wrap(
     std::shared_ptr<SoftwareDecoder> softwareDecoder, const VideoFormat& format) {
@@ -148,6 +219,24 @@ std::shared_ptr<tgfx::ImageBuffer> SoftwareDecoderWrapper::onRenderFrame() {
   if (frame == nullptr) {
     return nullptr;
   }
+#if defined(__ANDROID__) || defined(ANDROID)
+  // Route software-decoded frames through a RGBA HardwareBuffer bound via
+  // EGL_ANDROID_image_native_buffer instead of uploading three YUV planes with glTexSubImage2D.
+  // This avoids the cross-view frame corruption observed on Mali GPUs when multiple PAGImageView
+  // instances upload software-decoded frames concurrently. See issue #3540.
+  if (auto imageBuffer = MakeHardwareBufferFrame(frame.get(), videoFormat)) {
+    return imageBuffer;
+  }
+  // Report the first fallback so unexpected regressions on the HardwareBuffer path are visible in
+  // logs; subsequent fallbacks stay silent to avoid log spam.
+  static std::atomic_flag fallbackLogged = ATOMIC_FLAG_INIT;
+  if (!fallbackLogged.test_and_set(std::memory_order_relaxed)) {
+    LOGI(
+        "SoftwareDecoderWrapper: HardwareBuffer path unavailable, falling back to YUV upload. "
+        "size=%dx%d colorSpace=%d",
+        videoFormat.width, videoFormat.height, static_cast<int>(videoFormat.colorSpace));
+  }
+#endif
   auto yuvData =
       SoftwareData<SoftwareDecoder>::Make(videoFormat.width, videoFormat.height, frame->data,
                                           frame->lineSize, I420_PLANE_COUNT, softwareDecoder);

--- a/src/rendering/video/SoftwareDecoderWrapper.cpp
+++ b/src/rendering/video/SoftwareDecoderWrapper.cpp
@@ -24,7 +24,6 @@
 #include <atomic>
 #include "base/utils/Log.h"
 #include "libyuv/convert_argb.h"
-#include "tgfx/core/ColorSpace.h"
 #include "tgfx/platform/HardwareBuffer.h"
 #endif
 
@@ -70,6 +69,11 @@ static std::shared_ptr<tgfx::ImageBuffer> MakeHardwareBufferFrame(const YUVBuffe
   if (!tgfx::HardwareBufferAvailable()) {
     return nullptr;
   }
+  for (int i = 0; i < I420_PLANE_COUNT; i++) {
+    if (frame->data[i] == nullptr || frame->lineSize[i] <= 0) {
+      return nullptr;
+    }
+  }
   auto hardwareBuffer = tgfx::HardwareBufferAllocate(videoFormat.width, videoFormat.height, false);
   if (hardwareBuffer == nullptr) {
     return nullptr;
@@ -89,7 +93,7 @@ static std::shared_ptr<tgfx::ImageBuffer> MakeHardwareBufferFrame(const YUVBuffe
     tgfx::HardwareBufferRelease(hardwareBuffer);
     return nullptr;
   }
-  auto imageBuffer = tgfx::ImageBuffer::MakeFrom(hardwareBuffer, tgfx::ColorSpace::SRGB());
+  auto imageBuffer = tgfx::ImageBuffer::MakeFrom(hardwareBuffer);
   tgfx::HardwareBufferRelease(hardwareBuffer);
   return imageBuffer;
 }

--- a/vendor.json
+++ b/vendor.json
@@ -81,8 +81,8 @@
           "yuv"
         ],
         "arguments": [
-          "-DCMAKE_C_FLAGS=\"-w -march=armv8-a\"",
-          "-DCMAKE_CXX_FLAGS=\"-w -march=armv8-a\""
+          "-DCMAKE_C_FLAGS=\"-w\"",
+          "-DCMAKE_CXX_FLAGS=\"-w\""
         ],
         "platforms": [
           "android"

--- a/vendor.json
+++ b/vendor.json
@@ -75,6 +75,21 @@
       }
     },
     {
+      "name": "libyuv",
+      "cmake": {
+        "targets": [
+          "yuv"
+        ],
+        "arguments": [
+          "-DCMAKE_C_FLAGS=\"-w -march=armv8-a\"",
+          "-DCMAKE_CXX_FLAGS=\"-w -march=armv8-a\""
+        ],
+        "platforms": [
+          "android"
+        ]
+      }
+    },
+    {
       "name": "libxml2",
       "cmake": {
         "targets": [


### PR DESCRIPTION
Fix #3540

## 问题

多个 `PAGImageView` 同时播放包含视频层的 PAG 时，在低端联发科 Mali GPU 设备（如小米 Note8 Pro）上会出现**跨 view 画面污染**：某个 view 显示的画面里出现了其他 view 的内容片段。且被污染的错误帧一旦写入磁盘缓存，重启后依然显示错误。仅在**软解**（ffavc/libavc）路径下复现，硬解不复现。

## 根因分析

多个 `PAGImageView` 各自持有独立的 EGL context 和独立的 tgfx `Context`（`GLDevice::Make(nullptr)`，非共享），但底层共用同一个 Mali GPU 驱动。

- **软解路径**：`SoftwareDecoderWrapper::onRenderFrame` 返回 `YUVBuffer`（三平面 I420 指针），tgfx 走 `YUVTextureView::MakeI420` → 每帧通过 `glTexSubImage2D` 上传 3 张 GRAY_8 纹理。
- **硬解路径**：MediaCodec 输出通过 `SurfaceTexture` + `glEGLImageTargetTexture2DOES` 引用绑定，不经过 `glTexSubImage2D`。

在多个独立 EGL context 从不同工作线程并发调用 `glTexSubImage2D` 的场景下，Mali GPU 驱动内部存在跨 context 的纹理上传时序问题。tgfx 已经在 `GLCaps` 中有针对 Adreno 类似问题的 workaround（`flushBeforeWritePixels`，参考 [skia-review 571418](https://skia-review.googlesource.com/c/skia/+/571418)），本 PR 从另一个角度绕开这类问题。

## 修复方案

Android 上，将软解产出的 I420 帧通过 libyuv 在 CPU 侧转换为 RGBA 写入 `HardwareBuffer`，再通过 `EGL_ANDROID_image_native_buffer` 绑定到 GL texture 使用。这条路径**完全避开** `glTexSubImage2D`，转而通过 gralloc 共享物理内存零拷贝上屏，绕开触发问题的驱动路径。

具体改动：
- `DEPS` / `vendor.json` / `CMakeLists.txt`：引入 libyuv（Google 官方 chrome-m149，只在 Android 平台编译）
- `SoftwareDecoderWrapper.cpp`：Android 上新增 `MakeHardwareBufferFrame` 快路径，按 `videoFormat.colorSpace` 分派到 `I420ToABGR / J420ToABGR / H420ToABGR / U420ToABGR`；HardwareBuffer 不可用或 colorSpace 不支持时（BT709_FULL / BT2020_FULL）自动 fallback 到原 YUV 上传路径，首次 fallback 打一条 info log 便于排查

## 排查过程和实验数据

已验证：
| 路径 | 触发 `glTexSubImage2D` | 是否复现 |
|---|---|---|
| baseline (软解 + YUVTextureView) | ✓ | 稳定复现 |
| 强制硬解（跳过软解 factory） | ✗ | 不复现 |
| 本 PR（软解 + libyuv + HardwareBuffer） | ✗ | **不复现**（多次验证 + 日志确认路径生效）|

同时验证过（作为对照）：
- `readFrameInternal` 加全局锁串行化 `renderFrame`（即 PR #3565 的方案）：不复现，但覆盖面过窄且性能受影响
- `PAGSurface::draw` 里对 `context->flush() + context->submit()` 加全局锁：不复现，等效串行化 GL 命令提交

以上排查过程指向根因是**跨 context 并发调用 `glTexSubImage2D`**，本 PR 通过换传输路径避开该场景。

## 影响面

- 只影响 Android 平台的软解视频（MediaCodec 不支持或走 `preferSoftware` 分支的视频）
- 其他平台（iOS / macOS / Windows / Linux / OHOS / Web）代码完全不变
- Android < 8.0 或 `HardwareBufferAvailable() == false` 的设备自动走原 YUV 路径，不受影响
- `BT709_FULL` / `BT2020_FULL` colorSpace 走原 YUV 路径（libyuv 无对应函数），首次 fallback 有 log 提示

## 后续可优化项（不在本 PR 范围）

- HardwareBuffer 缓冲池（当前每帧 allocate/release，实测无明显开销）
- libyuv 从 armv8-a 基线升级到 armv8.2 SIMD（当前受 vendor_tools NDK 版本限制）
- Alpha 平面视频支持（当前只处理主 RGB 平面）
