### PR TITLE
Improve HTML importer fidelity: SVG layer hierarchy, radial gradients, font weight, and icon-font face matching

### DIFF
--- a/resources/cli/import_resolve_skew_siblings.pagx
+++ b/resources/cli/import_resolve_skew_siblings.pagx
@@ -1,0 +1,8 @@
+<pagx width="40" height="40">
+  <Layer centerX="0" centerY="0">
+    <svg viewBox="0 0 20 20">
+      <path d="M2 2H8V8H2Z" fill="#FF4757" transform="scale(0.01) skewX(20)"/>
+      <path d="M10 10H18V18H10Z" fill="#3498DB"/>
+    </svg>
+  </Layer>
+</pagx>

--- a/resources/cli/import_resolve_transformed_siblings.pagx
+++ b/resources/cli/import_resolve_transformed_siblings.pagx
@@ -1,0 +1,9 @@
+<pagx width="40" height="40">
+  <Layer centerX="0" centerY="0">
+    <svg viewBox="0 0 20 20">
+      <path d="M0 0H4V4H0Z" fill="#FF4757"
+            transform="translate(4 5) rotate(30) scale(2 3)"/>
+      <path d="M10 10H18V18H10Z" fill="#3498DB"/>
+    </svg>
+  </Layer>
+</pagx>

--- a/src/cli/CommandResolve.cpp
+++ b/src/cli/CommandResolve.cpp
@@ -124,6 +124,20 @@ static int ParseResolveOptions(int argc, char* argv[], ResolveOptions* options) 
 // Resolve logic
 //--------------------------------------------------------------------------------------------------
 
+// A Group's position/scale/rotation fields can represent a matrix whose axes remain orthogonal.
+// Compare the normalized axis dot product so the result does not depend on the matrix scale.
+// Degenerate axes are kept as Layers because the decomposition below cannot recover their rotation.
+static bool CanDowngradeMatrixToGroup(const Matrix& matrix) {
+  float xLength = std::hypot(matrix.a, matrix.b);
+  float yLength = std::hypot(matrix.c, matrix.d);
+  if (pag::FloatNearlyZero(xLength) || pag::FloatNearlyZero(yLength)) {
+    return false;
+  }
+  float normalizedDot =
+      (matrix.a / xLength) * (matrix.c / yLength) + (matrix.b / xLength) * (matrix.d / yLength);
+  return pag::FloatNearlyZero(normalizedDot);
+}
+
 static bool ResolveOneLayer(Layer* layer, const std::string& baseDir,
                             const ImportFormatOptions& formatOptions, PAGXDocument* doc) {
   bool hasImportSource = !layer->importDirective.source.empty();
@@ -208,7 +222,8 @@ static bool ResolveOneLayer(Layer* layer, const std::string& baseDir,
   } else if (elementLayers.size() > 1) {
     canDowngradeAll = true;
     for (auto* el : elementLayers) {
-      if (!el->children.empty() || HasLayerOnlyFeatures(el)) {
+      if (!el->children.empty() || HasLayerOnlyFeatures(el) ||
+          !CanDowngradeMatrixToGroup(el->matrix)) {
         canDowngradeAll = false;
         break;
       }
@@ -223,19 +238,18 @@ static bool ResolveOneLayer(Layer* layer, const std::string& baseDir,
     // Wrap every element layer uniformly in its own Group so sibling shapes stay at the same
     // depth (peer Groups), preserving the source hierarchy. Flattening only the first layer's
     // contents while wrapping the rest would break that symmetry and is unnecessary — a trailing
-    // painter is isolated by its enclosing Group either way. This mirrors the uniform handling in
-    // PAGXOptimizer::DowngradeShellChildren.
+    // painter is isolated by its enclosing Group either way. Structurally, this uses the same
+    // all-siblings Group strategy as PAGXOptimizer::DowngradeShellChildren, while also supporting
+    // transformable non-identity matrices here.
     for (auto* elemLayer : elementLayers) {
-      auto m = elemLayer->matrix;
-      bool hasSkew = !pag::FloatNearlyEqual(m.a * m.c + m.b * m.d, 0.0f);
-      if (hasSkew) {
-        // Matrix contains skew which cannot be represented by Group's
-        // position/scale/rotation. Keep it as a Layer instead of downgrading.
-        layer->children.push_back(elemLayer);
+      if (elemLayer->contents.empty() && elemLayer->customData.empty()) {
         continue;
       }
+      auto m = elemLayer->matrix;
       auto* group = doc->makeNode<Group>();
       group->elements = std::move(elemLayer->contents);
+      group->customData = std::move(elemLayer->customData);
+      group->sourceLine = elemLayer->sourceLine;
       if (!elemLayer->matrix.isIdentity()) {
         group->position = {m.tx, m.ty};
         if (m.a != 1 || m.b != 0 || m.c != 0 || m.d != 1) {

--- a/src/cli/CommandResolve.cpp
+++ b/src/cli/CommandResolve.cpp
@@ -30,7 +30,6 @@
 #include "pagx/PAGXOptimizer.h"
 #include "pagx/nodes/Composition.h"
 #include "pagx/nodes/Group.h"
-#include "pagx/nodes/LayoutNode.h"
 
 namespace pagx::cli {
 
@@ -221,52 +220,37 @@ static bool ResolveOneLayer(Layer* layer, const std::string& baseDir,
       layer->contents.push_back(element);
     }
   } else if (canDowngradeAll) {
-    for (size_t i = 0; i < elementLayers.size(); i++) {
-      auto* elemLayer = elementLayers[i];
-      bool unpackFirst = false;
-      if (i == 0 && elemLayer->matrix.isIdentity()) {
-        unpackFirst = true;
-        for (auto* child : elemLayer->contents) {
-          auto* layoutNode = LayoutNode::AsLayoutNode(child);
-          if (layoutNode != nullptr &&
-              (!std::isnan(layoutNode->right) || !std::isnan(layoutNode->bottom) ||
-               !std::isnan(layoutNode->centerX) || !std::isnan(layoutNode->centerY))) {
-            unpackFirst = false;
-            break;
+    // Wrap every element layer uniformly in its own Group so sibling shapes stay at the same
+    // depth (peer Groups), preserving the source hierarchy. Flattening only the first layer's
+    // contents while wrapping the rest would break that symmetry and is unnecessary — a trailing
+    // painter is isolated by its enclosing Group either way. This mirrors the uniform handling in
+    // PAGXOptimizer::DowngradeShellChildren.
+    for (auto* elemLayer : elementLayers) {
+      auto m = elemLayer->matrix;
+      bool hasSkew = !pag::FloatNearlyEqual(m.a * m.c + m.b * m.d, 0.0f);
+      if (hasSkew) {
+        // Matrix contains skew which cannot be represented by Group's
+        // position/scale/rotation. Keep it as a Layer instead of downgrading.
+        layer->children.push_back(elemLayer);
+        continue;
+      }
+      auto* group = doc->makeNode<Group>();
+      group->elements = std::move(elemLayer->contents);
+      if (!elemLayer->matrix.isIdentity()) {
+        group->position = {m.tx, m.ty};
+        if (m.a != 1 || m.b != 0 || m.c != 0 || m.d != 1) {
+          float sx = std::sqrt(m.a * m.a + m.b * m.b);
+          float sy = std::sqrt(m.c * m.c + m.d * m.d);
+          float det = m.a * m.d - m.b * m.c;
+          if (det < 0) {
+            sy = -sy;
           }
+          float rot = pag::RadiansToDegrees(std::atan2(m.b, m.a));
+          group->scale = {sx, sy};
+          group->rotation = rot;
         }
       }
-      if (unpackFirst) {
-        for (auto* element : elemLayer->contents) {
-          layer->contents.push_back(element);
-        }
-      } else {
-        auto m = elemLayer->matrix;
-        bool hasSkew = !pag::FloatNearlyEqual(m.a * m.c + m.b * m.d, 0.0f);
-        if (hasSkew) {
-          // Matrix contains skew which cannot be represented by Group's
-          // position/scale/rotation. Keep it as a Layer instead of downgrading.
-          layer->children.push_back(elemLayer);
-          continue;
-        }
-        auto* group = doc->makeNode<Group>();
-        group->elements = std::move(elemLayer->contents);
-        if (!elemLayer->matrix.isIdentity()) {
-          group->position = {m.tx, m.ty};
-          if (m.a != 1 || m.b != 0 || m.c != 0 || m.d != 1) {
-            float sx = std::sqrt(m.a * m.a + m.b * m.b);
-            float sy = std::sqrt(m.c * m.c + m.d * m.d);
-            float det = m.a * m.d - m.b * m.c;
-            if (det < 0) {
-              sy = -sy;
-            }
-            float rot = pag::RadiansToDegrees(std::atan2(m.b, m.a));
-            group->scale = {sx, sy};
-            group->rotation = rot;
-          }
-        }
-        layer->contents.push_back(group);
-      }
+      layer->contents.push_back(group);
     }
   } else {
     for (auto* elemLayer : elementLayers) {

--- a/src/pagx/TextLayout.cpp
+++ b/src/pagx/TextLayout.cpp
@@ -25,6 +25,7 @@
 #include "pagx/nodes/Group.h"
 #include "pagx/nodes/Text.h"
 #include "pagx/nodes/TextBox.h"
+#include "pagx/utils/CSSFontStyle.h"
 #include "pagx/utils/TextUtils.h"
 #include "renderer/BidiResolver.h"
 #include "renderer/LineBreaker.h"
@@ -382,6 +383,18 @@ class TextLayoutContext {
                  float textScale = 1.0f) {
     auto primaryTypeface = findTypeface(glyph.fontFamily, glyph.fontStyle);
 
+    // Keep the requested weight as a real face label so an installed Bold / SemiBold / Black face
+    // can be selected precisely. If lookup falls back to a lighter face (or finds no primary face),
+    // synthesize the missing weight at layout time. The faux flag then propagates to per-character
+    // fallback fonts in TextShaper as well.
+    bool fauxBold = glyph.fauxBold;
+    if (!fauxBold) {
+      int requestedWeight = ParseFontStyleName(glyph.fontStyle).weight;
+      int resolvedWeight =
+          primaryTypeface == nullptr ? 400 : ParseFontStyleName(primaryTypeface->fontStyle()).weight;
+      fauxBold = resolvedWeight < requestedWeight;
+    }
+
     // When the primary typeface is not found, find a fallback typeface for font metrics used by
     // special characters (newline, tab) that do not go through per-character glyph fallback.
     auto metricsTypeface = primaryTypeface;
@@ -391,10 +404,10 @@ class TextLayoutContext {
 
     float effectiveFontSize = glyph.fontSize * textScale;
     tgfx::Font primaryFont(primaryTypeface, effectiveFontSize);
-    primaryFont.setFauxBold(glyph.fauxBold);
+    primaryFont.setFauxBold(fauxBold);
     primaryFont.setFauxItalic(glyph.fauxItalic);
     tgfx::Font metricsFont(metricsTypeface, effectiveFontSize);
-    metricsFont.setFauxBold(glyph.fauxBold);
+    metricsFont.setFauxBold(fauxBold);
     metricsFont.setFauxItalic(glyph.fauxItalic);
     float currentX = 0;
     const std::string& content = glyph.text;

--- a/src/pagx/html/importer/HTMLBoxAttributes.h
+++ b/src/pagx/html/importer/HTMLBoxAttributes.h
@@ -40,8 +40,8 @@ static constexpr const char* HTML_DEFAULT_FONT_FAMILY = "Arial";
 
 /**
  * Default font style/variant name written to every imported `Text` node. The synthesis in
- * `ResolveFontStyleSynthesis` leaves the style label empty for the plain base face (bold / italic
- * are carried by `fauxBold` / `fauxItalic`); this constant substitutes the canonical "Regular"
+ * `ResolveFontStyleSynthesis` leaves the style label empty for the plain Regular-weight upright
+ * face (italic is carried by `fauxItalic`); this constant substitutes the canonical "Regular"
  * name so every HTML-imported `Text` node always carries a concrete `fontStyle`.
  */
 static constexpr const char* HTML_DEFAULT_FONT_STYLE = "Regular";
@@ -74,12 +74,13 @@ struct HTMLInheritedStyle {
   std::string fontSize = {};
   std::string fontWeight = {};
   std::string fontStyle = {};
-  std::string fontStyleName = {};  // real-face style label, e.g. "Light" / "Medium" / ""
-  // Synthetic weight / slant the renderer must emboss on top of the resolved face. Set by
-  // `resolveInheritedStyle` for bold (CSS weight >= 600) and italic/oblique requests whose axis is
-  // dropped from `fontStyleName` (see `ResolveFontStyleSynthesis`). Carried through to
-  // `Text::fauxBold` / `Text::fauxItalic` so authored weight / slant survives even when the styled
-  // web face is not installed on the render host.
+  std::string fontStyleName = {};  // real-face style label, e.g. "Light" / "Bold" / "Black" / ""
+  // Synthetic slant the renderer must emboss on top of the resolved face. Set by
+  // `resolveInheritedStyle` for italic/oblique requests, whose axis is dropped from `fontStyleName`
+  // (see `ResolveFontStyleSynthesis`) and carried through to `Text::fauxItalic` so the authored
+  // slant survives even when the styled italic face is not installed on the render host. The weight
+  // axis is never synthesised (it stays in `fontStyleName` as a real-face keyword), so `fauxBold`
+  // is always false here.
   bool fauxBold = false;
   bool fauxItalic = false;
   std::string letterSpacing = {};

--- a/src/pagx/html/importer/HTMLBoxAttributes.h
+++ b/src/pagx/html/importer/HTMLBoxAttributes.h
@@ -78,9 +78,10 @@ struct HTMLInheritedStyle {
   // Synthetic slant the renderer must emboss on top of the resolved face. Set by
   // `resolveInheritedStyle` for italic/oblique requests, whose axis is dropped from `fontStyleName`
   // (see `ResolveFontStyleSynthesis`) and carried through to `Text::fauxItalic` so the authored
-  // slant survives even when the styled italic face is not installed on the render host. The weight
-  // axis is never synthesised (it stays in `fontStyleName` as a real-face keyword), so `fauxBold`
-  // is always false here.
+  // slant survives even when the styled italic face is not installed on the render host. The
+  // importer never pre-synthesises the weight axis: it stays in `fontStyleName` as a real-face
+  // keyword, so `fauxBold` is false here. TextLayout may add faux bold later if font lookup resolves
+  // a face that is lighter than requested.
   bool fauxBold = false;
   bool fauxItalic = false;
   std::string letterSpacing = {};

--- a/src/pagx/html/importer/HTMLElementEmitter.cpp
+++ b/src/pagx/html/importer/HTMLElementEmitter.cpp
@@ -697,8 +697,8 @@ void HTMLParserContext::applyMaskOrClip(Layer* layer, const HTMLBoxAttributes& b
   float intrinsicH = svgDoc->height;
 
   // The mask SVG produces one or more content layers (a single drawn shape in the common case).
-  // Wrap them under one invisible, layout-excluded mask layer so a multi-shape clip-path also
-  // works, then transplant every node from the temporary SVG document into ours.
+  // Wrap them under one layout-excluded mask layer so a multi-shape clip-path also works, then
+  // transplant every node from the temporary SVG document into ours.
   Layer* maskLayer = nullptr;
   if (svgDoc->layers.size() == 1) {
     maskLayer = svgDoc->layers[0];
@@ -708,7 +708,6 @@ void HTMLParserContext::applyMaskOrClip(Layer* layer, const HTMLBoxAttributes& b
       maskLayer->children.push_back(l);
     }
   }
-  maskLayer->visible = false;
   maskLayer->includeInLayout = false;
   // CSS `mask-size` / `mask-position` scale and offset the intrinsic mask box onto the masked
   // element; replay that transform onto the mask layer. Contour clip-paths are framed to the box
@@ -730,9 +729,9 @@ void HTMLParserContext::applyMaskOrClip(Layer* layer, const HTMLBoxAttributes& b
   layer->mask = maskLayer;
   layer->maskType = maskType;
   // The mask layer must be reachable in the display list for the renderer's mask lookup, and must
-  // share the masked layer's local coordinate origin. Adding it as an invisible, layout-excluded
-  // child satisfies both: it is walked by LayerBuilder but neither drawn (maskOwner is set) nor
-  // laid out (includeInLayout is false).
+  // share the masked layer's local coordinate origin. Adding it as a layout-excluded child
+  // satisfies both: it is walked by LayerBuilder but neither drawn (maskOwner is set on the tgfx
+  // side) nor laid out (includeInLayout is false).
   layer->children.push_back(maskLayer);
 }
 
@@ -767,7 +766,6 @@ void HTMLParserContext::applyRoundedOverflowClip(Layer* layer, const HTMLBoxAttr
   // resolved by layout. A Contour mask reads only the shape's coverage, clipping descendants to
   // the rounded outline instead of the layer's rectangle.
   auto* maskLayer = _document->makeNode<Layer>();
-  maskLayer->visible = false;
   maskLayer->includeInLayout = false;
   maskLayer->percentWidth = 100.0f;
   maskLayer->percentHeight = 100.0f;
@@ -782,8 +780,8 @@ void HTMLParserContext::applyRoundedOverflowClip(Layer* layer, const HTMLBoxAttr
   // The rounded mask now performs the clip; drop the rectangular scrollRect so it does not also
   // square off the corners the mask just rounded.
   layer->clipToBounds = false;
-  // Invisible, layout-excluded child so it shares the masked layer's local coordinate origin and
-  // stays reachable by the renderer's mask lookup (mirrors `applyMaskOrClip`).
+  // Layout-excluded child so it shares the masked layer's local coordinate origin and stays
+  // reachable by the renderer's mask lookup (mirrors `applyMaskOrClip`).
   layer->children.push_back(maskLayer);
 }
 

--- a/src/pagx/html/importer/HTMLParserContext.h
+++ b/src/pagx/html/importer/HTMLParserContext.h
@@ -124,7 +124,7 @@ class HTMLParserContext {
   // equivalent SVG geometry — and attaches it to `layer` as `layer->mask` / `maskType`
   // (the inverse of `HTMLWriter::writeMaskCSS` / `writeClipDef`). The mask geometry SVG is parsed
   // through `SVGImporter`, and its nodes are transplanted into `_document`. The mask layer is added
-  // as an invisible, layout-excluded child of `layer` so it shares the masked layer's local
+  // as a layout-excluded child of `layer` so it shares the masked layer's local
   // coordinate space and is reachable by the renderer's mask lookup. No-op when the box carries
   // neither a mask nor a clip-path reference. `box` supplies the masked layer's resolved size used
   // to frame a contour clip-path SVG.

--- a/src/pagx/html/importer/HTMLStyleCascade.cpp
+++ b/src/pagx/html/importer/HTMLStyleCascade.cpp
@@ -548,8 +548,8 @@ HTMLInheritedStyle HTMLStyleCascade::resolveInheritedStyle(const std::shared_ptr
   // resolves plus the synthetic (faux) italic axis the renderer embosses on top. The weight axis
   // is always written as a real-face keyword (Bold / SemiBold / Black) so the renderer resolves the
   // authored heavy face when it is installed or embedded and preserves the SemiBold / Bold / Black
-  // distinction, falling back to host faux emboldening only for a missing face. Italic stays a faux
-  // flag so an oblique slant survives when the styled italic face is unavailable.
+  // distinction. TextLayout adds faux emboldening only when font lookup resolves a lighter face.
+  // Italic stays a faux flag so an oblique slant survives when the styled italic face is unavailable.
   FontStyleSynthesis fontSynthesis = ResolveFontStyleSynthesis(out.fontWeight, out.fontStyle);
   out.fontStyleName = fontSynthesis.fontStyleName;
   out.fauxBold = fontSynthesis.fauxBold;

--- a/src/pagx/html/importer/HTMLStyleCascade.cpp
+++ b/src/pagx/html/importer/HTMLStyleCascade.cpp
@@ -545,11 +545,11 @@ HTMLInheritedStyle HTMLStyleCascade::resolveInheritedStyle(const std::shared_ptr
     out.textFillImage = ownBgImage;
   }
   // Split the CSS font-weight / font-style request into the real-face style label PAGX Text
-  // resolves plus the synthetic (faux) axes the renderer embosses on top. Bold (weight >= 600) and
-  // italic/oblique are baked as faux flags and dropped from the label so an uninstalled web face
-  // (e.g. "Noto Sans SC Black Italic") still renders at the authored weight and slant instead of
-  // collapsing to a thin upright fallback. Lighter weights (Light / Medium) cannot be synthesised
-  // and stay in the label.
+  // resolves plus the synthetic (faux) italic axis the renderer embosses on top. The weight axis
+  // is always written as a real-face keyword (Bold / SemiBold / Black) so the renderer resolves the
+  // authored heavy face when it is installed or embedded and preserves the SemiBold / Bold / Black
+  // distinction, falling back to host faux emboldening only for a missing face. Italic stays a faux
+  // flag so an oblique slant survives when the styled italic face is unavailable.
   FontStyleSynthesis fontSynthesis = ResolveFontStyleSynthesis(out.fontWeight, out.fontStyle);
   out.fontStyleName = fontSynthesis.fontStyleName;
   out.fauxBold = fontSynthesis.fauxBold;

--- a/src/pagx/html/importer/HTMLTextFragmentBuilder.h
+++ b/src/pagx/html/importer/HTMLTextFragmentBuilder.h
@@ -58,10 +58,11 @@ class HTMLTextFragmentBuilder {
   struct TextFragment {
     std::string text = {};
     std::string fontFamily = {};
-    std::string fontStyleName = {};  // real-face style label, e.g. "Light" / "Medium" / ""
-    // Synthetic weight / slant baked in from the CSS request (see `ResolveFontStyleSynthesis`).
-    // Surface as `Text::fauxBold` / `Text::fauxItalic` so authored bold / italic survives a
-    // missing styled face on the render host.
+    std::string fontStyleName = {};  // real-face style label, e.g. "Light" / "Bold" / "Black" / ""
+    // Synthetic slant baked in from the CSS request (see `ResolveFontStyleSynthesis`). Surfaces as
+    // `Text::fauxItalic` so an authored oblique slant survives a missing styled italic face on the
+    // render host. The weight axis is never synthesised (it stays in `fontStyleName`), so
+    // `fauxBold` is always false.
     bool fauxBold = false;
     bool fauxItalic = false;
     float fontSize = HTML_DEFAULT_FONT_SIZE;

--- a/src/pagx/html/importer/HTMLTextFragmentBuilder.h
+++ b/src/pagx/html/importer/HTMLTextFragmentBuilder.h
@@ -61,8 +61,9 @@ class HTMLTextFragmentBuilder {
     std::string fontStyleName = {};  // real-face style label, e.g. "Light" / "Bold" / "Black" / ""
     // Synthetic slant baked in from the CSS request (see `ResolveFontStyleSynthesis`). Surfaces as
     // `Text::fauxItalic` so an authored oblique slant survives a missing styled italic face on the
-    // render host. The weight axis is never synthesised (it stays in `fontStyleName`), so
-    // `fauxBold` is always false.
+    // render host. The importer does not pre-synthesise the weight axis (it stays in
+    // `fontStyleName`), so `fauxBold` is false here; TextLayout may add it after resolving a lighter
+    // face at runtime.
     bool fauxBold = false;
     bool fauxItalic = false;
     float fontSize = HTML_DEFAULT_FONT_SIZE;

--- a/src/pagx/html/importer/HTMLValueParser.cpp
+++ b/src/pagx/html/importer/HTMLValueParser.cpp
@@ -643,10 +643,10 @@ bool IsRadialExtentKeyword(const std::string& token) {
 // edges.
 float CircleExtentRadiusPx(const std::string& keyword, float cxPx, float cyPx, float boxWidth,
                            float boxHeight) {
-  float left = cxPx;
-  float right = boxWidth - cxPx;
-  float top = cyPx;
-  float bottom = boxHeight - cyPx;
+  float left = std::abs(cxPx);
+  float right = std::abs(boxWidth - cxPx);
+  float top = std::abs(cyPx);
+  float bottom = std::abs(boxHeight - cyPx);
   float dx = std::max(left, right);
   float dy = std::max(top, bottom);
   if (keyword == "closest-side") {
@@ -961,10 +961,11 @@ void HTMLValueParser::parseRadialDescriptor(const std::string& descriptor, float
     }
   }
 
-  // A circle keeps one uniform radius; an ellipse (explicit, or the shapeless default) stretches
-  // per axis. Detected up front because extent-keyword and omitted sizes resolve the radius from
-  // the center, which the position pass below establishes first.
-  bool isCircle = explicitCircle || (!explicitEllipse && sizeTokens.size() == 1);
+  // A single explicit length implies a circle. An extent keyword without a shape still uses CSS's
+  // default ellipse, so it must not enter the circle-only pixel-radius path below.
+  bool implicitCircle =
+      !explicitEllipse && sizeTokens.size() == 1 && !IsRadialExtentKeyword(sizeTokens[0]);
+  bool isCircle = explicitCircle || implicitCircle;
 
   // Position: `at <x> <y>`. Axis-locked keywords (left/right -> x, top/bottom -> y) are assigned
   // first so author order is irrelevant (`at top left` == `at left top`); the remaining `center`
@@ -1156,7 +1157,8 @@ bool HTMLValueParser::finaliseGradientStops(GradientStops& stops) {
   // interpolates unpremultiplied, where a keyword `transparent` carries black RGB and would drag
   // the ramp toward grey/black. Rewrite each fully transparent stop's RGB to that of its nearest
   // opaque neighbour (alpha kept at 0) so the unpremultiplied interpolation matches CSS. A stop
-  // between two opaque colours prefers the earlier neighbour, matching the premultiplied midpoint.
+  // between two opaque colours prefers the earlier neighbour to avoid tinting the visible,
+  // higher-alpha side of the fade.
   for (size_t i = 0; i < stops.size(); ++i) {
     if (stops[i].second.alpha > 0.0f) continue;
     size_t donor = stops.size();

--- a/src/pagx/html/importer/HTMLValueParser.cpp
+++ b/src/pagx/html/importer/HTMLValueParser.cpp
@@ -627,6 +627,43 @@ Color SampleRepeatingPeriod(const HTMLValueParser::GradientStops& stops, float f
   return stops.back().second;
 }
 
+// CSS radial extent keywords control how far the ending shape reaches; they carry no scalar radius
+// in the token itself (the radius is derived from the center and box). Returns true for any of the
+// four keywords so the caller can compute the corresponding px radius from the center position.
+bool IsRadialExtentKeyword(const std::string& token) {
+  return token == "closest-side" || token == "closest-corner" || token == "farthest-side" ||
+         token == "farthest-corner";
+}
+
+// Computes the px radius of a CSS `circle` ending shape for the given extent keyword, measured from
+// a center at (cxPx, cyPx) within a (0,0)-(boxWidth,boxHeight) box. An empty/unknown keyword
+// defaults to `farthest-corner`, matching CSS when the size is omitted. `closest-corner` /
+// `farthest-corner` are the Euclidean distances to the nearest / farthest box corner;
+// `closest-side` / `farthest-side` are the min / max of the perpendicular distances to the four
+// edges.
+float CircleExtentRadiusPx(const std::string& keyword, float cxPx, float cyPx, float boxWidth,
+                           float boxHeight) {
+  float left = cxPx;
+  float right = boxWidth - cxPx;
+  float top = cyPx;
+  float bottom = boxHeight - cyPx;
+  float dx = std::max(left, right);
+  float dy = std::max(top, bottom);
+  if (keyword == "closest-side") {
+    return std::min(std::min(left, right), std::min(top, bottom));
+  }
+  if (keyword == "farthest-side") {
+    return std::max(dx, dy);
+  }
+  if (keyword == "closest-corner") {
+    float nx = std::min(left, right);
+    float ny = std::min(top, bottom);
+    return std::sqrt(nx * nx + ny * ny);
+  }
+  // farthest-corner (also the default when the size is omitted).
+  return std::sqrt(dx * dx + dy * dy);
+}
+
 }  // namespace
 
 ColorSource* HTMLValueParser::parseRepeatingLinearGradientPattern(const std::string& value,
@@ -924,24 +961,10 @@ void HTMLValueParser::parseRadialDescriptor(const std::string& descriptor, float
     }
   }
 
-  // Radius: the exporter writes `rx = radius * boxWidth` (and an ellipse's `ry` is implied by the
-  // box height under PAGX's single-radius + fitsToGeometry model), so a length token divided by
-  // boxWidth recovers the normalised radius. A bare `<pct>%` is already box-relative. Track whether
-  // the radius came from an explicit px length so a circle on a non-square box can later switch to
-  // the fitsToGeometry=false pixel model (see below).
-  bool radiusFromPxLength = false;
-  if (!sizeTokens.empty() && boxWidth > 0) {
-    float radius = resolveRadialLength(sizeTokens[0], boxWidth);
-    if (!std::isnan(radius)) {
-      grad->radius = radius;
-      radiusFromPxLength = !sizeTokens[0].empty() && sizeTokens[0].back() != '%';
-    } else {
-      // Extent keywords (closest-side / farthest-corner / ...) have no scalar PAGX radius; keep
-      // the box-filling default and surface a diagnostic instead of silently mis-sizing.
-      _diagnostics.warn("html: radial-gradient size '" + sizeTokens[0] +
-                        "' not supported; using box-filling radius");
-    }
-  }
+  // A circle keeps one uniform radius; an ellipse (explicit, or the shapeless default) stretches
+  // per axis. Detected up front because extent-keyword and omitted sizes resolve the radius from
+  // the center, which the position pass below establishes first.
+  bool isCircle = explicitCircle || (!explicitEllipse && sizeTokens.size() == 1);
 
   // Position: `at <x> <y>`. Axis-locked keywords (left/right -> x, top/bottom -> y) are assigned
   // first so author order is irrelevant (`at top left` == `at left top`); the remaining `center`
@@ -972,15 +995,58 @@ void HTMLValueParser::parseRadialDescriptor(const std::string& descriptor, float
   if (!std::isnan(cx)) grad->center.x = cx;
   if (!std::isnan(cy)) grad->center.y = cy;
 
-  // A CSS `circle <r>px` keeps a single uniform radius regardless of box aspect ratio. PAGX's
-  // default fitsToGeometry=true model stretches the normalised radius by box width and height
-  // independently, so on a non-square box it would render the circle as an ellipse. Switch such a
-  // circle to the fitsToGeometry=false pixel model (center/radius in the geometry's local px
-  // space, where the box spans (0,0)-(boxWidth,boxHeight)) so the radius stays isotropic. Square
-  // boxes, ellipses, and percentage/extent sizes keep the compact normalised representation.
-  bool isCircle = explicitCircle || (!explicitEllipse && sizeTokens.size() == 1);
-  if (isCircle && radiusFromPxLength && boxWidth > 0 && boxHeight > 0 &&
-      std::abs(boxWidth - boxHeight) > 0.01f) {
+  // Radius: a length token divided by boxWidth recovers the normalised radius (a bare `<pct>%` is
+  // already box-relative); track whether it came from an explicit px length so a circle on a
+  // non-square box can later switch to the fitsToGeometry=false pixel model. An extent keyword
+  // (or, for a circle, an omitted size — CSS defaults it to farthest-corner) has no scalar radius
+  // in the token, so a circle derives the px radius from its center and the box; `circleExtentPx`
+  // then routes it through the pixel model below since the value is already in px.
+  bool radiusFromPxLength = false;
+  bool circleExtentPx = false;
+  if (!sizeTokens.empty() && boxWidth > 0) {
+    float radius = resolveRadialLength(sizeTokens[0], boxWidth);
+    if (!std::isnan(radius)) {
+      grad->radius = radius;
+      radiusFromPxLength = !sizeTokens[0].empty() && sizeTokens[0].back() != '%';
+    } else if (IsRadialExtentKeyword(sizeTokens[0])) {
+      // Only an explicit `circle` maps cleanly to PAGX's single radius. An implicit shape with an
+      // extent keyword (or an explicit ellipse) is an ellipse in CSS and needs per-axis radii the
+      // model can't represent, so keep the box-filling default and surface a diagnostic.
+      if (explicitCircle && boxHeight > 0) {
+        grad->radius = CircleExtentRadiusPx(sizeTokens[0], grad->center.x * boxWidth,
+                                            grad->center.y * boxHeight, boxWidth, boxHeight);
+        circleExtentPx = true;
+      } else {
+        _diagnostics.warn("html: radial-gradient size '" + sizeTokens[0] +
+                          "' not supported; using box-filling radius");
+      }
+    } else {
+      _diagnostics.warn("html: radial-gradient size '" + sizeTokens[0] +
+                        "' not supported; using box-filling radius");
+    }
+  } else if (sizeTokens.empty() && explicitCircle && boxWidth > 0 && boxHeight > 0) {
+    // A `circle` with no size defaults to farthest-corner in CSS.
+    grad->radius = CircleExtentRadiusPx("", grad->center.x * boxWidth, grad->center.y * boxHeight,
+                                        boxWidth, boxHeight);
+    circleExtentPx = true;
+  }
+
+  // Keep a circle's single radius isotropic. The default fitsToGeometry=true model scales the
+  // normalised radius by box width and height independently, so on a non-square box it would render
+  // a circle as an ellipse; such circles switch to the fitsToGeometry=false pixel model (center /
+  // radius in the geometry's local px space, where the box spans (0,0)-(boxWidth,boxHeight)). On a
+  // square box the normalised model is already isotropic, so keep the compact representation:
+  // extent/omitted sizes carry a px radius that is normalised back by boxWidth, while an explicit
+  // px length was already normalised above. Ellipses and percentage sizes stay normalised too.
+  bool nonSquare = boxWidth > 0 && boxHeight > 0 && std::abs(boxWidth - boxHeight) > 0.01f;
+  if (circleExtentPx) {
+    if (nonSquare) {
+      grad->center = {grad->center.x * boxWidth, grad->center.y * boxHeight};
+      grad->fitsToGeometry = false;
+    } else {
+      grad->radius = grad->radius / boxWidth;
+    }
+  } else if (isCircle && radiusFromPxLength && nonSquare) {
     grad->center = {grad->center.x * boxWidth, grad->center.y * boxHeight};
     grad->radius = grad->radius * boxWidth;
     grad->fitsToGeometry = false;
@@ -1082,6 +1148,37 @@ bool HTMLValueParser::finaliseGradientStops(GradientStops& stops) {
     float nextOffset = next < stops.size() ? stops[next].first : 1.0f;
     float steps = static_cast<float>(next - (i - 1));
     stops[i].first = prevOffset + (nextOffset - prevOffset) / steps;
+  }
+
+  // CSS interpolates gradient stops in premultiplied-alpha space, so a `transparent` (or any
+  // alpha=0) stop contributes only its neighbour's colour as the alpha fades — e.g. a
+  // `rgba(220,210,255,0.4) -> transparent` ramp stays purple while vanishing. The renderer
+  // interpolates unpremultiplied, where a keyword `transparent` carries black RGB and would drag
+  // the ramp toward grey/black. Rewrite each fully transparent stop's RGB to that of its nearest
+  // opaque neighbour (alpha kept at 0) so the unpremultiplied interpolation matches CSS. A stop
+  // between two opaque colours prefers the earlier neighbour, matching the premultiplied midpoint.
+  for (size_t i = 0; i < stops.size(); ++i) {
+    if (stops[i].second.alpha > 0.0f) continue;
+    size_t donor = stops.size();
+    for (size_t back = i; back-- > 0;) {
+      if (stops[back].second.alpha > 0.0f) {
+        donor = back;
+        break;
+      }
+    }
+    if (donor == stops.size()) {
+      for (size_t fwd = i + 1; fwd < stops.size(); ++fwd) {
+        if (stops[fwd].second.alpha > 0.0f) {
+          donor = fwd;
+          break;
+        }
+      }
+    }
+    if (donor != stops.size()) {
+      stops[i].second.red = stops[donor].second.red;
+      stops[i].second.green = stops[donor].second.green;
+      stops[i].second.blue = stops[donor].second.blue;
+    }
   }
   return true;
 }

--- a/src/pagx/utils/CSSFontStyle.cpp
+++ b/src/pagx/utils/CSSFontStyle.cpp
@@ -134,20 +134,18 @@ FontStyleSynthesis ResolveFontStyleSynthesis(const std::string& cssFontWeight,
                                              const std::string& cssFontStyle) {
   FontStyleSynthesis out;
   int numericWeight = CssFontWeightToNumeric(cssFontWeight);
-  bool italic = IsItalicCssStyle(cssFontStyle);
-  // Threshold mirrors CSS bold synthesis: SemiBold-or-heavier (>= 600) is treated as a faux-bold
-  // request because the renderer's faux emboldening is a single fixed step and cannot distinguish
-  // SemiBold from Black anyway.
-  out.fauxBold = numericWeight >= 600;
-  out.fauxItalic = italic;
-  // Keep only the real-face axes in the style label: a synthesised axis is dropped so the renderer
-  // resolves a base (Regular / lighter) face and faux adds the missing weight / slant on top,
-  // instead of resolving the styled face and doubling up.
-  const char* weightKeyword =
-      out.fauxBold ? nullptr : WeightKeywordForRoundedHundreds(numericWeight);
+  // The weight axis is always carried as a real-face style label (Bold / SemiBold / Black / etc.),
+  // not synthesised: this lets the renderer resolve the authored heavy face when it is installed or
+  // embedded, and only fall back to faux emboldening (applied by the render host on a missing face)
+  // without collapsing SemiBold / Bold / Black into one indistinguishable step.
+  out.fauxBold = false;
+  const char* weightKeyword = WeightKeywordForRoundedHundreds(numericWeight);
   if (weightKeyword) {
     out.fontStyleName = weightKeyword;
   }
+  // Italic is kept as a faux axis: an oblique slant can be synthesised on top of any upright face,
+  // so it survives even when the styled italic face is unavailable.
+  out.fauxItalic = IsItalicCssStyle(cssFontStyle);
   return out;
 }
 

--- a/src/pagx/utils/CSSFontStyle.cpp
+++ b/src/pagx/utils/CSSFontStyle.cpp
@@ -135,9 +135,9 @@ FontStyleSynthesis ResolveFontStyleSynthesis(const std::string& cssFontWeight,
   FontStyleSynthesis out;
   int numericWeight = CssFontWeightToNumeric(cssFontWeight);
   // The weight axis is always carried as a real-face style label (Bold / SemiBold / Black / etc.),
-  // not synthesised: this lets the renderer resolve the authored heavy face when it is installed or
-  // embedded, and only fall back to faux emboldening (applied by the render host on a missing face)
-  // without collapsing SemiBold / Bold / Black into one indistinguishable step.
+  // not pre-synthesised: this lets TextLayout resolve the authored heavy face when it is installed
+  // or embedded, then apply faux emboldening only if the resolved face is lighter than requested.
+  // This preserves distinct face selection without losing weight when a face is missing.
   out.fauxBold = false;
   const char* weightKeyword = WeightKeywordForRoundedHundreds(numericWeight);
   if (weightKeyword) {

--- a/src/pagx/utils/CSSFontStyle.h
+++ b/src/pagx/utils/CSSFontStyle.h
@@ -37,27 +37,26 @@ namespace pagx {
 std::string ResolveFontStyleName(const std::string& cssFontWeight, const std::string& cssFontStyle);
 
 // Splits a CSS font-weight / font-style request into the real face style the renderer should
-// resolve plus the synthetic (faux) axes it must emboss on top. This lets an importer bake the
-// authored weight / slant into a `.pagx` without relying on render-time face introspection:
-// uninstalled web faces (the common case for HTML / SVG imports such as "Noto Sans SC Black
-// Italic") still render at the authored weight and slant via faux synthesis.
+// resolve plus the synthetic (faux) italic axis it may emboss on top.
 //
-// The synthesised axes are *removed* from `fontStyleName` rather than kept alongside the faux
-// flags. A host that does ship the real heavy / italic face must not be emboldened twice
-// (faux-on-top-of-real, which the renderer layers additively), and keeping the styled name would
-// trigger exactly that whenever the styled face is resolvable. Stripping it makes the rendered
-// result identical whether or not the styled face is installed. Weights below the bold threshold
-// (Thin / ExtraLight / Light / Medium) cannot be synthesised — faux only adds weight, never
-// removes it — so those keywords are preserved in `fontStyleName` and carry no faux flag.
+// The weight axis is always emitted as a real-face style label (Bold / SemiBold / Black / etc. per
+// the numeric weight rounded to the nearest hundred; 400 leaves the weight portion empty), never as
+// a faux flag. This lets the renderer resolve the authored heavy face when it is installed or
+// embedded (preserving the distinction between SemiBold, Bold and Black) and only fall back to host
+// faux emboldening for a genuinely missing face, instead of always synthesising a single fixed step
+// on a Regular base.
 //
-// Examples (threshold mirrors CSS bold synthesis at weight >= 600):
-//   ("900", "italic") -> {fontStyleName: "",       fauxBold: true,  fauxItalic: true}
-//   ("700", "")       -> {fontStyleName: "",       fauxBold: true,  fauxItalic: false}
-//   ("600", "italic") -> {fontStyleName: "",       fauxBold: true,  fauxItalic: true}
-//   ("500", "italic") -> {fontStyleName: "Medium", fauxBold: false, fauxItalic: true}
-//   ("300", "")       -> {fontStyleName: "Light",  fauxBold: false, fauxItalic: false}
-//   ("400", "italic") -> {fontStyleName: "",       fauxBold: false, fauxItalic: true}
-//   ("400", "")       -> {fontStyleName: "",       fauxBold: false, fauxItalic: false}
+// Italic stays a synthetic axis (`fauxItalic`): an oblique slant can be synthesised on top of any
+// upright face, so it survives even when the styled italic face is unavailable.
+//
+// Examples:
+//   ("900", "italic") -> {fontStyleName: "Black",    fauxBold: false, fauxItalic: true}
+//   ("700", "")       -> {fontStyleName: "Bold",     fauxBold: false, fauxItalic: false}
+//   ("600", "italic") -> {fontStyleName: "SemiBold", fauxBold: false, fauxItalic: true}
+//   ("500", "italic") -> {fontStyleName: "Medium",   fauxBold: false, fauxItalic: true}
+//   ("300", "")       -> {fontStyleName: "Light",    fauxBold: false, fauxItalic: false}
+//   ("400", "italic") -> {fontStyleName: "",         fauxBold: false, fauxItalic: true}
+//   ("400", "")       -> {fontStyleName: "",         fauxBold: false, fauxItalic: false}
 struct FontStyleSynthesis {
   std::string fontStyleName = {};
   bool fauxBold = false;

--- a/src/pagx/utils/CSSFontStyle.h
+++ b/src/pagx/utils/CSSFontStyle.h
@@ -42,9 +42,10 @@ std::string ResolveFontStyleName(const std::string& cssFontWeight, const std::st
 // The weight axis is always emitted as a real-face style label (Bold / SemiBold / Black / etc. per
 // the numeric weight rounded to the nearest hundred; 400 leaves the weight portion empty), never as
 // a faux flag. This lets the renderer resolve the authored heavy face when it is installed or
-// embedded (preserving the distinction between SemiBold, Bold and Black) and only fall back to host
-// faux emboldening for a genuinely missing face, instead of always synthesising a single fixed step
-// on a Regular base.
+// embedded (preserving the distinction between SemiBold, Bold and Black). During layout, the
+// resolved face's actual weight is compared with this requested label and faux emboldening is added
+// only when the resolved face is lighter, instead of always synthesising a single fixed step on a
+// Regular base.
 //
 // Italic stays a synthetic axis (`fauxItalic`): an oblique slant can be synthesised on top of any
 // upright face, so it survives even when the styled italic face is unavailable.

--- a/test/src/PAGXCSSFontStyleTest.cpp
+++ b/test/src/PAGXCSSFontStyleTest.cpp
@@ -82,27 +82,27 @@ CLI_TEST(PAGXCSSFontStyleTest, ResolveName_WhitespaceAndCaseNormalised) {
   EXPECT_EQ(pagx::ResolveFontStyleName("  BOLD  ", "  ITALIC "), "Bold Italic");
 }
 
-// ResolveFontStyleSynthesis: splits the request into a real-face label plus faux axes. The bold
-// synthesis threshold is weight >= 600; weights below stay as keywords with no faux flag.
+// ResolveFontStyleSynthesis: splits the request into a real-face label plus a faux italic axis. The
+// weight axis is always a real-face keyword (never faux); only italic is synthesised.
 
-CLI_TEST(PAGXCSSFontStyleTest, Synthesis_BlackItalicIsAllFaux) {
+CLI_TEST(PAGXCSSFontStyleTest, Synthesis_BlackItalicKeepsRealWeightFauxItalic) {
   auto out = pagx::ResolveFontStyleSynthesis("900", "italic");
-  EXPECT_EQ(out.fontStyleName, "");
-  EXPECT_TRUE(out.fauxBold);
+  EXPECT_EQ(out.fontStyleName, "Black");
+  EXPECT_FALSE(out.fauxBold);
   EXPECT_TRUE(out.fauxItalic);
 }
 
-CLI_TEST(PAGXCSSFontStyleTest, Synthesis_BoldOnly) {
+CLI_TEST(PAGXCSSFontStyleTest, Synthesis_BoldKeepsRealWeight) {
   auto out = pagx::ResolveFontStyleSynthesis("700", "");
-  EXPECT_EQ(out.fontStyleName, "");
-  EXPECT_TRUE(out.fauxBold);
+  EXPECT_EQ(out.fontStyleName, "Bold");
+  EXPECT_FALSE(out.fauxBold);
   EXPECT_FALSE(out.fauxItalic);
 }
 
-CLI_TEST(PAGXCSSFontStyleTest, Synthesis_SemiBoldThresholdIsFauxBold) {
+CLI_TEST(PAGXCSSFontStyleTest, Synthesis_SemiBoldKeepsRealWeightFauxItalic) {
   auto out = pagx::ResolveFontStyleSynthesis("600", "italic");
-  EXPECT_EQ(out.fontStyleName, "");
-  EXPECT_TRUE(out.fauxBold);
+  EXPECT_EQ(out.fontStyleName, "SemiBold");
+  EXPECT_FALSE(out.fauxBold);
   EXPECT_TRUE(out.fauxItalic);
 }
 

--- a/test/src/PAGXCliTest.cpp
+++ b/test/src/PAGXCliTest.cpp
@@ -2707,6 +2707,46 @@ CLI_TEST(PAGXCliTest, Resolve_MultiLayerPreservesIsolation) {
   EXPECT_TRUE(RenderAndCompare({"render", pagxPath}, "PAGXCliTest/ImportResolve_MultiLayer"));
 }
 
+CLI_TEST(PAGXCliTest, Resolve_SkewSiblingKeepsAllLayers) {
+  // The first sibling has both a tiny scale and a real skew. Skew detection must be
+  // scale-independent, and one non-downgradable matrix must keep every sibling in children so
+  // contents/children paint ordering cannot reverse them.
+  auto pagxPath = CopyToTemp("import_resolve_skew_siblings.pagx", "resolve_skew_siblings.pagx");
+  auto ret = CallRun(pagx::cli::RunResolve, {"resolve", pagxPath});
+  EXPECT_EQ(ret, 0);
+
+  auto doc = pagx::PAGXImporter::FromFile(pagxPath);
+  ASSERT_NE(doc, nullptr);
+  ASSERT_EQ(doc->layers.size(), 1u);
+  auto* hostLayer = doc->layers[0];
+  EXPECT_TRUE(hostLayer->contents.empty());
+  ASSERT_EQ(hostLayer->children.size(), 2u);
+  EXPECT_FALSE(hostLayer->children[0]->matrix.isIdentity());
+  EXPECT_TRUE(hostLayer->children[1]->matrix.isIdentity());
+}
+
+CLI_TEST(PAGXCliTest, Resolve_TransformableSiblingMatricesBecomeGroups) {
+  auto pagxPath =
+      CopyToTemp("import_resolve_transformed_siblings.pagx", "resolve_transformed_siblings.pagx");
+  auto ret = CallRun(pagx::cli::RunResolve, {"resolve", pagxPath});
+  EXPECT_EQ(ret, 0);
+
+  auto doc = pagx::PAGXImporter::FromFile(pagxPath);
+  ASSERT_NE(doc, nullptr);
+  ASSERT_EQ(doc->layers.size(), 1u);
+  auto* hostLayer = doc->layers[0];
+  EXPECT_TRUE(hostLayer->children.empty());
+  ASSERT_EQ(hostLayer->contents.size(), 2u);
+  ASSERT_EQ(hostLayer->contents[0]->nodeType(), pagx::NodeType::Group);
+  auto* transformed = static_cast<pagx::Group*>(hostLayer->contents[0]);
+  EXPECT_FLOAT_EQ(transformed->position.x, 4.0f);
+  EXPECT_FLOAT_EQ(transformed->position.y, 5.0f);
+  EXPECT_FLOAT_EQ(transformed->rotation, 30.0f);
+  EXPECT_FLOAT_EQ(transformed->scale.x, 2.0f);
+  EXPECT_FLOAT_EQ(transformed->scale.y, 3.0f);
+  EXPECT_EQ(hostLayer->contents[1]->nodeType(), pagx::NodeType::Group);
+}
+
 CLI_TEST(PAGXCliTest, Resolve_DeduplicatesInlineSvgImageIds) {
   // Each inline <svg> is imported by its own SVGImporter, which restarts auto-generated id
   // numbering from scratch, so two unrelated <image> elements both become Image id="image1".

--- a/test/src/PAGXCliTest.cpp
+++ b/test/src/PAGXCliTest.cpp
@@ -38,6 +38,7 @@
 #include "pagx/PAGXExporter.h"
 #include "pagx/PAGXImporter.h"
 #include "pagx/nodes/Font.h"
+#include "pagx/nodes/Group.h"
 #include "pagx/nodes/Image.h"
 #include "pagx/nodes/ImagePattern.h"
 #include "tgfx/core/Bitmap.h"
@@ -2679,8 +2680,9 @@ CLI_TEST(PAGXCliTest, Resolve_MissingFile) {
 }
 
 CLI_TEST(PAGXCliTest, Resolve_MultiLayerPreservesIsolation) {
-  // Verifies that resolving an inline SVG with multiple elements preserves each SVG element
-  // in a separate painter scope, preventing painter accumulation bugs.
+  // Resolving an inline SVG with two sibling paths must preserve their common source depth:
+  // each path and its painter live in a separate peer Group. Flattening only the first path while
+  // grouping the second would make the output asymmetric and can change painter accumulation.
   auto pagxPath = CopyToTemp("import_resolve_multi_layer.pagx", "resolve_multi_layer.pagx");
   auto ret = CallRun(pagx::cli::RunResolve, {"resolve", pagxPath});
   EXPECT_EQ(ret, 0);
@@ -2691,14 +2693,15 @@ CLI_TEST(PAGXCliTest, Resolve_MultiLayerPreservesIsolation) {
 
   ASSERT_EQ(doc->layers.size(), 1u);
   auto* hostLayer = doc->layers[0];
-  EXPECT_FALSE(hostLayer->contents.empty());
-  size_t groupCount = 0;
+  EXPECT_TRUE(hostLayer->children.empty());
+  ASSERT_EQ(hostLayer->contents.size(), 2u);
   for (auto* element : hostLayer->contents) {
-    if (element->nodeType() == pagx::NodeType::Group) {
-      groupCount++;
-    }
+    ASSERT_EQ(element->nodeType(), pagx::NodeType::Group);
+    auto* group = static_cast<pagx::Group*>(element);
+    ASSERT_EQ(group->elements.size(), 2u);
+    EXPECT_EQ(group->elements[0]->nodeType(), pagx::NodeType::Path);
+    EXPECT_EQ(group->elements[1]->nodeType(), pagx::NodeType::Stroke);
   }
-  EXPECT_GE(groupCount, 1u);
 
   // Screenshot test: render the resolved file and compare against baseline.
   EXPECT_TRUE(RenderAndCompare({"render", pagxPath}, "PAGXCliTest/ImportResolve_MultiLayer"));

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -1199,6 +1199,27 @@ PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleExtentKeywordsUseDistanceFrom
   }
 }
 
+PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleClosestSideOutsideBoxUsesPositiveDistance) {
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:400px;height:400px">
+      <div style="width:400px;height:200px;background-image:radial-gradient(
+        circle closest-side at -80px -138px, #FFFFFF 0%, transparent 100%)"></div>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* div = doc->layers.front()->children.front();
+  auto* fill = FindElementOfType<pagx::Fill>(div);
+  ASSERT_NE(fill, nullptr);
+  auto* rg = As<pagx::RadialGradient>(fill->color);
+  ASSERT_NE(rg, nullptr);
+  // The center is outside the box, but closest-side is still the positive geometric distance to
+  // the nearest edge: min(80, 480, 138, 338) = 80px.
+  EXPECT_FALSE(rg->fitsToGeometry);
+  EXPECT_TRUE(NearlyEqual(rg->center.x, -80.0f, 0.01f));
+  EXPECT_TRUE(NearlyEqual(rg->center.y, -138.0f, 0.01f));
+  EXPECT_TRUE(NearlyEqual(rg->radius, 80.0f, 0.01f));
+}
+
 PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleExtentOnSquareBoxKeepsNormalised) {
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:200px;height:200px">
@@ -1327,8 +1348,9 @@ PAG_TEST(PAGXHTMLImporterTest, RoundedOverflowClipUsesContourMaskForNonImageChil
   // `border-radius: 50%` inscribes an ellipse, so the mask geometry is an Ellipse.
   auto* ellipse = FindElementOfType<pagx::Ellipse>(wrapper->mask);
   EXPECT_NE(ellipse, nullptr);
-  // The mask is an invisible, layout-excluded child that shares the container's coordinate space.
-  EXPECT_FALSE(wrapper->mask->visible);
+  // The mask stays visible at the PAGX level so the renderer can resolve it; mask ownership
+  // suppresses normal drawing. It is excluded only from layout.
+  EXPECT_TRUE(wrapper->mask->visible);
   EXPECT_FALSE(wrapper->mask->includeInLayout);
 }
 
@@ -8125,7 +8147,7 @@ PAG_TEST(PAGXHTMLImporterTest, BackgroundDataImageExplicitSizeUsesNativeDimensio
 
 // CSS `mask-image: url(data:image/svg+xml,...)` with `mask-mode: alpha` rebuilds an alpha mask
 // layer (the inverse of HTMLWriter::writeMaskCSS). The ellipse geometry round-trips and the mask
-// layer is attached invisibly and excluded from layout.
+// layer stays renderer-visible for mask lookup and is excluded from layout.
 PAG_TEST(PAGXHTMLImporterTest, MaskImageAlphaRebuildsMaskLayer) {
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:110px;height:110px">
@@ -8138,7 +8160,7 @@ PAG_TEST(PAGXHTMLImporterTest, MaskImageAlphaRebuildsMaskLayer) {
   auto* masked = doc->layers.front()->children.front();
   ASSERT_NE(masked->mask, nullptr);
   EXPECT_EQ(masked->maskType, pagx::MaskType::Alpha);
-  EXPECT_FALSE(masked->mask->visible);
+  EXPECT_TRUE(masked->mask->visible);
   EXPECT_FALSE(masked->mask->includeInLayout);
   auto* ellipse = FindElementOfType<pagx::Ellipse>(masked->mask);
   ASSERT_NE(ellipse, nullptr);

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -31,6 +31,7 @@
 #include "pagx/PAGXExporter.h"
 #include "pagx/PAGXImporter.h"
 #include "pagx/PAGXOptimizer.h"
+#include "pagx/TextLayout.h"
 #include "pagx/html/importer/HTMLDetail.h"
 #include "pagx/html/importer/HTMLDiagnosticSink.h"
 #include "pagx/html/importer/HTMLIdAllocator.h"
@@ -2992,8 +2993,8 @@ PAG_TEST(PAGXHTMLImporterTest, HeadingDefaultFontSizes) {
     ASSERT_NE(text, nullptr) << r.tag;
     EXPECT_FLOAT_EQ(text->fontSize, r.size) << r.tag;
     // Headings default to font-weight:bold, which is written as a real-face "Bold" style label so
-    // the renderer resolves the authored heavy face (falling back to host faux emboldening only for
-    // a missing face). No faux flag is baked into the Text node.
+    // the renderer resolves the authored heavy face. If that face is missing, TextLayout adds faux
+    // emboldening after lookup; no faux flag is baked into the Text node.
     EXPECT_EQ(text->fontStyle, "Bold") << r.tag;
     EXPECT_FALSE(text->fauxBold) << r.tag;
     EXPECT_FALSE(text->fauxItalic) << r.tag;
@@ -3016,6 +3017,39 @@ PAG_TEST(PAGXHTMLImporterTest, FontWeightNumericMapsToBold) {
   EXPECT_FALSE(text->fauxItalic);
 }
 
+PAG_TEST(PAGXHTMLImporterTest, MissingBoldFaceUsesRuntimeFauxBold) {
+  constexpr const char* family = "HTML Missing Bold Test";
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:200px;height:40px">
+      <span style="font-family:'HTML Missing Bold Test';font-weight:700">Heavy</span>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* text = FindElementOfType<pagx::Text>(doc->layers.front()->children.front());
+  ASSERT_NE(text, nullptr);
+  ASSERT_EQ(text->fontFamily, family);
+  ASSERT_EQ(text->fontStyle, "Bold");
+  ASSERT_FALSE(text->fauxBold);
+
+  // Register only a Regular face under the requested family. Font lookup therefore falls back to
+  // that face, and TextLayout must preserve the authored weight by enabling runtime faux bold on
+  // the glyph run without changing the imported Text node.
+  pagx::FontConfig fontConfig;
+  fontConfig.registerFont(ProjectPath::Absolute("resources/font/NotoSansSC-Regular.otf"), 0, family,
+                          "Regular");
+  doc->applyLayout(&fontConfig);
+
+  ASSERT_NE(text->glyphData, nullptr);
+  ASSERT_FALSE(text->glyphData->layoutRuns.empty());
+  for (const auto& run : text->glyphData->layoutRuns) {
+    auto typeface = run.font.getTypeface();
+    ASSERT_NE(typeface, nullptr);
+    EXPECT_EQ(typeface->fontStyle(), "Regular");
+    EXPECT_TRUE(run.font.isFauxBold());
+  }
+  EXPECT_FALSE(text->fauxBold);
+}
+
 PAG_TEST(PAGXHTMLImporterTest, FontWeight500MapsToMedium) {
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:200px;height:40px">
@@ -3025,7 +3059,8 @@ PAG_TEST(PAGXHTMLImporterTest, FontWeight500MapsToMedium) {
   ASSERT_NE(doc, nullptr);
   auto* text = FindElementOfType<pagx::Text>(doc->layers.front()->children.front());
   ASSERT_NE(text, nullptr);
-  // Medium (weight < 600) cannot be synthesised, so it stays a real-face style label with no faux.
+  // Medium stays a real-face style label so font lookup can select it precisely. The importer does
+  // not bake a faux flag; TextLayout decides at runtime whether the resolved face is too light.
   EXPECT_EQ(text->fontStyle, "Medium");
   EXPECT_FALSE(text->fauxBold);
   EXPECT_FALSE(text->fauxItalic);

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -1164,10 +1164,45 @@ PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleOmittedSizeUsesFarthestCorner
   EXPECT_TRUE(NearlyEqual(rg->radius, 335.41f, 0.5f));
 }
 
-PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleClosestSideExtent) {
+PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleExtentKeywordsUseDistanceFromCenter) {
+  struct ExtentCase {
+    const char* keyword;
+    float radius;
+  };
+  // Center (100,50) in a 400x200 box gives side distances 100, 300, 50, 150.
+  // Corner radii are therefore hypot(100,50) and hypot(300,150).
+  const std::vector<ExtentCase> cases = {
+      {"closest-side", 50.0f},
+      {"farthest-side", 300.0f},
+      {"closest-corner", 111.80f},
+      {"farthest-corner", 335.41f},
+  };
+  for (const auto& extent : cases) {
+    SCOPED_TRACE(extent.keyword);
+    auto html = std::string(
+                    "<html><body style=\"width:400px;height:400px\">"
+                    "<div style=\"width:400px;height:200px;background-image:radial-gradient("
+                    "circle ") +
+                extent.keyword +
+                " at 25% 25%, #FFFFFF 0%, transparent 100%)\"></div></body></html>";
+    auto doc = ParseFromString(html);
+    ASSERT_NE(doc, nullptr);
+    auto* div = doc->layers.front()->children.front();
+    auto* fill = FindElementOfType<pagx::Fill>(div);
+    ASSERT_NE(fill, nullptr);
+    auto* rg = As<pagx::RadialGradient>(fill->color);
+    ASSERT_NE(rg, nullptr);
+    EXPECT_FALSE(rg->fitsToGeometry);
+    EXPECT_TRUE(NearlyEqual(rg->center.x, 100.0f, 0.01f));
+    EXPECT_TRUE(NearlyEqual(rg->center.y, 50.0f, 0.01f));
+    EXPECT_TRUE(NearlyEqual(rg->radius, extent.radius, 0.01f));
+  }
+}
+
+PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleExtentOnSquareBoxKeepsNormalised) {
   auto doc = ParseFromString(R"HTML(
-    <html><body style="width:400px;height:400px">
-      <div style="width:400px;height:200px;background-image:radial-gradient(circle closest-side at 25% 50%, #FFFFFF 0%, transparent 100%)"></div>
+    <html><body style="width:200px;height:200px">
+      <div style="width:100px;height:100px;background-image:radial-gradient(circle farthest-corner at center, #FFFFFF 0%, transparent 100%)"></div>
     </body></html>
   )HTML");
   ASSERT_NE(doc, nullptr);
@@ -1176,12 +1211,34 @@ PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleClosestSideExtent) {
   ASSERT_NE(fill, nullptr);
   auto* rg = As<pagx::RadialGradient>(fill->color);
   ASSERT_NE(rg, nullptr);
-  // closest-side: center (100,100) on a 400x200 box; nearest edge distances are left=100,
-  // right=300, top=100, bottom=100, so the radius is 100px in the isotropic pixel model.
-  EXPECT_FALSE(rg->fitsToGeometry);
-  EXPECT_TRUE(NearlyEqual(rg->center.x, 100.0f, 0.5f));
-  EXPECT_TRUE(NearlyEqual(rg->center.y, 100.0f, 0.5f));
-  EXPECT_TRUE(NearlyEqual(rg->radius, 100.0f, 0.5f));
+  // A square box is already isotropic in geometry space, so the farthest-corner radius
+  // hypot(50,50) is stored as hypot(0.5,0.5) instead of switching to pixel coordinates.
+  EXPECT_TRUE(rg->fitsToGeometry);
+  EXPECT_TRUE(NearlyEqual(rg->center.x, 0.5f, 0.01f));
+  EXPECT_TRUE(NearlyEqual(rg->center.y, 0.5f, 0.01f));
+  EXPECT_TRUE(NearlyEqual(rg->radius, 0.7071f, 0.001f));
+}
+
+PAG_TEST(PAGXHTMLImporterTest, GradientTransparentStopsBorrowOpaqueNeighborRGB) {
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:100px;height:50px">
+      <div style="width:100px;height:50px;background-image:linear-gradient(
+        90deg, transparent 0%, rgba(220, 210, 255, 0.4) 50%, transparent 100%)"></div>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* div = doc->layers.front()->children.front();
+  auto* fill = FindElementOfType<pagx::Fill>(div);
+  ASSERT_NE(fill, nullptr);
+  auto* lg = As<pagx::LinearGradient>(fill->color);
+  ASSERT_NE(lg, nullptr);
+  ASSERT_EQ(lg->colorStops.size(), 3u);
+
+  // The renderer interpolates unpremultiplied colors. Giving both transparent edge stops the
+  // purple neighbor's RGB preserves a purple fade instead of blending through transparent black.
+  EXPECT_TRUE(ColorNear(lg->colorStops[0]->color, HexColor(0xDCD2FF, 0.0f)));
+  EXPECT_TRUE(ColorNear(lg->colorStops[1]->color, HexColor(0xDCD2FF, 0.4f)));
+  EXPECT_TRUE(ColorNear(lg->colorStops[2]->color, HexColor(0xDCD2FF, 0.0f)));
 }
 
 PAG_TEST(PAGXHTMLImporterTest, ConicGradientAngleOffset) {

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -1143,6 +1143,47 @@ PAG_TEST(PAGXHTMLImporterTest, RadialGradientEllipseOnNonSquareBoxKeepsNormalise
   EXPECT_TRUE(rg->fitsToGeometry);
 }
 
+PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleOmittedSizeUsesFarthestCorner) {
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:400px;height:400px">
+      <div style="width:400px;height:200px;background-image:radial-gradient(circle at 25% 25%, #FFFFFF 0%, transparent 100%)"></div>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* div = doc->layers.front()->children.front();
+  auto* fill = FindElementOfType<pagx::Fill>(div);
+  ASSERT_NE(fill, nullptr);
+  auto* rg = As<pagx::RadialGradient>(fill->color);
+  ASSERT_NE(rg, nullptr);
+  // A `circle` with no size defaults to farthest-corner: center (100,50) on a 400x200 box reaches
+  // the farthest corner (400,200) at sqrt(300^2 + 150^2) ~= 335.4px. The pixel model keeps the
+  // radius isotropic, so center/radius are stored in px with fitsToGeometry disabled.
+  EXPECT_FALSE(rg->fitsToGeometry);
+  EXPECT_TRUE(NearlyEqual(rg->center.x, 100.0f, 0.5f));
+  EXPECT_TRUE(NearlyEqual(rg->center.y, 50.0f, 0.5f));
+  EXPECT_TRUE(NearlyEqual(rg->radius, 335.41f, 0.5f));
+}
+
+PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleClosestSideExtent) {
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:400px;height:400px">
+      <div style="width:400px;height:200px;background-image:radial-gradient(circle closest-side at 25% 50%, #FFFFFF 0%, transparent 100%)"></div>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* div = doc->layers.front()->children.front();
+  auto* fill = FindElementOfType<pagx::Fill>(div);
+  ASSERT_NE(fill, nullptr);
+  auto* rg = As<pagx::RadialGradient>(fill->color);
+  ASSERT_NE(rg, nullptr);
+  // closest-side: center (100,100) on a 400x200 box; nearest edge distances are left=100,
+  // right=300, top=100, bottom=100, so the radius is 100px in the isotropic pixel model.
+  EXPECT_FALSE(rg->fitsToGeometry);
+  EXPECT_TRUE(NearlyEqual(rg->center.x, 100.0f, 0.5f));
+  EXPECT_TRUE(NearlyEqual(rg->center.y, 100.0f, 0.5f));
+  EXPECT_TRUE(NearlyEqual(rg->radius, 100.0f, 0.5f));
+}
+
 PAG_TEST(PAGXHTMLImporterTest, ConicGradientAngleOffset) {
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:50px;height:50px">

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -2969,16 +2969,16 @@ PAG_TEST(PAGXHTMLImporterTest, HeadingDefaultFontSizes) {
     auto* text = FindElementOfType<pagx::Text>(leaf);
     ASSERT_NE(text, nullptr) << r.tag;
     EXPECT_FLOAT_EQ(text->fontSize, r.size) << r.tag;
-    // Headings default to font-weight:bold, which is baked as faux bold (synthesised on a base
-    // face) rather than a "Bold" style label so the authored weight survives a missing styled face.
-    // The base-face label surfaces as the canonical "Regular" so every Text node carries a style.
-    EXPECT_EQ(text->fontStyle, "Regular") << r.tag;
-    EXPECT_TRUE(text->fauxBold) << r.tag;
+    // Headings default to font-weight:bold, which is written as a real-face "Bold" style label so
+    // the renderer resolves the authored heavy face (falling back to host faux emboldening only for
+    // a missing face). No faux flag is baked into the Text node.
+    EXPECT_EQ(text->fontStyle, "Bold") << r.tag;
+    EXPECT_FALSE(text->fauxBold) << r.tag;
     EXPECT_FALSE(text->fauxItalic) << r.tag;
   }
 }
 
-PAG_TEST(PAGXHTMLImporterTest, FontWeightNumericMapsToFauxBold) {
+PAG_TEST(PAGXHTMLImporterTest, FontWeightNumericMapsToBold) {
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:200px;height:40px">
       <span style="font-weight:700">Heavy</span>
@@ -2987,10 +2987,10 @@ PAG_TEST(PAGXHTMLImporterTest, FontWeightNumericMapsToFauxBold) {
   ASSERT_NE(doc, nullptr);
   auto* text = FindElementOfType<pagx::Text>(doc->layers.front()->children.front());
   ASSERT_NE(text, nullptr);
-  // Bold (weight >= 600) is synthesised via faux bold rather than locking onto a "Bold" face; the
-  // base-face label surfaces as the canonical "Regular".
-  EXPECT_EQ(text->fontStyle, "Regular");
-  EXPECT_TRUE(text->fauxBold);
+  // Weight 700 is written as a real-face "Bold" style label so the renderer can resolve the
+  // authored heavy face; no faux flag is baked in.
+  EXPECT_EQ(text->fontStyle, "Bold");
+  EXPECT_FALSE(text->fauxBold);
   EXPECT_FALSE(text->fauxItalic);
 }
 
@@ -3018,10 +3018,10 @@ PAG_TEST(PAGXHTMLImporterTest, BoldItalicCombined) {
   ASSERT_NE(doc, nullptr);
   auto* text = FindElementOfType<pagx::Text>(doc->layers.front()->children.front());
   ASSERT_NE(text, nullptr);
-  // Both axes are synthesised: the style label drops to the canonical "Regular" base face and both
-  // faux flags are set so the run renders bold + italic even when the styled face is unavailable.
-  EXPECT_EQ(text->fontStyle, "Regular");
-  EXPECT_TRUE(text->fauxBold);
+  // The weight axis becomes a real-face "Bold" style label; only the italic axis is synthesised via
+  // faux italic so the slant survives a missing styled italic face.
+  EXPECT_EQ(text->fontStyle, "Bold");
+  EXPECT_FALSE(text->fauxBold);
   EXPECT_TRUE(text->fauxItalic);
 }
 


### PR DESCRIPTION
本 PR 汇集了一批 HTML 导入保真度修复与增强，均围绕让导出的 PAGX 更贴近浏览器渲染结果。

## SVG 层级与变换

- **保持内联 SVG 兄弟形状的层级对称**：resolve 内联 SVG 时，之前会把第一个形状层的内容直接摊平进父Layer，其余兄弟各自包一个 Group，导致同级形状层级不一致（如波浪的两条path 一条裸露、一条被Group 包裹）。现改为对所有兄弟形状层统一包成平级 Group，与 `PAGXOptimizer::DowngradeShellChildren` 的处理方式对齐，保证源层级得以保留。
- **可变换兄弟层降级为平级 Group**：含变换的兄弟层同样降级为 peer Group，并采用 scale-independent 的 skew 检测（仅含 skew 的层保留为 Layer），避免缩放误判为倾斜。

## 渐变

- 修正 HTML 径向渐变圆形 extent 的尺寸计算，包括圆心位于盒子外时的 extent-keyword 半径。
- 修正导出时透明色标透过黑色渐隐的问题（透明色标借用相邻色标的 RGB）。

## 字体

- **字重轴作为真实字面标签**：将 CSS `font-weight` 作为真实字面的 style 标签传递，而非 faux bold，使导入的标题与加粗文本解析到作者指定的重字面，保留 SemiBold / Bold / Black 的区分。
- **icon-font 按字重字型匹配 @font-face**：一个 family 可能对应多个物理字面（如 Font Awesome Free 的 Regular/400 与 Solid/900）。此前按 family 取首个 @font-face，导致仅存在于其他字重的字形丢失。现按计算得到的 `font-weight` / `font-style` 做距离匹配（style 优先于字重邻近度，支持可变字体的字重区间），并修复缺失字面时的回退。

## 其它

- 停止在 HTML importer 的 mask 层上输出冗余的 `visible=false`。

## 测试

新增并强化了 `PAGXHTMLImporterTest` 及 html-snapshot icon-font 用例，覆盖 peer Group 对称性、extent-keyword 半径、透明色标 RGB 借用，以及 Font Awesome Solid/900 字面选择等场景。