### PR TITLE
Fix double-release of ANativeWindow when HardwareDecoder init fails.

### DIFF
--- a/src/platform/android/HardwareDecoder.cpp
+++ b/src/platform/android/HardwareDecoder.cpp
@@ -154,6 +154,7 @@ bool HardwareDecoder::initDecoder(const VideoFormat& format) {
   if (status != AMEDIA_OK) {
     LOGE("HardwareDecoder: Error on configuring videoDecoder.\n");
     ANativeWindow_release(nativeWindow);
+    nativeWindow = nullptr;
     AMediaCodec_delete(videoDecoder);
     videoDecoder = nullptr;
     return false;
@@ -163,6 +164,7 @@ bool HardwareDecoder::initDecoder(const VideoFormat& format) {
   if (status != AMEDIA_OK) {
     LOGE("HardwareDecoder: Error on starting videoDecoder.\n");
     ANativeWindow_release(nativeWindow);
+    nativeWindow = nullptr;
     AMediaCodec_delete(videoDecoder);
     videoDecoder = nullptr;
     return false;


### PR DESCRIPTION
In `HardwareDecoder::initDecoder()`, when `AMediaCodec_configure` or `AMediaCodec_start` fails after `ANativeWindow_fromSurface` has succeeded, `ANativeWindow_release(nativeWindow)` is called but `nativeWindow` is not set to `nullptr`. When the `HardwareDecoder` object is subsequently destroyed, the destructor calls `ANativeWindow_release(nativeWindow)` again on the already-released window, causing a double-release that crashes in `android::RefBase::decStrong()`.

This fix adds `nativeWindow = nullptr` after the two `ANativeWindow_release` calls in the configure/start failure paths, consistent with the destructor pattern.