### PR TITLE
Fix CFRelease(NULL) crash when CVPixelBufferCreateResolvedAttributesDictionary fails

### DIFF
--- a/src/platform/mac/private/HardwareDecoder.mm
+++ b/src/platform/mac/private/HardwareDecoder.mm
@@ -163,7 +163,12 @@ bool HardwareDecoder::resetVideoToolBox() {
   const void* combineDics[] = {inAttrs};
   CFArrayRef combines = CFArrayCreate(NULL, combineDics, 1, NULL);
   CFDictionaryRef outAttrs = NULL;
-  CVPixelBufferCreateResolvedAttributesDictionary(NULL, combines, &outAttrs);
+  // CVPixelBufferCreateResolvedAttributesDictionary may fail on newer macOS
+  // versions (e.g., macOS 27 beta) and set outAttrs to NULL.
+  auto resolvedResult = CVPixelBufferCreateResolvedAttributesDictionary(NULL, combines, &outAttrs);
+  if (resolvedResult != kCVReturnSuccess) {
+    outAttrs = NULL;
+  }
   VTDecompressionOutputCallbackRecord callBackRecord;
   callBackRecord.decompressionOutputCallback = DidDecompress;
   callBackRecord.decompressionOutputRefCon = NULL;
@@ -171,7 +176,9 @@ bool HardwareDecoder::resetVideoToolBox() {
   OSStatus status = VTDecompressionSessionCreate(kCFAllocatorDefault, videoFormatDescription, NULL,
                                                  outAttrs, &callBackRecord, &session);
 
-  CFRelease(outAttrs);
+  if (outAttrs != NULL) {
+    CFRelease(outAttrs);
+  }
   CFRelease(combines);
   CFRelease(inAttrs);
   CFRelease(pixelFormatTypeValue);

--- a/src/platform/mac/private/HardwareDecoder.mm
+++ b/src/platform/mac/private/HardwareDecoder.mm
@@ -163,9 +163,12 @@ bool HardwareDecoder::resetVideoToolBox() {
   const void* combineDics[] = {inAttrs};
   CFArrayRef combines = CFArrayCreate(NULL, combineDics, 1, NULL);
   CFDictionaryRef outAttrs = NULL;
-  // CVPixelBufferCreateResolvedAttributesDictionary may fail on newer macOS
-  // versions (e.g., macOS 27 beta) and set outAttrs to NULL.
-  auto resolvedResult = CVPixelBufferCreateResolvedAttributesDictionary(NULL, combines, &outAttrs);
+  // CVPixelBufferCreateResolvedAttributesDictionary may fail when attributes
+  // contain keys unsupported by the current environment (e.g., the OpenGL
+  // compatibility key is no longer recognized on newer macOS), and will set
+  // outAttrs to NULL in that case.
+  CVReturn resolvedResult =
+      CVPixelBufferCreateResolvedAttributesDictionary(NULL, combines, &outAttrs);
   if (resolvedResult != kCVReturnSuccess) {
     outAttrs = NULL;
   }


### PR DESCRIPTION
修复 macOS 27 beta 上因 kCVPixelBufferOpenGLCompatibilityKey 不再被支持，导致 CVPixelBufferCreateResolvedAttributesDictionary 返回 NULL，进而 CFRelease(NULL) 崩溃的问题。

## 修改内容

- 检查 CVPixelBufferCreateResolvedAttributesDictionary 的返回值，失败时将 outAttrs 置为 NULL
- 给 CFRelease 加 NULL 保护，避免传入空指针

## 相关 Issue

Fixes #3591