### PR TITLE
Add interactive zoom, pan, and scroll to PAGViewer canvas

### DIFF
--- a/viewer/assets/images/reset-view.svg
+++ b/viewer/assets/images/reset-view.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#CCCCCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+  <path d="M3 3v5h5"/>
+</svg>

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -496,24 +496,12 @@ PAGWindow {
     function resizeContentView() {
         if (!contentView)
             return;
-        let width = contentView.viewModel.width;
-        let height = contentView.viewModel.height;
         let windowWidth = mainForm.centerItem.width;
         let windowHeight = mainForm.centerItem.height - mainForm.controlForm.height;
-        let finalHeight = 1;
-        let finalWidth = 1;
-        let pagIsNarrower = height / width > windowHeight / windowWidth;
-        if (pagIsNarrower) {
-            finalHeight = windowHeight;
-            finalWidth = finalHeight / height * width;
-        } else {
-            finalWidth = windowWidth;
-            finalHeight = finalWidth / width * height;
-        }
-        mainForm.contentViewLoader.item.width = finalWidth;
-        mainForm.contentViewLoader.item.height = finalHeight;
-        mainForm.contentViewLoader.item.x = (windowWidth - finalWidth) / 2;
-        mainForm.contentViewLoader.item.y = (windowHeight - finalHeight) / 2;
+        mainForm.contentViewLoader.item.width = windowWidth;
+        mainForm.contentViewLoader.item.height = windowHeight;
+        mainForm.contentViewLoader.item.x = 0;
+        mainForm.contentViewLoader.item.y = 0;
     }
 
     function updateAvailable(hasNewVersion) {
@@ -578,6 +566,18 @@ PAGWindow {
             break;
         case "toggle-edit-panel":
             toggleEditPanel();
+            break;
+        case "zoom-in":
+            if (contentView)
+                contentView.zoomAt(1.5, contentView.width / 2, contentView.height / 2);
+            break;
+        case "zoom-out":
+            if (contentView)
+                contentView.zoomAt(1.0 / 1.5, contentView.width / 2, contentView.height / 2);
+            break;
+        case "reset-zoom":
+            if (contentView)
+                contentView.resetView();
             break;
         case "open-help":
             Qt.openUrlExternally("https://pag.io/#pag-player");

--- a/viewer/assets/qml/MainForm.qml
+++ b/viewer/assets/qml/MainForm.qml
@@ -84,6 +84,7 @@ SplitView {
 
     PAGRectangle {
         id: centerItem
+        clip: true
         SplitView.minimumWidth: minPlayerWidth
         SplitView.fillWidth: true
         color: "#000000"
@@ -163,10 +164,137 @@ SplitView {
             anchors.rightMargin: resizeHandleSize
             anchors.bottom: parent.bottom
             anchors.bottomMargin: controlFormHeight + 9
-            onClicked: {
-                if (contentView) {
+            acceptedButtons: Qt.LeftButton
+            cursorShape: pressed && dragging ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+            property real pressX: 0
+            property real pressY: 0
+            property real lastX: 0
+            property real lastY: 0
+            property bool dragging: false
+
+            onPressed: function (mouse) {
+                pressX = mouse.x;
+                pressY = mouse.y;
+                lastX = mouse.x;
+                lastY = mouse.y;
+                dragging = false;
+            }
+            onPositionChanged: function (mouse) {
+                if (!contentView || !pressed) {
+                    return;
+                }
+                if (!dragging) {
+                    var distance = Math.hypot(mouse.x - pressX, mouse.y - pressY);
+                    if (distance < 4) {
+                        return;
+                    }
+                    dragging = true;
+                    contentView.panBy(mouse.x - pressX, mouse.y - pressY);
+                } else {
+                    contentView.panBy(mouse.x - lastX, mouse.y - lastY);
+                }
+                lastX = mouse.x;
+                lastY = mouse.y;
+            }
+            onReleased: function (mouse) {
+                if (!dragging && contentView) {
                     contentView.viewModel.isPlaying = !contentView.viewModel.isPlaying;
                 }
+                dragging = false;
+            }
+            onCanceled: dragging = false
+            onWheel: function (wheel) {
+                if (!contentView) {
+                    return;
+                }
+                if (pinchHandler.active) {
+                    wheel.accepted = true;
+                    return;
+                }
+                var pixelDeltaX = wheel.pixelDelta.x !== 0 ? wheel.pixelDelta.x : wheel.angleDelta.x / 4;
+                var pixelDeltaY = wheel.pixelDelta.y !== 0 ? wheel.pixelDelta.y : wheel.angleDelta.y / 4;
+                if (wheel.modifiers & Qt.ControlModifier || wheel.modifiers & Qt.MetaModifier) {
+                    var anchor = mouseArea.mapToItem(contentView, wheel.x, wheel.y);
+                    var rawDelta = wheel.pixelDelta.y !== 0 ? wheel.pixelDelta.y : wheel.angleDelta.y;
+                    var ratio = wheel.pixelDelta.y !== 0 ? 240 : 600;
+                    contentView.zoomAt(Math.exp(rawDelta / ratio), anchor.x, anchor.y);
+                } else if (wheel.modifiers & Qt.ShiftModifier) {
+                    contentView.panBy(pixelDeltaY, 0);
+                } else {
+                    contentView.panBy(pixelDeltaX, pixelDeltaY);
+                }
+                wheel.accepted = true;
+            }
+        }
+        // macOS trackpad pinch-to-zoom (two-finger pinch gesture).
+        PinchHandler {
+            id: pinchHandler
+            target: null
+            acceptedDevices: PointerDevice.TouchPad | PointerDevice.TouchScreen
+
+            property real lastScale: 1.0
+
+            onScaleChanged: {
+                if (!active || !contentView) {
+                    return;
+                }
+                var factor = scale / pinchHandler.lastScale;
+                pinchHandler.lastScale = scale;
+                if (factor > 0 && isFinite(factor) && factor !== 1) {
+                    contentView.zoomAt(factor, centroid.position.x, centroid.position.y);
+                }
+            }
+            onActiveChanged: {
+                pinchHandler.lastScale = scale;
+            }
+        }
+        Row {
+            id: viewControls
+            z: 4
+            visible: hasPAGFile && contentView
+            anchors.right: parent.right
+            anchors.rightMargin: 16
+            anchors.bottom: controlForm.top
+            anchors.bottomMargin: 16
+            spacing: 8
+
+            Rectangle {
+                id: zoomScaleBadge
+                width: zoomScaleText.implicitWidth + 24
+                height: 32
+                radius: 8
+                color: "#99000000"
+
+                Text {
+                    id: zoomScaleText
+                    anchors.centerIn: parent
+                    color: "#cccccc"
+                    font.pixelSize: 12
+                    text: contentView ? Math.round(contentView.viewModel.zoomScale * 100) + "%" : ""
+                }
+            }
+
+            Button {
+                id: resetViewButton
+                width: 32
+                height: 32
+                hoverEnabled: true
+                padding: 7
+                onClicked: contentView.resetView()
+
+                background: Rectangle {
+                    radius: 8
+                    color: resetViewButton.pressed ? "#cc000000" : resetViewButton.hovered ? "#b3000000" : "#99000000"
+                }
+
+                contentItem: Image {
+                    source: "qrc:/images/reset-view.svg"
+                    fillMode: Image.PreserveAspectFit
+                }
+
+                ToolTip.visible: hovered
+                ToolTip.text: qsTr("Reset View")
+                ToolTip.delay: 500
             }
         }
         DropArea {

--- a/viewer/assets/qml/MainForm.qml
+++ b/viewer/assets/qml/MainForm.qml
@@ -280,7 +280,11 @@ SplitView {
                 height: 32
                 hoverEnabled: true
                 padding: 7
-                onClicked: contentView.resetView()
+                onClicked: {
+                    if (contentView) {
+                        contentView.resetView();
+                    }
+                }
 
                 background: Rectangle {
                     radius: 8

--- a/viewer/assets/qml/MainForm.qml
+++ b/viewer/assets/qml/MainForm.qml
@@ -293,7 +293,7 @@ SplitView {
                 }
 
                 ToolTip.visible: hovered
-                ToolTip.text: qsTr("Reset View")
+                ToolTip.text: qsTr("Reset Zoom")
                 ToolTip.delay: 500
             }
         }

--- a/viewer/assets/qml/Menu.qml
+++ b/viewer/assets/qml/Menu.qml
@@ -161,6 +161,7 @@ Item {
                         root.command("toggle-edit-panel");
                     }
                 }
+                MenuSeparator {}
                 Action {
                     text: qsTr("Zoom In")
                     enabled: root.hasPAGFile

--- a/viewer/assets/qml/Menu.qml
+++ b/viewer/assets/qml/Menu.qml
@@ -161,6 +161,30 @@ Item {
                         root.command("toggle-edit-panel");
                     }
                 }
+                Action {
+                    text: qsTr("Zoom In")
+                    enabled: root.hasPAGFile
+                    shortcut: "Ctrl+="
+                    onTriggered: {
+                        root.command("zoom-in");
+                    }
+                }
+                Action {
+                    text: qsTr("Zoom Out")
+                    enabled: root.hasPAGFile
+                    shortcut: "Ctrl+-"
+                    onTriggered: {
+                        root.command("zoom-out");
+                    }
+                }
+                Action {
+                    text: qsTr("Reset Zoom")
+                    enabled: root.hasPAGFile
+                    shortcut: "Ctrl+0"
+                    onTriggered: {
+                        root.command("reset-zoom");
+                    }
+                }
             }
 
             PAGMenu {
@@ -378,6 +402,31 @@ Item {
                     shortcut: "L"
                     onTriggered: {
                         root.command("toggle-edit-panel");
+                    }
+                }
+                Platform.MenuSeparator {}
+                Platform.MenuItem {
+                    text: qsTr("Zoom In")
+                    enabled: root.hasPAGFile
+                    shortcut: "Meta+="
+                    onTriggered: {
+                        root.command("zoom-in");
+                    }
+                }
+                Platform.MenuItem {
+                    text: qsTr("Zoom Out")
+                    enabled: root.hasPAGFile
+                    shortcut: "Meta+-"
+                    onTriggered: {
+                        root.command("zoom-out");
+                    }
+                }
+                Platform.MenuItem {
+                    text: qsTr("Reset Zoom")
+                    enabled: root.hasPAGFile
+                    shortcut: "Meta+0"
+                    onTriggered: {
+                        root.command("reset-zoom");
                     }
                 }
             }

--- a/viewer/assets/res.qrc
+++ b/viewer/assets/res.qrc
@@ -29,6 +29,7 @@
         <!-- svg -->
         <file>images/close-dark.svg</file>
         <file>images/restore-dark.svg</file>
+        <file>images/reset-view.svg</file>
         <file>images/maximize-dark.svg</file>
         <file>images/minimize-dark.svg</file>
 

--- a/viewer/assets/translation/Chinese.ts
+++ b/viewer/assets/translation/Chinese.ts
@@ -188,8 +188,8 @@
     </message>
     <message>
         <location filename="../qml/MainForm.qml" line="296"/>
-        <source>Reset View</source>
-        <translation>重置视图</translation>
+        <source>Reset Zoom</source>
+        <translation>重置缩放</translation>
     </message>
     <message>
         <location filename="../qml/MainForm.qml" line="803"/>

--- a/viewer/assets/translation/Chinese.ts
+++ b/viewer/assets/translation/Chinese.ts
@@ -189,7 +189,7 @@
     <message>
         <location filename="../qml/MainForm.qml" line="296"/>
         <source>Reset View</source>
-        <translation type="unfinished"></translation>
+        <translation>重置视图</translation>
     </message>
     <message>
         <location filename="../qml/MainForm.qml" line="803"/>
@@ -334,19 +334,19 @@
         <location filename="../qml/Menu.qml" line="165"/>
         <location filename="../qml/Menu.qml" line="409"/>
         <source>Zoom In</source>
-        <translation type="unfinished"></translation>
+        <translation>放大</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="173"/>
         <location filename="../qml/Menu.qml" line="417"/>
         <source>Zoom Out</source>
-        <translation type="unfinished"></translation>
+        <translation>缩小</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="181"/>
         <location filename="../qml/Menu.qml" line="425"/>
         <source>Reset Zoom</source>
-        <translation type="unfinished"></translation>
+        <translation>重置缩放</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="192"/>

--- a/viewer/assets/translation/Chinese.ts
+++ b/viewer/assets/translation/Chinese.ts
@@ -95,7 +95,7 @@
         <translation>导出错误，错误码：</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="540"/>
+        <location filename="../qml/Main.qml" line="528"/>
         <source>Open PAG File</source>
         <translation>打开PAG文件</translation>
     </message>
@@ -122,72 +122,77 @@
 <context>
     <name>MainForm</name>
     <message>
-        <location filename="../qml/MainForm.qml" line="185"/>
+        <location filename="../qml/MainForm.qml" line="313"/>
         <source>Click the menu or drag-drop here to open a PAG file</source>
         <translation>点击菜单，或拖放到这里打开一个PAG文件</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="245"/>
+        <location filename="../qml/MainForm.qml" line="373"/>
         <source>Edit Layer</source>
         <translation>图层编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="250"/>
+        <location filename="../qml/MainForm.qml" line="378"/>
         <source>File Structure</source>
         <translation>文件结构</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="250"/>
+        <location filename="../qml/MainForm.qml" line="378"/>
         <source>Source Editor</source>
         <translation>源码编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="318"/>
+        <location filename="../qml/MainForm.qml" line="446"/>
         <source>No layer was editable</source>
         <translation>没有可以编辑的图层</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="318"/>
+        <location filename="../qml/MainForm.qml" line="446"/>
         <source>PAGX files do not support layer editing</source>
         <translation>PAGX 文件不支持图层编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="326"/>
+        <location filename="../qml/MainForm.qml" line="454"/>
         <source>Go to Source Editor →</source>
         <translation>前往源码编辑 →</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="400"/>
+        <location filename="../qml/MainForm.qml" line="528"/>
         <source>Edit Text</source>
         <translation>文本编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="482"/>
+        <location filename="../qml/MainForm.qml" line="610"/>
         <source>Edit Image</source>
         <translation>图片编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="610"/>
+        <location filename="../qml/MainForm.qml" line="738"/>
         <source>Discard</source>
         <translation>放弃</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="644"/>
+        <location filename="../qml/MainForm.qml" line="772"/>
         <source>Apply</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="684"/>
+        <location filename="../qml/MainForm.qml" line="812"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="638"/>
+        <location filename="../qml/MainForm.qml" line="766"/>
         <source>Changes discarded</source>
         <translation>修改已放弃</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="675"/>
+        <location filename="../qml/MainForm.qml" line="296"/>
+        <source>Reset View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/MainForm.qml" line="803"/>
         <source>Changes applied</source>
         <translation>修改已应用</translation>
     </message>
@@ -196,7 +201,7 @@
         <translation type="vanished">应用修改失败</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="717"/>
+        <location filename="../qml/MainForm.qml" line="845"/>
         <source>File saved</source>
         <translation>文件已保存</translation>
     </message>
@@ -209,19 +214,19 @@
     <name>Menu</name>
     <message>
         <location filename="../qml/Menu.qml" line="31"/>
-        <location filename="../qml/Menu.qml" line="274"/>
+        <location filename="../qml/Menu.qml" line="298"/>
         <source>File</source>
         <translation>文件</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="33"/>
-        <location filename="../qml/Menu.qml" line="276"/>
+        <location filename="../qml/Menu.qml" line="300"/>
         <source>Open...</source>
         <translation>打开...</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="40"/>
-        <location filename="../qml/Menu.qml" line="265"/>
+        <location filename="../qml/Menu.qml" line="289"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
@@ -232,67 +237,67 @@
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="53"/>
-        <location filename="../qml/Menu.qml" line="226"/>
+        <location filename="../qml/Menu.qml" line="250"/>
         <source>Check for Updates</source>
         <translation>检查更新</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="59"/>
-        <location filename="../qml/Menu.qml" line="283"/>
+        <location filename="../qml/Menu.qml" line="307"/>
         <source>Performance Test</source>
         <translation>性能测试</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="66"/>
-        <location filename="../qml/Menu.qml" line="290"/>
+        <location filename="../qml/Menu.qml" line="314"/>
         <source>Performance Benchmark Test</source>
         <translation>性能基准测试</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="74"/>
-        <location filename="../qml/Menu.qml" line="297"/>
+        <location filename="../qml/Menu.qml" line="321"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="76"/>
-        <location filename="../qml/Menu.qml" line="299"/>
+        <location filename="../qml/Menu.qml" line="323"/>
         <source>Export as PNG Sequence Frames</source>
         <translation>导出为PNG序列帧</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="83"/>
-        <location filename="../qml/Menu.qml" line="306"/>
+        <location filename="../qml/Menu.qml" line="330"/>
         <source>Export as APNG</source>
         <translation>导出为APNG</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="90"/>
-        <location filename="../qml/Menu.qml" line="313"/>
+        <location filename="../qml/Menu.qml" line="337"/>
         <source>Export current frame as PNG</source>
         <translation>导出当前帧为PNG</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="102"/>
-        <location filename="../qml/Menu.qml" line="323"/>
+        <location filename="../qml/Menu.qml" line="347"/>
         <source>Play</source>
         <translation>播放</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="104"/>
-        <location filename="../qml/Menu.qml" line="325"/>
+        <location filename="../qml/Menu.qml" line="349"/>
         <source>Pause and go to the first frame</source>
         <translation>暂停并回到首帧</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="112"/>
-        <location filename="../qml/Menu.qml" line="333"/>
+        <location filename="../qml/Menu.qml" line="357"/>
         <source>Pause and go to the last frame</source>
         <translation>暂停并回到末帧</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="120"/>
-        <location filename="../qml/Menu.qml" line="341"/>
+        <location filename="../qml/Menu.qml" line="365"/>
         <source>Previous frame</source>
         <translation>上一帧</translation>
     </message>
@@ -303,107 +308,125 @@
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="136"/>
-        <location filename="../qml/Menu.qml" line="357"/>
+        <location filename="../qml/Menu.qml" line="381"/>
         <source>Pause/Play</source>
         <translation>暂停/播放</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="147"/>
-        <location filename="../qml/Menu.qml" line="366"/>
+        <location filename="../qml/Menu.qml" line="390"/>
         <source>View</source>
         <translation>视图</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="149"/>
-        <location filename="../qml/Menu.qml" line="368"/>
+        <location filename="../qml/Menu.qml" line="392"/>
         <source>Show/Hide Background</source>
         <translation>显示/隐藏背景色</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="157"/>
-        <location filename="../qml/Menu.qml" line="376"/>
+        <location filename="../qml/Menu.qml" line="400"/>
         <source>Show/Hide Edit Panel</source>
         <translation>显示/隐藏编辑面板</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="168"/>
-        <location filename="../qml/Menu.qml" line="408"/>
+        <location filename="../qml/Menu.qml" line="165"/>
+        <location filename="../qml/Menu.qml" line="409"/>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Menu.qml" line="173"/>
+        <location filename="../qml/Menu.qml" line="417"/>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Menu.qml" line="181"/>
+        <location filename="../qml/Menu.qml" line="425"/>
+        <source>Reset Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Menu.qml" line="192"/>
+        <location filename="../qml/Menu.qml" line="457"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="170"/>
-        <location filename="../qml/Menu.qml" line="410"/>
+        <location filename="../qml/Menu.qml" line="194"/>
+        <location filename="../qml/Menu.qml" line="459"/>
         <source>Help for PAGViewer</source>
         <translation>PAGViewer帮助</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="176"/>
-        <location filename="../qml/Menu.qml" line="258"/>
+        <location filename="../qml/Menu.qml" line="200"/>
+        <location filename="../qml/Menu.qml" line="282"/>
         <source>About PAGViewer</source>
         <translation>关于PAGViewer</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="182"/>
-        <location filename="../qml/Menu.qml" line="416"/>
+        <location filename="../qml/Menu.qml" line="206"/>
+        <location filename="../qml/Menu.qml" line="465"/>
         <source>Feedback</source>
         <translation>问题反馈</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="188"/>
-        <location filename="../qml/Menu.qml" line="218"/>
+        <location filename="../qml/Menu.qml" line="212"/>
+        <location filename="../qml/Menu.qml" line="242"/>
         <source>About PAG Enterprise Edition</source>
         <translation>了解PAG企业版</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="194"/>
-        <location filename="../qml/Menu.qml" line="234"/>
+        <location filename="../qml/Menu.qml" line="218"/>
+        <location filename="../qml/Menu.qml" line="258"/>
         <source>Install Plugin</source>
         <translation>安装插件</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="200"/>
-        <location filename="../qml/Menu.qml" line="242"/>
+        <location filename="../qml/Menu.qml" line="224"/>
+        <location filename="../qml/Menu.qml" line="266"/>
         <source>Uninstall Plugin</source>
         <translation>卸载插件</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="215"/>
+        <location filename="../qml/Menu.qml" line="239"/>
         <source>PAGViewer</source>
         <translation>PAGViewer</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="250"/>
+        <location filename="../qml/Menu.qml" line="274"/>
         <source>Preference Settings</source>
         <translation>偏好设置</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="349"/>
+        <location filename="../qml/Menu.qml" line="373"/>
         <source>Next frame</source>
         <translation>下一帧</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="385"/>
+        <location filename="../qml/Menu.qml" line="434"/>
         <source>Window</source>
         <translation>窗口</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="387"/>
+        <location filename="../qml/Menu.qml" line="436"/>
         <source>Minimize</source>
         <translation>最小化</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="394"/>
+        <location filename="../qml/Menu.qml" line="443"/>
         <source>Zoom</source>
         <translation>缩放</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="400"/>
+        <location filename="../qml/Menu.qml" line="449"/>
         <source>Exit Fullscreen</source>
         <translation>退出全屏</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="400"/>
+        <location filename="../qml/Menu.qml" line="449"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
@@ -602,7 +625,7 @@
 <context>
     <name>pag::PAGXViewModel</name>
     <message>
-        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="387"/>
+        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="399"/>
         <source>Failed to parse XML: invalid syntax or structure</source>
         <translation>解析 XML 失败：语法或结构无效</translation>
     </message>
@@ -611,22 +634,22 @@
         <translation type="vanished">从 XML 文档构建图层失败</translation>
     </message>
     <message>
-        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="393"/>
+        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="405"/>
         <source>Failed to build PAGScene from XML document</source>
         <translation>从 XML 文档构建 PAGScene 失败</translation>
     </message>
     <message>
-        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="419"/>
+        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="431"/>
         <source>No file path specified</source>
         <translation>未指定文件路径</translation>
     </message>
     <message>
-        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="423"/>
+        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="435"/>
         <source>Failed to open file for writing: %1</source>
         <translation>无法打开文件进行写入：%1</translation>
     </message>
     <message>
-        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="428"/>
+        <location filename="../../src/rendering/pagx/PAGXViewModel.cpp" line="440"/>
         <source>Failed to write all data to file</source>
         <translation>写入文件数据不完整</translation>
     </message>

--- a/viewer/assets/translation/Chinese.ts
+++ b/viewer/assets/translation/Chinese.ts
@@ -122,77 +122,77 @@
 <context>
     <name>MainForm</name>
     <message>
-        <location filename="../qml/MainForm.qml" line="313"/>
+        <location filename="../qml/MainForm.qml" line="317"/>
         <source>Click the menu or drag-drop here to open a PAG file</source>
         <translation>点击菜单，或拖放到这里打开一个PAG文件</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="373"/>
+        <location filename="../qml/MainForm.qml" line="377"/>
         <source>Edit Layer</source>
         <translation>图层编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="378"/>
+        <location filename="../qml/MainForm.qml" line="382"/>
         <source>File Structure</source>
         <translation>文件结构</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="378"/>
+        <location filename="../qml/MainForm.qml" line="382"/>
         <source>Source Editor</source>
         <translation>源码编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="446"/>
+        <location filename="../qml/MainForm.qml" line="450"/>
         <source>No layer was editable</source>
         <translation>没有可以编辑的图层</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="446"/>
+        <location filename="../qml/MainForm.qml" line="450"/>
         <source>PAGX files do not support layer editing</source>
         <translation>PAGX 文件不支持图层编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="454"/>
+        <location filename="../qml/MainForm.qml" line="458"/>
         <source>Go to Source Editor →</source>
         <translation>前往源码编辑 →</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="528"/>
+        <location filename="../qml/MainForm.qml" line="532"/>
         <source>Edit Text</source>
         <translation>文本编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="610"/>
+        <location filename="../qml/MainForm.qml" line="614"/>
         <source>Edit Image</source>
         <translation>图片编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="738"/>
+        <location filename="../qml/MainForm.qml" line="742"/>
         <source>Discard</source>
         <translation>放弃</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="772"/>
+        <location filename="../qml/MainForm.qml" line="776"/>
         <source>Apply</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="812"/>
+        <location filename="../qml/MainForm.qml" line="816"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="766"/>
+        <location filename="../qml/MainForm.qml" line="770"/>
         <source>Changes discarded</source>
         <translation>修改已放弃</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="296"/>
+        <location filename="../qml/MainForm.qml" line="300"/>
         <source>Reset Zoom</source>
         <translation>重置缩放</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="803"/>
+        <location filename="../qml/MainForm.qml" line="807"/>
         <source>Changes applied</source>
         <translation>修改已应用</translation>
     </message>
@@ -201,7 +201,7 @@
         <translation type="vanished">应用修改失败</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="845"/>
+        <location filename="../qml/MainForm.qml" line="849"/>
         <source>File saved</source>
         <translation>文件已保存</translation>
     </message>

--- a/viewer/assets/translation/Chinese.ts
+++ b/viewer/assets/translation/Chinese.ts
@@ -214,19 +214,19 @@
     <name>Menu</name>
     <message>
         <location filename="../qml/Menu.qml" line="31"/>
-        <location filename="../qml/Menu.qml" line="298"/>
+        <location filename="../qml/Menu.qml" line="299"/>
         <source>File</source>
         <translation>文件</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="33"/>
-        <location filename="../qml/Menu.qml" line="300"/>
+        <location filename="../qml/Menu.qml" line="301"/>
         <source>Open...</source>
         <translation>打开...</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="40"/>
-        <location filename="../qml/Menu.qml" line="289"/>
+        <location filename="../qml/Menu.qml" line="290"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
@@ -237,67 +237,67 @@
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="53"/>
-        <location filename="../qml/Menu.qml" line="250"/>
+        <location filename="../qml/Menu.qml" line="251"/>
         <source>Check for Updates</source>
         <translation>检查更新</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="59"/>
-        <location filename="../qml/Menu.qml" line="307"/>
+        <location filename="../qml/Menu.qml" line="308"/>
         <source>Performance Test</source>
         <translation>性能测试</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="66"/>
-        <location filename="../qml/Menu.qml" line="314"/>
+        <location filename="../qml/Menu.qml" line="315"/>
         <source>Performance Benchmark Test</source>
         <translation>性能基准测试</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="74"/>
-        <location filename="../qml/Menu.qml" line="321"/>
+        <location filename="../qml/Menu.qml" line="322"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="76"/>
-        <location filename="../qml/Menu.qml" line="323"/>
+        <location filename="../qml/Menu.qml" line="324"/>
         <source>Export as PNG Sequence Frames</source>
         <translation>导出为PNG序列帧</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="83"/>
-        <location filename="../qml/Menu.qml" line="330"/>
+        <location filename="../qml/Menu.qml" line="331"/>
         <source>Export as APNG</source>
         <translation>导出为APNG</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="90"/>
-        <location filename="../qml/Menu.qml" line="337"/>
+        <location filename="../qml/Menu.qml" line="338"/>
         <source>Export current frame as PNG</source>
         <translation>导出当前帧为PNG</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="102"/>
-        <location filename="../qml/Menu.qml" line="347"/>
+        <location filename="../qml/Menu.qml" line="348"/>
         <source>Play</source>
         <translation>播放</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="104"/>
-        <location filename="../qml/Menu.qml" line="349"/>
+        <location filename="../qml/Menu.qml" line="350"/>
         <source>Pause and go to the first frame</source>
         <translation>暂停并回到首帧</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="112"/>
-        <location filename="../qml/Menu.qml" line="357"/>
+        <location filename="../qml/Menu.qml" line="358"/>
         <source>Pause and go to the last frame</source>
         <translation>暂停并回到末帧</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="120"/>
-        <location filename="../qml/Menu.qml" line="365"/>
+        <location filename="../qml/Menu.qml" line="366"/>
         <source>Previous frame</source>
         <translation>上一帧</translation>
     </message>
@@ -308,125 +308,125 @@
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="136"/>
-        <location filename="../qml/Menu.qml" line="381"/>
+        <location filename="../qml/Menu.qml" line="382"/>
         <source>Pause/Play</source>
         <translation>暂停/播放</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="147"/>
-        <location filename="../qml/Menu.qml" line="390"/>
+        <location filename="../qml/Menu.qml" line="391"/>
         <source>View</source>
         <translation>视图</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="149"/>
-        <location filename="../qml/Menu.qml" line="392"/>
+        <location filename="../qml/Menu.qml" line="393"/>
         <source>Show/Hide Background</source>
         <translation>显示/隐藏背景色</translation>
     </message>
     <message>
         <location filename="../qml/Menu.qml" line="157"/>
-        <location filename="../qml/Menu.qml" line="400"/>
+        <location filename="../qml/Menu.qml" line="401"/>
         <source>Show/Hide Edit Panel</source>
         <translation>显示/隐藏编辑面板</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="165"/>
-        <location filename="../qml/Menu.qml" line="409"/>
+        <location filename="../qml/Menu.qml" line="166"/>
+        <location filename="../qml/Menu.qml" line="410"/>
         <source>Zoom In</source>
         <translation>放大</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="173"/>
-        <location filename="../qml/Menu.qml" line="417"/>
+        <location filename="../qml/Menu.qml" line="174"/>
+        <location filename="../qml/Menu.qml" line="418"/>
         <source>Zoom Out</source>
         <translation>缩小</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="181"/>
-        <location filename="../qml/Menu.qml" line="425"/>
+        <location filename="../qml/Menu.qml" line="182"/>
+        <location filename="../qml/Menu.qml" line="426"/>
         <source>Reset Zoom</source>
         <translation>重置缩放</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="192"/>
-        <location filename="../qml/Menu.qml" line="457"/>
+        <location filename="../qml/Menu.qml" line="193"/>
+        <location filename="../qml/Menu.qml" line="458"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="194"/>
-        <location filename="../qml/Menu.qml" line="459"/>
+        <location filename="../qml/Menu.qml" line="195"/>
+        <location filename="../qml/Menu.qml" line="460"/>
         <source>Help for PAGViewer</source>
         <translation>PAGViewer帮助</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="200"/>
-        <location filename="../qml/Menu.qml" line="282"/>
+        <location filename="../qml/Menu.qml" line="201"/>
+        <location filename="../qml/Menu.qml" line="283"/>
         <source>About PAGViewer</source>
         <translation>关于PAGViewer</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="206"/>
-        <location filename="../qml/Menu.qml" line="465"/>
+        <location filename="../qml/Menu.qml" line="207"/>
+        <location filename="../qml/Menu.qml" line="466"/>
         <source>Feedback</source>
         <translation>问题反馈</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="212"/>
-        <location filename="../qml/Menu.qml" line="242"/>
+        <location filename="../qml/Menu.qml" line="213"/>
+        <location filename="../qml/Menu.qml" line="243"/>
         <source>About PAG Enterprise Edition</source>
         <translation>了解PAG企业版</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="218"/>
-        <location filename="../qml/Menu.qml" line="258"/>
+        <location filename="../qml/Menu.qml" line="219"/>
+        <location filename="../qml/Menu.qml" line="259"/>
         <source>Install Plugin</source>
         <translation>安装插件</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="224"/>
-        <location filename="../qml/Menu.qml" line="266"/>
+        <location filename="../qml/Menu.qml" line="225"/>
+        <location filename="../qml/Menu.qml" line="267"/>
         <source>Uninstall Plugin</source>
         <translation>卸载插件</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="239"/>
+        <location filename="../qml/Menu.qml" line="240"/>
         <source>PAGViewer</source>
         <translation>PAGViewer</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="274"/>
+        <location filename="../qml/Menu.qml" line="275"/>
         <source>Preference Settings</source>
         <translation>偏好设置</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="373"/>
+        <location filename="../qml/Menu.qml" line="374"/>
         <source>Next frame</source>
         <translation>下一帧</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="434"/>
+        <location filename="../qml/Menu.qml" line="435"/>
         <source>Window</source>
         <translation>窗口</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="436"/>
+        <location filename="../qml/Menu.qml" line="437"/>
         <source>Minimize</source>
         <translation>最小化</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="443"/>
+        <location filename="../qml/Menu.qml" line="444"/>
         <source>Zoom</source>
         <translation>缩放</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="449"/>
+        <location filename="../qml/Menu.qml" line="450"/>
         <source>Exit Fullscreen</source>
         <translation>退出全屏</translation>
     </message>
     <message>
-        <location filename="../qml/Menu.qml" line="449"/>
+        <location filename="../qml/Menu.qml" line="450"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>

--- a/viewer/src/rendering/ContentView.cpp
+++ b/viewer/src/rendering/ContentView.cpp
@@ -67,6 +67,20 @@ void ContentView::prepareForRemoval() {
   releaseDrawable();
 }
 
+void ContentView::zoomAt(double factor, double x, double y) {
+  auto pixelRatio = window() == nullptr ? 1.0 : window()->devicePixelRatio();
+  getViewModel()->zoomAt(factor, x * pixelRatio, y * pixelRatio);
+}
+
+void ContentView::panBy(double deltaX, double deltaY) {
+  auto pixelRatio = window() == nullptr ? 1.0 : window()->devicePixelRatio();
+  getViewModel()->panBy(deltaX * pixelRatio, deltaY * pixelRatio);
+}
+
+void ContentView::resetView() {
+  getViewModel()->resetView();
+}
+
 void ContentView::sizeChangedDelayHandle() {
   resizeTimer->stop();
   if (sizeChanged) {

--- a/viewer/src/rendering/ContentView.h
+++ b/viewer/src/rendering/ContentView.h
@@ -52,6 +52,9 @@ class ContentView : public QQuickItem {
   /// itemChange(ItemSceneChange) when the item loses its window, but those fire too
   /// late for a Loader component switch where RenderThread needs the window context.
   Q_INVOKABLE void prepareForRemoval();
+  Q_INVOKABLE void zoomAt(double factor, double x, double y);
+  Q_INVOKABLE void panBy(double deltaX, double deltaY);
+  Q_INVOKABLE void resetView();
 
   /**
    * Updates the QSG texture node with the current drawable's texture.

--- a/viewer/src/rendering/ContentViewModel.cpp
+++ b/viewer/src/rendering/ContentViewModel.cpp
@@ -1,0 +1,83 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "ContentViewModel.h"
+#include <algorithm>
+#include <cmath>
+
+namespace pag {
+
+static constexpr double MinZoom = 0.001;
+static constexpr double MaxZoom = 1000.0;
+static constexpr double TransformEpsilon = 0.001;
+
+double ContentViewModel::zoomScale() const {
+  std::lock_guard<std::mutex> lock(viewTransformMutex);
+  return viewTransform.zoomScale;
+}
+
+ContentViewModel::ViewTransform ContentViewModel::getViewTransform() const {
+  std::lock_guard<std::mutex> lock(viewTransformMutex);
+  return viewTransform;
+}
+
+void ContentViewModel::zoomAt(double factor, double anchorX, double anchorY) {
+  double newZoomScale = 1.0;
+  {
+    std::lock_guard<std::mutex> lock(viewTransformMutex);
+    newZoomScale = std::clamp(viewTransform.zoomScale * factor, MinZoom, MaxZoom);
+    if (newZoomScale == viewTransform.zoomScale) {
+      return;
+    }
+    auto appliedFactor = newZoomScale / viewTransform.zoomScale;
+    viewTransform.offsetX = (viewTransform.offsetX - anchorX) * appliedFactor + anchorX;
+    viewTransform.offsetY = (viewTransform.offsetY - anchorY) * appliedFactor + anchorY;
+    viewTransform.zoomScale = newZoomScale;
+  }
+  notifyViewTransformChanged(newZoomScale);
+}
+
+void ContentViewModel::panBy(double deltaX, double deltaY) {
+  if (std::abs(deltaX) < TransformEpsilon && std::abs(deltaY) < TransformEpsilon) {
+    return;
+  }
+  double currentZoomScale = 1.0;
+  {
+    std::lock_guard<std::mutex> lock(viewTransformMutex);
+    viewTransform.offsetX += deltaX;
+    viewTransform.offsetY += deltaY;
+    currentZoomScale = viewTransform.zoomScale;
+  }
+  notifyViewTransformChanged(currentZoomScale);
+}
+
+void ContentViewModel::resetView() {
+  {
+    std::lock_guard<std::mutex> lock(viewTransformMutex);
+    viewTransform = {};
+  }
+  notifyViewTransformChanged(1.0);
+}
+
+void ContentViewModel::notifyViewTransformChanged(double newZoomScale) {
+  onViewTransformChanged();
+  Q_EMIT zoomScaleChanged(newZoomScale);
+  Q_EMIT requestFlush();
+}
+
+}  // namespace pag

--- a/viewer/src/rendering/ContentViewModel.cpp
+++ b/viewer/src/rendering/ContentViewModel.cpp
@@ -22,9 +22,9 @@
 
 namespace pag {
 
-static constexpr double MinZoom = 0.001;
-static constexpr double MaxZoom = 1000.0;
-static constexpr double TransformEpsilon = 0.001;
+static constexpr double MIN_ZOOM = 0.001;
+static constexpr double MAX_ZOOM = 1000.0;
+static constexpr double TRANSFORM_EPSILON = 0.001;
 
 double ContentViewModel::zoomScale() const {
   std::lock_guard<std::mutex> lock(viewTransformMutex);
@@ -40,7 +40,7 @@ void ContentViewModel::zoomAt(double factor, double anchorX, double anchorY) {
   double newZoomScale = 1.0;
   {
     std::lock_guard<std::mutex> lock(viewTransformMutex);
-    newZoomScale = std::clamp(viewTransform.zoomScale * factor, MinZoom, MaxZoom);
+    newZoomScale = std::clamp(viewTransform.zoomScale * factor, MIN_ZOOM, MAX_ZOOM);
     if (newZoomScale == viewTransform.zoomScale) {
       return;
     }
@@ -53,7 +53,7 @@ void ContentViewModel::zoomAt(double factor, double anchorX, double anchorY) {
 }
 
 void ContentViewModel::panBy(double deltaX, double deltaY) {
-  if (std::abs(deltaX) < TransformEpsilon && std::abs(deltaY) < TransformEpsilon) {
+  if (std::abs(deltaX) < TRANSFORM_EPSILON && std::abs(deltaY) < TRANSFORM_EPSILON) {
     return;
   }
   double currentZoomScale = 1.0;
@@ -72,6 +72,34 @@ void ContentViewModel::resetView() {
     viewTransform = {};
   }
   notifyViewTransformChanged(1.0);
+}
+
+void ContentViewModel::adjustForSurfaceResize(double oldSurfaceWidth, double oldSurfaceHeight,
+                                              double newSurfaceWidth, double newSurfaceHeight,
+                                              double contentWidth, double contentHeight) {
+  if (contentWidth <= 0 || contentHeight <= 0 || oldSurfaceWidth <= 0 || oldSurfaceHeight <= 0 ||
+      newSurfaceWidth <= 0 || newSurfaceHeight <= 0) {
+    return;
+  }
+  auto oldContentScale =
+      std::min(oldSurfaceWidth / contentWidth, oldSurfaceHeight / contentHeight);
+  auto newContentScale =
+      std::min(newSurfaceWidth / contentWidth, newSurfaceHeight / contentHeight);
+  auto oldContentOffsetX = (oldSurfaceWidth - contentWidth * oldContentScale) * 0.5;
+  auto oldContentOffsetY = (oldSurfaceHeight - contentHeight * oldContentScale) * 0.5;
+  auto newContentOffsetX = (newSurfaceWidth - contentWidth * newContentScale) * 0.5;
+  auto newContentOffsetY = (newSurfaceHeight - contentHeight * newContentScale) * 0.5;
+  {
+    std::lock_guard<std::mutex> lock(viewTransformMutex);
+    if (viewTransform.zoomScale == 1.0 && viewTransform.offsetX == 0.0 &&
+        viewTransform.offsetY == 0.0) {
+      return;
+    }
+    viewTransform.offsetX +=
+        (oldContentOffsetX - newContentOffsetX) * viewTransform.zoomScale;
+    viewTransform.offsetY +=
+        (oldContentOffsetY - newContentOffsetY) * viewTransform.zoomScale;
+  }
 }
 
 void ContentViewModel::notifyViewTransformChanged(double newZoomScale) {

--- a/viewer/src/rendering/ContentViewModel.cpp
+++ b/viewer/src/rendering/ContentViewModel.cpp
@@ -81,10 +81,8 @@ void ContentViewModel::adjustForSurfaceResize(double oldSurfaceWidth, double old
       newSurfaceWidth <= 0 || newSurfaceHeight <= 0) {
     return;
   }
-  auto oldContentScale =
-      std::min(oldSurfaceWidth / contentWidth, oldSurfaceHeight / contentHeight);
-  auto newContentScale =
-      std::min(newSurfaceWidth / contentWidth, newSurfaceHeight / contentHeight);
+  auto oldContentScale = std::min(oldSurfaceWidth / contentWidth, oldSurfaceHeight / contentHeight);
+  auto newContentScale = std::min(newSurfaceWidth / contentWidth, newSurfaceHeight / contentHeight);
   auto oldContentOffsetX = (oldSurfaceWidth - contentWidth * oldContentScale) * 0.5;
   auto oldContentOffsetY = (oldSurfaceHeight - contentHeight * oldContentScale) * 0.5;
   auto newContentOffsetX = (newSurfaceWidth - contentWidth * newContentScale) * 0.5;
@@ -95,10 +93,8 @@ void ContentViewModel::adjustForSurfaceResize(double oldSurfaceWidth, double old
         viewTransform.offsetY == 0.0) {
       return;
     }
-    viewTransform.offsetX +=
-        (oldContentOffsetX - newContentOffsetX) * viewTransform.zoomScale;
-    viewTransform.offsetY +=
-        (oldContentOffsetY - newContentOffsetY) * viewTransform.zoomScale;
+    viewTransform.offsetX += (oldContentOffsetX - newContentOffsetX) * viewTransform.zoomScale;
+    viewTransform.offsetY += (oldContentOffsetY - newContentOffsetY) * viewTransform.zoomScale;
   }
 }
 

--- a/viewer/src/rendering/ContentViewModel.h
+++ b/viewer/src/rendering/ContentViewModel.h
@@ -23,6 +23,7 @@
 #include <QSizeF>
 #include <QString>
 #include <memory>
+#include <mutex>
 
 namespace pag {
 
@@ -58,6 +59,7 @@ class ContentViewModel : public QObject {
                  editableImageLayerCountChanged)
   Q_PROPERTY(bool showVideoFrames READ getShowVideoFrames WRITE setShowVideoFrames)
   Q_PROPERTY(ContentType contentType READ getContentType CONSTANT)
+  Q_PROPERTY(double zoomScale READ zoomScale NOTIFY zoomScaleChanged)
 
   explicit ContentViewModel(QObject* parent = nullptr) : QObject(parent) {
   }
@@ -89,6 +91,18 @@ class ContentViewModel : public QObject {
   Q_INVOKABLE virtual void nextFrame() = 0;
   Q_INVOKABLE virtual void previousFrame() = 0;
 
+  struct ViewTransform {
+    double zoomScale = 1.0;
+    double offsetX = 0.0;
+    double offsetY = 0.0;
+  };
+
+  double zoomScale() const;
+  ViewTransform getViewTransform() const;
+  void zoomAt(double factor, double anchorX, double anchorY);
+  void panBy(double deltaX, double deltaY);
+  void resetView();
+
   Q_SIGNAL void isPlayingChanged(bool isPlaying);
   Q_SIGNAL void hasAnimationChanged(bool hasAnimation);
   Q_SIGNAL void progressChanged(double progress);
@@ -101,6 +115,17 @@ class ContentViewModel : public QObject {
   Q_SIGNAL void preferredSizeChanged();
   Q_SIGNAL void requestFlush();
   Q_SIGNAL void contentSizeChanged();
+  Q_SIGNAL void zoomScaleChanged(double value);
+
+ protected:
+  virtual void onViewTransformChanged() {
+  }
+
+ private:
+  void notifyViewTransformChanged(double zoomScale);
+
+  mutable std::mutex viewTransformMutex = {};
+  ViewTransform viewTransform = {};
 };
 
 }  // namespace pag

--- a/viewer/src/rendering/ContentViewModel.h
+++ b/viewer/src/rendering/ContentViewModel.h
@@ -97,11 +97,26 @@ class ContentViewModel : public QObject {
     double offsetY = 0.0;
   };
 
+  /// Returns the current zoom scale factor.
   double zoomScale() const;
+
+  /// Returns a snapshot of the current view transform (zoom + pan offset).
   ViewTransform getViewTransform() const;
+
+  /// Applies a zoom factor anchored at the given point in surface pixel coordinates.
   void zoomAt(double factor, double anchorX, double anchorY);
+
+  /// Pans the view by the given delta in surface pixel coordinates.
   void panBy(double deltaX, double deltaY);
+
+  /// Resets the view transform to the default (no zoom, no pan).
   void resetView();
+
+  /// Adjusts the pan offset to compensate for a surface size change, keeping the content visually
+  /// anchored at the same position. All parameters are in surface pixel coordinates.
+  void adjustForSurfaceResize(double oldSurfaceWidth, double oldSurfaceHeight,
+                              double newSurfaceWidth, double newSurfaceHeight, double contentWidth,
+                              double contentHeight);
 
   Q_SIGNAL void isPlayingChanged(bool isPlaying);
   Q_SIGNAL void hasAnimationChanged(bool hasAnimation);
@@ -122,7 +137,7 @@ class ContentViewModel : public QObject {
   }
 
  private:
-  void notifyViewTransformChanged(double zoomScale);
+  void notifyViewTransformChanged(double newZoomScale);
 
   mutable std::mutex viewTransformMutex = {};
   ViewTransform viewTransform = {};

--- a/viewer/src/rendering/pag/PAGRenderer.cpp
+++ b/viewer/src/rendering/pag/PAGRenderer.cpp
@@ -17,10 +17,15 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "rendering/pag/PAGRenderer.h"
+#include <algorithm>
 
 namespace pag {
 
 PAGRenderer::PAGRenderer(PAGViewModel* viewModel) : viewModel(viewModel) {
+}
+
+void PAGRenderer::setDrawable(GPUDrawable* drawable) {
+  this->drawable = drawable;
 }
 
 bool PAGRenderer::isReady() const {
@@ -35,6 +40,28 @@ void PAGRenderer::updateSize() {
   }
 }
 
+void PAGRenderer::applyDisplayTransform() {
+  if (drawable == nullptr || drawable->width() <= 0 || drawable->height() <= 0 ||
+      viewModel->getWidth() <= 0 || viewModel->getHeight() <= 0) {
+    return;
+  }
+  auto surfaceWidth = static_cast<float>(drawable->width());
+  auto surfaceHeight = static_cast<float>(drawable->height());
+  auto contentWidth = static_cast<float>(viewModel->getWidth());
+  auto contentHeight = static_cast<float>(viewModel->getHeight());
+  auto contentScale = std::min(surfaceWidth / contentWidth, surfaceHeight / contentHeight);
+  auto contentOffsetX = (surfaceWidth - contentWidth * contentScale) * 0.5f;
+  auto contentOffsetY = (surfaceHeight - contentHeight * contentScale) * 0.5f;
+  auto transform = viewModel->getViewTransform();
+  auto zoomScale = static_cast<float>(transform.zoomScale);
+  auto matrix = Matrix::MakeAll(contentScale * zoomScale, 0.0f,
+                                contentOffsetX * zoomScale + static_cast<float>(transform.offsetX),
+                                0.0f, contentScale * zoomScale,
+                                contentOffsetY * zoomScale + static_cast<float>(transform.offsetY),
+                                0.0f, 0.0f, 1.0f);
+  viewModel->getPAGPlayer()->setMatrix(matrix);
+}
+
 IContentRenderer::RenderMetrics PAGRenderer::flush() {
   RenderMetrics metrics = {};
   if (!isReady()) {
@@ -45,6 +72,7 @@ IContentRenderer::RenderMetrics PAGRenderer::flush() {
   if (file == nullptr) {
     return metrics;
   }
+  applyDisplayTransform();
   player->flush();
   double progress = file->getProgress();
   auto totalFrames =

--- a/viewer/src/rendering/pag/PAGRenderer.cpp
+++ b/viewer/src/rendering/pag/PAGRenderer.cpp
@@ -35,8 +35,18 @@ bool PAGRenderer::isReady() const {
 
 void PAGRenderer::updateSize() {
   auto pagSurface = viewModel->getPAGPlayer()->getSurface();
-  if (pagSurface != nullptr) {
-    pagSurface->updateSize();
+  if (pagSurface == nullptr || drawable == nullptr) {
+    return;
+  }
+  auto oldWidth = static_cast<double>(drawable->width());
+  auto oldHeight = static_cast<double>(drawable->height());
+  pagSurface->updateSize();
+  auto newWidth = static_cast<double>(drawable->width());
+  auto newHeight = static_cast<double>(drawable->height());
+  if (oldWidth != newWidth || oldHeight != newHeight) {
+    viewModel->adjustForSurfaceResize(oldWidth, oldHeight, newWidth, newHeight,
+                                      static_cast<double>(viewModel->getWidth()),
+                                      static_cast<double>(viewModel->getHeight()));
   }
 }
 

--- a/viewer/src/rendering/pag/PAGRenderer.h
+++ b/viewer/src/rendering/pag/PAGRenderer.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "platform/qt/GPUDrawable.h"
 #include "rendering/IContentRenderer.h"
 #include "rendering/pag/PAGViewModel.h"
 
@@ -34,9 +35,13 @@ class PAGRenderer : public IContentRenderer {
   RenderMetrics flush() override;
   void updateSize() override;
   bool isReady() const override;
+  void setDrawable(GPUDrawable* drawable) override;
 
  private:
+  void applyDisplayTransform();
+
   PAGViewModel* viewModel = nullptr;
+  GPUDrawable* drawable = nullptr;
 };
 
 }  // namespace pag

--- a/viewer/src/rendering/pag/PAGView.cpp
+++ b/viewer/src/rendering/pag/PAGView.cpp
@@ -73,6 +73,7 @@ void PAGView::initDrawable() {
   }
   viewModel->getPAGPlayer()->setSurface(pagSurface);
   if (renderThread != nullptr) {
+    renderThread->setDrawable(drawable.get());
     drawable->moveToThread(renderThread.get());
   }
 }

--- a/viewer/src/rendering/pag/PAGViewModel.cpp
+++ b/viewer/src/rendering/pag/PAGViewModel.cpp
@@ -264,6 +264,8 @@ bool PAGViewModel::loadFile(const QString& filePath) {
 
   reportPAGFileInfo(pagFile, byteData->length());
 
+  resetView();
+
   return true;
 }
 

--- a/viewer/src/rendering/pagx/PAGXRenderer.cpp
+++ b/viewer/src/rendering/pagx/PAGXRenderer.cpp
@@ -99,7 +99,7 @@ IContentRenderer::RenderMetrics PAGXRenderer::flush() {
   metrics.currentFrame = computeProfileFrame(state);
 
   if (state.contentWidth > 0 && state.contentHeight > 0) {
-    applyFitTransform(state, tgfxSurface->width(), tgfxSurface->height());
+    applyDisplayTransform(state, tgfxSurface->width(), tgfxSurface->height());
   }
 
   auto renderStart = tgfx::Clock::Now();
@@ -237,17 +237,26 @@ int64_t PAGXRenderer::computeProfileFrame(const PAGXViewModel::RenderState& stat
   return frame;
 }
 
-void PAGXRenderer::applyFitTransform(PAGXViewModel::RenderState& state, int surfaceWidth,
-                                     int surfaceHeight) {
+void PAGXRenderer::applyDisplayTransform(PAGXViewModel::RenderState& state, int surfaceWidth,
+                                         int surfaceHeight) {
   float scaleX = static_cast<float>(surfaceWidth) / static_cast<float>(state.contentWidth);
   float scaleY = static_cast<float>(surfaceHeight) / static_cast<float>(state.contentHeight);
-  float scale = std::min(scaleX, scaleY);
-  float offsetX =
-      (static_cast<float>(surfaceWidth) - static_cast<float>(state.contentWidth) * scale) * 0.5f;
-  float offsetY =
-      (static_cast<float>(surfaceHeight) - static_cast<float>(state.contentHeight) * scale) * 0.5f;
-  state.scene->getDisplayOptions()->setZoomScale(scale);
-  state.scene->getDisplayOptions()->setContentOffset(offsetX, offsetY);
+  float contentScale = std::min(scaleX, scaleY);
+  float contentOffsetX =
+      (static_cast<float>(surfaceWidth) - static_cast<float>(state.contentWidth) * contentScale) *
+      0.5f;
+  float contentOffsetY =
+      (static_cast<float>(surfaceHeight) - static_cast<float>(state.contentHeight) * contentScale) *
+      0.5f;
+
+  // Combine fit-to-screen transform with user zoom/pan from gesture interaction.
+  float finalScale = contentScale * static_cast<float>(state.viewTransform.zoomScale);
+  float finalOffsetX = contentOffsetX * static_cast<float>(state.viewTransform.zoomScale) +
+                       static_cast<float>(state.viewTransform.offsetX);
+  float finalOffsetY = contentOffsetY * static_cast<float>(state.viewTransform.zoomScale) +
+                       static_cast<float>(state.viewTransform.offsetY);
+  state.scene->getDisplayOptions()->setZoomScale(finalScale);
+  state.scene->getDisplayOptions()->setContentOffset(finalOffsetX, finalOffsetY);
 }
 
 }  // namespace pag

--- a/viewer/src/rendering/pagx/PAGXRenderer.cpp
+++ b/viewer/src/rendering/pagx/PAGXRenderer.cpp
@@ -41,9 +41,19 @@ bool PAGXRenderer::isReady() const {
 }
 
 void PAGXRenderer::updateSize() {
-  if (drawable != nullptr) {
-    drawable->freeSurface();
-    drawable->updateSize();
+  if (drawable == nullptr) {
+    return;
+  }
+  auto oldWidth = static_cast<double>(drawable->width());
+  auto oldHeight = static_cast<double>(drawable->height());
+  drawable->freeSurface();
+  drawable->updateSize();
+  auto newWidth = static_cast<double>(drawable->width());
+  auto newHeight = static_cast<double>(drawable->height());
+  if (oldWidth != newWidth || oldHeight != newHeight) {
+    viewModel->adjustForSurfaceResize(oldWidth, oldHeight, newWidth, newHeight,
+                                      static_cast<double>(viewModel->getWidth()),
+                                      static_cast<double>(viewModel->getHeight()));
   }
 }
 

--- a/viewer/src/rendering/pagx/PAGXRenderer.h
+++ b/viewer/src/rendering/pagx/PAGXRenderer.h
@@ -54,9 +54,9 @@ class PAGXRenderer : public IContentRenderer {
   // Returns -1 when no frame applies (no timeline, zero duration, or non-positive frame rate).
   int64_t computeProfileFrame(const PAGXViewModel::RenderState& state) const;
 
-  // Applies the fit-to-screen transform to the scene's display options so the content is centered
-  // and uniformly scaled to fit the surface.
-  void applyFitTransform(PAGXViewModel::RenderState& state, int surfaceWidth, int surfaceHeight);
+  // Applies the combined fit-to-screen and user zoom/pan transform to the scene's display options.
+  void applyDisplayTransform(PAGXViewModel::RenderState& state, int surfaceWidth,
+                             int surfaceHeight);
 
   PAGXViewModel* viewModel = nullptr;
   GPUDrawable* drawable = nullptr;

--- a/viewer/src/rendering/pagx/PAGXViewModel.cpp
+++ b/viewer/src/rendering/pagx/PAGXViewModel.cpp
@@ -150,6 +150,10 @@ void PAGXViewModel::markNeedsRender() {
   needsRender = true;
 }
 
+void PAGXViewModel::onViewTransformChanged() {
+  markNeedsRender();
+}
+
 void PAGXViewModel::updateProgressFromRender(double newProgress, uint64_t generation) {
   QMetaObject::invokeMethod(this, "applyProgressFromRender", Qt::QueuedConnection,
                             Q_ARG(double, newProgress),
@@ -192,7 +196,8 @@ PAGXViewModel::RenderState PAGXViewModel::getRenderState() {
           isPlaying_.load(),
           progress,
           pendingSeek.exchange(false),
-          playbackGeneration.load()};
+          playbackGeneration.load(),
+          getViewTransform()};
 }
 
 bool PAGXViewModel::hasContent() {
@@ -297,6 +302,8 @@ bool PAGXViewModel::loadFile(const QString& filePath) {
   // will be called from onRenderCompleted() after the first render finishes.
   // This avoids race conditions between ListView updates and texture presentation.
   pendingXmlContent = xmlString;
+
+  resetView();
 
   return true;
 }

--- a/viewer/src/rendering/pagx/PAGXViewModel.h
+++ b/viewer/src/rendering/pagx/PAGXViewModel.h
@@ -81,6 +81,7 @@ class PAGXViewModel : public ContentViewModel {
     double progress = 0.0;
     bool seekRequested = false;
     uint64_t generation = 0;
+    ViewTransform viewTransform = {};
   };
 
   void setWindow(QQuickWindow* window);
@@ -123,6 +124,9 @@ class PAGXViewModel : public ContentViewModel {
    * This is used to defer XmlLinesModel updates until the first render is done.
    */
   Q_SLOT void onRenderCompleted();
+
+ protected:
+  void onViewTransformChanged() override;
 
  private:
   void clearContent();


### PR DESCRIPTION
## 概述

为 PAGViewer 的画布区域添加交互式缩放、平移和滚动功能，支持鼠标滚轮缩放、触控板双指缩放、拖拽平移，以及菜单/快捷键控制。

## 主要改动

### 架构设计
- 在 `ContentViewModel` 基类中新增 `ViewTransform` 结构体（zoomScale + offsetX/offsetY），通过 mutex 保护实现 UI 线程与渲染线程间的安全共享
- `ContentView` 作为 QML 桥接层，负责 devicePixelRatio 坐标缩放
- PAG 和 PAGX 两种渲染器分别实现 `applyDisplayTransform()`，将 fit-to-screen 变换与用户交互变换组合应用

### 交互方式
- **鼠标滚轮**：普通滚动 → 平移；Ctrl/Cmd+滚动 → 以光标为锚点缩放；Shift+滚动 → 水平平移
- **触控板**：双指捏合缩放（PinchHandler），双指滑动平移
- **鼠标拖拽**：左键按住拖拽平移（含 4px 阈值防止误触），未拖拽时点击切换播放/暂停
- **菜单/快捷键**：View 菜单新增 Zoom In (Ctrl+=)、Zoom Out (Ctrl+-)、Reset Zoom (Ctrl+0)
- **工具栏**：右下角显示当前缩放百分比和重置按钮

### 其他
- 加载新文件时自动重置视图变换
- 画布区域启用 clip 防止缩放内容溢出
- 完善中文翻译

## 测试
- 编译验证通过
- 经过三轮自动化代码审查