### PR TITLE
Fix UAF in napi_ref lifecycle management on OHOS

### DIFF
--- a/src/platform/ohos/JsHelper.cpp
+++ b/src/platform/ohos/JsHelper.cpp
@@ -67,16 +67,16 @@ static bool SetConstructor(napi_env env, napi_value constructor, const std::stri
       return false;
     }
   }
-  auto refIt = envMap.find(name);
-  if (refIt != envMap.end()) {
-    napi_delete_reference(env, refIt->second);
-    envMap.erase(refIt);
-  }
   napi_ref ref = nullptr;
   auto refStatus = napi_create_reference(env, constructor, 1, &ref);
   if (refStatus != napi_ok) {
     LOGE("SetConstructor napi_create_reference failed :%d", refStatus);
     return false;
+  }
+  auto refIt = envMap.find(name);
+  if (refIt != envMap.end()) {
+    napi_delete_reference(env, refIt->second);
+    envMap.erase(refIt);
   }
   envMap[name] = ref;
   return true;
@@ -86,7 +86,7 @@ napi_value GetConstructor(napi_env env, const std::string& name) {
   if (env == nullptr || name.empty()) {
     return nullptr;
   }
-  napi_ref ref = nullptr;
+  napi_value result = nullptr;
   {
     std::lock_guard<std::mutex> autoLock(ConstructorRefMapMutex);
     auto envIt = ConstructorRefMap.find(env);
@@ -97,10 +97,8 @@ napi_value GetConstructor(napi_env env, const std::string& name) {
     if (refIt == envIt->second.end()) {
       return nullptr;
     }
-    ref = refIt->second;
+    napi_get_reference_value(env, refIt->second, &result);
   }
-  napi_value result = nullptr;
-  napi_get_reference_value(env, ref, &result);
   return result;
 }
 


### PR DESCRIPTION
修复 OHOS 平台 JsHelper 中 napi_ref 生命周期管理的两个问题，**修复 Discussion #3627** 描述的崩溃。

## 修改内容

### 1.  — 将  移入锁内

原代码将  从互斥锁保护的 map 中拷贝出来，释放锁后在锁外调用 。期间另一个线程（ 或 ）可能已删除该 ref，导致 Use-After-Free。被污染的  在后续使用中触发 ARK 运行时 UBSan 检测到无效值加载（）。

### 2.  — 先创建新 ref，成功后再删旧的

原代码先删旧 ref 再建新 ref，如果  失败则旧 ref 永久丢失， 或后续  会面对已失效的条目。

## 相关

- Discussion #3627
- 分支：bugfix/markffan_ohos_napi_uaf