### PR TITLE
[release/4.5] Fix double-release of ANativeWindow when HardwareDecoder init fails.

### DIFF
--- a/src/platform/android/HardwareDecoder.cpp
+++ b/src/platform/android/HardwareDecoder.cpp
@@ -154,6 +154,7 @@ bool HardwareDecoder::initDecoder(const VideoFormat& format) {
   if (status != AMEDIA_OK) {
     LOGE("HardwareDecoder: Error on configuring videoDecoder.\n");
     ANativeWindow_release(nativeWindow);
+    nativeWindow = nullptr;
     AMediaCodec_delete(videoDecoder);
     videoDecoder = nullptr;
     return false;
@@ -163,6 +164,7 @@ bool HardwareDecoder::initDecoder(const VideoFormat& format) {
   if (status != AMEDIA_OK) {
     LOGE("HardwareDecoder: Error on starting videoDecoder.\n");
     ANativeWindow_release(nativeWindow);
+    nativeWindow = nullptr;
     AMediaCodec_delete(videoDecoder);
     videoDecoder = nullptr;
     return false;


### PR DESCRIPTION
Cherry-pick of #3630 to release/4.5.