### PR TITLE
Fix PAGImageView main-thread NetworkOnMainThreadException by keeping composition resident on decoder rebuild

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGFile.java
+++ b/android/libpag/src/main/java/org/libpag/PAGFile.java
@@ -40,7 +40,10 @@ public class PAGFile extends PAGComposition {
 
     /**
      * Load a pag file from the specified path, returns null if the file does not exist or the
-     * data is not a pag file.
+     * data is not a pag file. If the path is a network URL (starting with "http://" or "https://"),
+     * this method must be called on a worker thread; otherwise it throws a
+     * NetworkOnMainThreadException when the file is not in the disk cache. Use LoadAsync() to load a
+     * network file from the UI thread.
      * Note: All PAGFiles loaded by the same path share the same internal cache. The internal
      * cache is alive until all PAGFiles are released. Use 'PAGFile.Load(byte[])' instead
      * if you don't want to load a PAGFile from the intenal caches.
@@ -58,7 +61,9 @@ public class PAGFile extends PAGComposition {
     }
 
     /**
-     * Asynchronously load a pag file from the specific path.
+     * Asynchronously loads a pag file from the specified path. The path can be a network URL
+     * ("http://" or "https://") or a local path; the file is loaded on a worker thread, so this
+     * method is safe to call from the UI thread.
      */
     public static void LoadAsync(String path, LoadListener listener) {
         NativeTask.Run(() -> {

--- a/android/libpag/src/main/java/org/libpag/PAGImageView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageView.java
@@ -26,6 +26,7 @@ import android.graphics.Paint;
 import android.hardware.HardwareBuffer;
 import android.os.Build;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.util.Pair;
 import android.view.View;
 
@@ -154,7 +155,10 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
     /**
      * Asynchronously loads a pag file from the specified path. The path can be a network URL
      * ("http://" or "https://") or a local path; the file is loaded on a worker thread, so this
-     * method is safe to call from the UI thread.
+     * method is safe to call from the UI thread. Note: if the load fails (missing file, invalid
+     * data, or network error), the view keeps its previous content and null is reported to the
+     * listener; the load is NOT retried automatically, so the caller must invoke setPathAsync()
+     * again to retry.
      */
     public void setPathAsync(String path, PAGFile.LoadListener listener) {
         setPathAsync(path, DEFAULT_MAX_FRAMERATE, listener);
@@ -518,7 +522,9 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
                 // lifecycle on the main thread, so a network path would throw a
                 // NetworkOnMainThreadException and a local path would block on disk I/O. The
                 // composition is loaded once by setPath()/setPathAsync()/setComposition() and is
-                // never reloaded here.
+                // never reloaded here. Trade-off: the previous "null out the composition to save
+                // memory" optimization is dropped, so path-loaded compositions now stay resident;
+                // large lists should reuse or detach views to bound memory.
                 decoderInfo.initDecoder(_composition, width, height, _maxFrameRate);
                 if (!decoderInfo.isValid()) {
                     return;
@@ -616,7 +622,9 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
             if (!decoderInfo.hasPAGDecoder()) {
                 // Reuse the in-memory composition; never reload it from _pagFilePath here (see
                 // initDecoderInfo() for why reloading on this thread is unsafe).
-                decoderInfo.initDecoder(composition, width, height, _maxFrameRate);
+                if (!decoderInfo.initDecoder(composition, width, height, _maxFrameRate)) {
+                    Log.w(TAG, "initDecoder failed in checkStatusChange, composition=" + composition);
+                }
             }
         }
     }

--- a/android/libpag/src/main/java/org/libpag/PAGImageView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageView.java
@@ -130,7 +130,9 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
     /**
      * Loads a pag file from the specified path, returns false if the file does not exist or the
      * data is not a pag file. The path starts with "assets://" means that it is located in assets
-     * directory.
+     * directory. If the path is a network URL (starting with "http://" or "https://"), this method
+     * must be called on a worker thread; otherwise it throws a NetworkOnMainThreadException when the
+     * file is not in the disk cache. Use setPathAsync() to load a network file from the UI thread.
      */
     public boolean setPath(String path) {
         return setPath(path, DEFAULT_MAX_FRAMERATE);
@@ -139,7 +141,9 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
     /**
      * Loads a pag file from the specified path with the maxFrameRate limit, returns false if the file does not exist or the
      * data is not a pag file. The path starts with "assets://" means that it is located in assets
-     * directory.
+     * directory. If the path is a network URL (starting with "http://" or "https://"), this method
+     * must be called on a worker thread; otherwise it throws a NetworkOnMainThreadException when the
+     * file is not in the disk cache. Use setPathAsync() to load a network file from the UI thread.
      */
     public boolean setPath(String path, float maxFrameRate) {
         PAGComposition composition = getCompositionFromPath(path);
@@ -148,20 +152,25 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
     }
 
     /**
-     * Asynchronously Loads a pag file from the specified path.
+     * Asynchronously loads a pag file from the specified path. The path can be a network URL
+     * ("http://" or "https://") or a local path; the file is loaded on a worker thread, so this
+     * method is safe to call from the UI thread.
      */
     public void setPathAsync(String path, PAGFile.LoadListener listener) {
         setPathAsync(path, DEFAULT_MAX_FRAMERATE, listener);
     }
 
     /**
-     * Asynchronously loads a pag file from the specified path with the maxFrameRate limit.
+     * Asynchronously loads a pag file from the specified path with the maxFrameRate limit. The path
+     * can be a network URL ("http://" or "https://") or a local path; the file is loaded on a worker
+     * thread, so this method is safe to call from the UI thread.
      */
     public void setPathAsync(String path, float maxFrameRate, PAGFile.LoadListener listener) {
         NativeTask.Run(() -> {
-            // Keep a local reference to the loaded composition. The _composition field may be reset
-            // to null by the render thread in initDecoderInfo() for path-loaded views, so reading it
-            // here would race and frequently return null to the callback.
+            // Load on this worker thread so a network path never touches the main thread. Keep a
+            // local reference to the loaded composition so the callback always reports the freshly
+            // loaded file, even if a later setPath()/setComposition() replaces _composition before
+            // the callback runs.
             PAGComposition composition = getCompositionFromPath(path);
             refreshResource(path, composition, maxFrameRate);
             if (listener != null) {
@@ -503,14 +512,14 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
         decoderInfo.lock();
         try {
             if (!decoderInfo.isValid()) {
-                if (_composition == null) {
-                    _composition = getCompositionFromPath(_pagFilePath);
-                }
-                if (decoderInfo.initDecoder(_composition, width, height, _maxFrameRate)) {
-                    if (_pagFilePath != null) {
-                        _composition = null;
-                    }
-                }
+                // Reuse the composition kept in memory. Reloading it from _pagFilePath when the
+                // decoder is rebuilt (after detach/reattach or a size change) would reissue
+                // PAGFile.Load() on the caller thread. These rebuilds are driven by the view
+                // lifecycle on the main thread, so a network path would throw a
+                // NetworkOnMainThreadException and a local path would block on disk I/O. The
+                // composition is loaded once by setPath()/setPathAsync()/setComposition() and is
+                // never reloaded here.
+                decoderInfo.initDecoder(_composition, width, height, _maxFrameRate);
                 if (!decoderInfo.isValid()) {
                     return;
                 }
@@ -605,9 +614,8 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
         if (needResetBitmapCache) {
             bitmapCache.clear();
             if (!decoderInfo.hasPAGDecoder()) {
-                if (composition == null) {
-                    composition = getCompositionFromPath(_pagFilePath);
-                }
+                // Reuse the in-memory composition; never reload it from _pagFilePath here (see
+                // initDecoderInfo() for why reloading on this thread is unsafe).
                 decoderInfo.initDecoder(composition, width, height, _maxFrameRate);
             }
         }

--- a/android/libpag/src/main/java/org/libpag/PAGImageView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageView.java
@@ -612,7 +612,10 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
             memoryCacheStatusHasChanged = false;
         }
         PAGComposition composition = _composition; // Hold strong reference to avoid UAF
-        if (_pagFilePath == null && composition != null) {
+        // The composition is kept resident for path-loaded views too, so detect content changes
+        // (e.g. replaceText/replaceImage on a PAGFile obtained from setPathAsync) for them as well,
+        // not only for compositions set via setComposition().
+        if (composition != null) {
             int nVersion = ContentVersion(composition);
             if (lastContentVersion >= 0 && lastContentVersion != nVersion) {
                 needResetBitmapCache = true;

--- a/android/libpag/src/main/java/org/libpag/PAGImageView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGImageView.java
@@ -525,7 +525,9 @@ public class PAGImageView extends View implements PAGAnimator.Listener {
                 // never reloaded here. Trade-off: the previous "null out the composition to save
                 // memory" optimization is dropped, so path-loaded compositions now stay resident;
                 // large lists should reuse or detach views to bound memory.
-                decoderInfo.initDecoder(_composition, width, height, _maxFrameRate);
+                if (!decoderInfo.initDecoder(_composition, width, height, _maxFrameRate)) {
+                    Log.w(TAG, "initDecoder failed in initDecoderInfo, composition=" + _composition);
+                }
                 if (!decoderInfo.isValid()) {
                     return;
                 }

--- a/android/libpag/src/main/java/org/libpag/PAGView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGView.java
@@ -232,7 +232,10 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
     /**
      * Loads a pag file from the specified path, returns false if the file does not exist or the
      * data is not a pag file. The path starts with "assets://" means that it is located in assets
-     * directory. Note: All PAGFiles loaded by the same path share the same internal cache. The
+     * directory. If the path is a network URL (starting with "http://" or "https://"), this method
+     * must be called on a worker thread; otherwise it throws a NetworkOnMainThreadException when the
+     * file is not in the disk cache. Use setPathAsync() to load a network file from the UI thread.
+     * Note: All PAGFiles loaded by the same path share the same internal cache. The
      * internal cache remains alive until all PAGFiles are released. Use 'PAGFile.Load(byte[])'
      * instead if you don't want to load a PAGFile from the internal caches.
      */
@@ -249,7 +252,9 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
     }
 
     /**
-     * Asynchronously load a pag file from the specific path.
+     * Asynchronously loads a pag file from the specified path. The path can be a network URL
+     * ("http://" or "https://") or a local path; the file is loaded on a worker thread, so this
+     * method is safe to call from the UI thread.
      */
     public void setPathAsync(String path, PAGFile.LoadListener listener) {
         NativeTask.Run(() -> {


### PR DESCRIPTION
## 问题背景

升级到 4.4.57 后，PAGImageView 使用网络图片路径时出现 NetworkOnMainThreadException 崩溃，崩溃率明显上升（关联 PR #3570 评论区反馈）。

## 根本原因

PAGImageView 在 decoder 重建时会「回头从 `_pagFilePath` 重新加载文件」：

1. 首次加载成功后，为省内存 `_composition` 会被置空；
2. 当 view 在 RecyclerView / ViewPager2 中被回收（detach → reattach）时，`onDetachedFromWindow` 会 reset decoder；
3. 随后 `onAttachedToWindow` 在**主线程**驱动 `checkVisible` → `animator.update` → `flush` → `initDecoderInfo`；
4. 此时 `_composition` 已为空，便通过 `getCompositionFromPath(_pagFilePath)` → `PAGFile.Load(网络URL)` 在**主线程同步发起网络请求**，抛出 NetworkOnMainThreadException。

该重建路径由 View 生命周期在主线程驱动，调用方即便切到 IO 线程加载也无法拦截——这才是崩溃的根本原因。

## 修复方案（根治，非补丁）

对齐 PAGView 的做法：**加载后始终在内存保留 composition，decoder 重建时直接复用，绝不回头从路径重载**。

1. `initDecoderInfo()` / `checkStatusChange()` 移除 `getCompositionFromPath(_pagFilePath)` 的重载分支，以及 `initDecoder` 成功后的 `_composition = null` 置空；decoder 重建的三条路径（detach/reattach、尺寸变化、cacheAllInMemory 释放后重建）统一复用常驻的 `_composition`；
2. 底层 `DecoderInfo.initDecoder` 对 null composition 已有防护（直接返回 false，不 reload、不 NPE）；
3. `PAGFile.Load(String)` / `LoadAsync`、`PAGImageView.setPath` / `setPathAsync`、`PAGView.setPath` / `setPathAsync` 补齐网络 URL 的线程约束 Javadoc；
4. `initDecoderInfo` 与 `checkStatusChange` 在 `initDecoder` 失败时统一输出 `Log.w`。

## 行为变化

- decoder 重建不再隐式重载网络 URL，消除主线程网络崩溃；
- **内存权衡**：放弃「置空 composition 省内存」的优化，path-loaded 的 composition 会常驻内存。真正占内存的是 bitmap 缓存（不受影响），大列表可通过复用 / 回收 view 控制；
- 首次 `setPath` / `setPathAsync` 加载失败后不再自动重试（保留原有内容、回调返回 null），需再次调用重试（已在 Javadoc 说明）；
- `setPath(网络URL)` 在主线程仍会同步加载，属调用方契约：网络路径须在 worker 线程调用或使用 `setPathAsync`（Javadoc 已约束）。

## iOS 说明（另行处理）

iOS 存在**同源缺陷**：`src/platform/ios/PAGImageView.mm` 路径加载时不保存 composition，`updatePAGDecoder` 每次执行 `[PAGFile Load:filePath]`，且由 `handleSizeChanged` / `setRenderScale` / `setContentScaleFactor` 在主线程调用，`PAGFileImpl` 对网络路径同步 `dataWithContentsOfURL` 阻塞主线程（iOS 不抛异常，但同样阻塞主线程）。**本 PR 仅修复 Android；iOS 问题将另行提 PR 跟进。**

## 验证方式

- 构造网络 URL + `PAGDiskCache.RemoveAll()` 清缓存的复现场景（demo 内嵌 HTTP server + RecyclerView 式 detach/reattach）：修复前在模拟器上稳定崩溃，修复后不再崩溃；
- 本地路径加载、`setPathAsync` 异步加载、常规播放等回归用例均通过。

## 关联信息

- 修复 PR #3570 升级后引入的 NetworkOnMainThreadException 崩溃问题。
