### PR TITLE
Improve HTML import and PPT text export fidelity

### DIFF
--- a/resources/cli/import_resolve_skew_siblings.pagx
+++ b/resources/cli/import_resolve_skew_siblings.pagx
@@ -1,0 +1,8 @@
+<pagx width="40" height="40">
+  <Layer centerX="0" centerY="0">
+    <svg viewBox="0 0 20 20">
+      <path d="M2 2H8V8H2Z" fill="#FF4757" transform="scale(0.01) skewX(20)"/>
+      <path d="M10 10H18V18H10Z" fill="#3498DB"/>
+    </svg>
+  </Layer>
+</pagx>

--- a/resources/cli/import_resolve_transformed_siblings.pagx
+++ b/resources/cli/import_resolve_transformed_siblings.pagx
@@ -1,0 +1,9 @@
+<pagx width="40" height="40">
+  <Layer centerX="0" centerY="0">
+    <svg viewBox="0 0 20 20">
+      <path d="M0 0H4V4H0Z" fill="#FF4757"
+            transform="translate(4 5) rotate(30) scale(2 3)"/>
+      <path d="M10 10H18V18H10Z" fill="#3498DB"/>
+    </svg>
+  </Layer>
+</pagx>

--- a/src/cli/CommandResolve.cpp
+++ b/src/cli/CommandResolve.cpp
@@ -124,6 +124,20 @@ static int ParseResolveOptions(int argc, char* argv[], ResolveOptions* options) 
 // Resolve logic
 //--------------------------------------------------------------------------------------------------
 
+// A Group's position/scale/rotation fields can represent a matrix whose axes remain orthogonal.
+// Compare the normalized axis dot product so the result does not depend on the matrix scale.
+// Degenerate axes are kept as Layers because the decomposition below cannot recover their rotation.
+static bool CanDowngradeMatrixToGroup(const Matrix& matrix) {
+  float xLength = std::hypot(matrix.a, matrix.b);
+  float yLength = std::hypot(matrix.c, matrix.d);
+  if (pag::FloatNearlyZero(xLength) || pag::FloatNearlyZero(yLength)) {
+    return false;
+  }
+  float normalizedDot =
+      (matrix.a / xLength) * (matrix.c / yLength) + (matrix.b / xLength) * (matrix.d / yLength);
+  return pag::FloatNearlyZero(normalizedDot);
+}
+
 static bool ResolveOneLayer(Layer* layer, const std::string& baseDir,
                             const ImportFormatOptions& formatOptions, PAGXDocument* doc) {
   bool hasImportSource = !layer->importDirective.source.empty();
@@ -208,7 +222,8 @@ static bool ResolveOneLayer(Layer* layer, const std::string& baseDir,
   } else if (elementLayers.size() > 1) {
     canDowngradeAll = true;
     for (auto* el : elementLayers) {
-      if (!el->children.empty() || HasLayerOnlyFeatures(el)) {
+      if (!el->children.empty() || HasLayerOnlyFeatures(el) ||
+          !CanDowngradeMatrixToGroup(el->matrix)) {
         canDowngradeAll = false;
         break;
       }
@@ -223,19 +238,18 @@ static bool ResolveOneLayer(Layer* layer, const std::string& baseDir,
     // Wrap every element layer uniformly in its own Group so sibling shapes stay at the same
     // depth (peer Groups), preserving the source hierarchy. Flattening only the first layer's
     // contents while wrapping the rest would break that symmetry and is unnecessary — a trailing
-    // painter is isolated by its enclosing Group either way. This mirrors the uniform handling in
-    // PAGXOptimizer::DowngradeShellChildren.
+    // painter is isolated by its enclosing Group either way. Structurally, this uses the same
+    // all-siblings Group strategy as PAGXOptimizer::DowngradeShellChildren, while also supporting
+    // transformable non-identity matrices here.
     for (auto* elemLayer : elementLayers) {
-      auto m = elemLayer->matrix;
-      bool hasSkew = !pag::FloatNearlyEqual(m.a * m.c + m.b * m.d, 0.0f);
-      if (hasSkew) {
-        // Matrix contains skew which cannot be represented by Group's
-        // position/scale/rotation. Keep it as a Layer instead of downgrading.
-        layer->children.push_back(elemLayer);
+      if (elemLayer->contents.empty() && elemLayer->customData.empty()) {
         continue;
       }
+      auto m = elemLayer->matrix;
       auto* group = doc->makeNode<Group>();
       group->elements = std::move(elemLayer->contents);
+      group->customData = std::move(elemLayer->customData);
+      group->sourceLine = elemLayer->sourceLine;
       if (!elemLayer->matrix.isIdentity()) {
         group->position = {m.tx, m.ty};
         if (m.a != 1 || m.b != 0 || m.c != 0 || m.d != 1) {

--- a/src/cli/CommandResolve.cpp
+++ b/src/cli/CommandResolve.cpp
@@ -30,7 +30,6 @@
 #include "pagx/PAGXOptimizer.h"
 #include "pagx/nodes/Composition.h"
 #include "pagx/nodes/Group.h"
-#include "pagx/nodes/LayoutNode.h"
 
 namespace pagx::cli {
 
@@ -221,52 +220,37 @@ static bool ResolveOneLayer(Layer* layer, const std::string& baseDir,
       layer->contents.push_back(element);
     }
   } else if (canDowngradeAll) {
-    for (size_t i = 0; i < elementLayers.size(); i++) {
-      auto* elemLayer = elementLayers[i];
-      bool unpackFirst = false;
-      if (i == 0 && elemLayer->matrix.isIdentity()) {
-        unpackFirst = true;
-        for (auto* child : elemLayer->contents) {
-          auto* layoutNode = LayoutNode::AsLayoutNode(child);
-          if (layoutNode != nullptr &&
-              (!std::isnan(layoutNode->right) || !std::isnan(layoutNode->bottom) ||
-               !std::isnan(layoutNode->centerX) || !std::isnan(layoutNode->centerY))) {
-            unpackFirst = false;
-            break;
+    // Wrap every element layer uniformly in its own Group so sibling shapes stay at the same
+    // depth (peer Groups), preserving the source hierarchy. Flattening only the first layer's
+    // contents while wrapping the rest would break that symmetry and is unnecessary — a trailing
+    // painter is isolated by its enclosing Group either way. This mirrors the uniform handling in
+    // PAGXOptimizer::DowngradeShellChildren.
+    for (auto* elemLayer : elementLayers) {
+      auto m = elemLayer->matrix;
+      bool hasSkew = !pag::FloatNearlyEqual(m.a * m.c + m.b * m.d, 0.0f);
+      if (hasSkew) {
+        // Matrix contains skew which cannot be represented by Group's
+        // position/scale/rotation. Keep it as a Layer instead of downgrading.
+        layer->children.push_back(elemLayer);
+        continue;
+      }
+      auto* group = doc->makeNode<Group>();
+      group->elements = std::move(elemLayer->contents);
+      if (!elemLayer->matrix.isIdentity()) {
+        group->position = {m.tx, m.ty};
+        if (m.a != 1 || m.b != 0 || m.c != 0 || m.d != 1) {
+          float sx = std::sqrt(m.a * m.a + m.b * m.b);
+          float sy = std::sqrt(m.c * m.c + m.d * m.d);
+          float det = m.a * m.d - m.b * m.c;
+          if (det < 0) {
+            sy = -sy;
           }
+          float rot = pag::RadiansToDegrees(std::atan2(m.b, m.a));
+          group->scale = {sx, sy};
+          group->rotation = rot;
         }
       }
-      if (unpackFirst) {
-        for (auto* element : elemLayer->contents) {
-          layer->contents.push_back(element);
-        }
-      } else {
-        auto m = elemLayer->matrix;
-        bool hasSkew = !pag::FloatNearlyEqual(m.a * m.c + m.b * m.d, 0.0f);
-        if (hasSkew) {
-          // Matrix contains skew which cannot be represented by Group's
-          // position/scale/rotation. Keep it as a Layer instead of downgrading.
-          layer->children.push_back(elemLayer);
-          continue;
-        }
-        auto* group = doc->makeNode<Group>();
-        group->elements = std::move(elemLayer->contents);
-        if (!elemLayer->matrix.isIdentity()) {
-          group->position = {m.tx, m.ty};
-          if (m.a != 1 || m.b != 0 || m.c != 0 || m.d != 1) {
-            float sx = std::sqrt(m.a * m.a + m.b * m.b);
-            float sy = std::sqrt(m.c * m.c + m.d * m.d);
-            float det = m.a * m.d - m.b * m.c;
-            if (det < 0) {
-              sy = -sy;
-            }
-            float rot = pag::RadiansToDegrees(std::atan2(m.b, m.a));
-            group->scale = {sx, sy};
-            group->rotation = rot;
-          }
-        }
-        layer->contents.push_back(group);
-      }
+      layer->contents.push_back(group);
     }
   } else {
     for (auto* elemLayer : elementLayers) {

--- a/src/pagx/TextLayout.cpp
+++ b/src/pagx/TextLayout.cpp
@@ -390,8 +390,9 @@ class TextLayoutContext {
     bool fauxBold = glyph.fauxBold;
     if (!fauxBold) {
       int requestedWeight = ParseFontStyleName(glyph.fontStyle).weight;
-      int resolvedWeight =
-          primaryTypeface == nullptr ? 400 : ParseFontStyleName(primaryTypeface->fontStyle()).weight;
+      int resolvedWeight = primaryTypeface == nullptr
+                               ? 400
+                               : ParseFontStyleName(primaryTypeface->fontStyle()).weight;
       fauxBold = resolvedWeight < requestedWeight;
     }
 

--- a/src/pagx/TextLayout.cpp
+++ b/src/pagx/TextLayout.cpp
@@ -25,6 +25,7 @@
 #include "pagx/nodes/Group.h"
 #include "pagx/nodes/Text.h"
 #include "pagx/nodes/TextBox.h"
+#include "pagx/utils/CSSFontStyle.h"
 #include "pagx/utils/TextUtils.h"
 #include "renderer/BidiResolver.h"
 #include "renderer/LineBreaker.h"
@@ -382,6 +383,18 @@ class TextLayoutContext {
                  float textScale = 1.0f) {
     auto primaryTypeface = findTypeface(glyph.fontFamily, glyph.fontStyle);
 
+    // Keep the requested weight as a real face label so an installed Bold / SemiBold / Black face
+    // can be selected precisely. If lookup falls back to a lighter face (or finds no primary face),
+    // synthesize the missing weight at layout time. The faux flag then propagates to per-character
+    // fallback fonts in TextShaper as well.
+    bool fauxBold = glyph.fauxBold;
+    if (!fauxBold) {
+      int requestedWeight = ParseFontStyleName(glyph.fontStyle).weight;
+      int resolvedWeight =
+          primaryTypeface == nullptr ? 400 : ParseFontStyleName(primaryTypeface->fontStyle()).weight;
+      fauxBold = resolvedWeight < requestedWeight;
+    }
+
     // When the primary typeface is not found, find a fallback typeface for font metrics used by
     // special characters (newline, tab) that do not go through per-character glyph fallback.
     auto metricsTypeface = primaryTypeface;
@@ -391,10 +404,10 @@ class TextLayoutContext {
 
     float effectiveFontSize = glyph.fontSize * textScale;
     tgfx::Font primaryFont(primaryTypeface, effectiveFontSize);
-    primaryFont.setFauxBold(glyph.fauxBold);
+    primaryFont.setFauxBold(fauxBold);
     primaryFont.setFauxItalic(glyph.fauxItalic);
     tgfx::Font metricsFont(metricsTypeface, effectiveFontSize);
-    metricsFont.setFauxBold(glyph.fauxBold);
+    metricsFont.setFauxBold(fauxBold);
     metricsFont.setFauxItalic(glyph.fauxItalic);
     float currentX = 0;
     const std::string& content = glyph.text;

--- a/src/pagx/TextLayout.cpp
+++ b/src/pagx/TextLayout.cpp
@@ -25,7 +25,6 @@
 #include "pagx/nodes/Group.h"
 #include "pagx/nodes/Text.h"
 #include "pagx/nodes/TextBox.h"
-#include "pagx/utils/CSSFontStyle.h"
 #include "pagx/utils/TextUtils.h"
 #include "renderer/BidiResolver.h"
 #include "renderer/LineBreaker.h"
@@ -383,19 +382,6 @@ class TextLayoutContext {
                  float textScale = 1.0f) {
     auto primaryTypeface = findTypeface(glyph.fontFamily, glyph.fontStyle);
 
-    // Keep the requested weight as a real face label so an installed Bold / SemiBold / Black face
-    // can be selected precisely. If lookup falls back to a lighter face (or finds no primary face),
-    // synthesize the missing weight at layout time. The faux flag then propagates to per-character
-    // fallback fonts in TextShaper as well.
-    bool fauxBold = glyph.fauxBold;
-    if (!fauxBold) {
-      int requestedWeight = ParseFontStyleName(glyph.fontStyle).weight;
-      int resolvedWeight = primaryTypeface == nullptr
-                               ? 400
-                               : ParseFontStyleName(primaryTypeface->fontStyle()).weight;
-      fauxBold = resolvedWeight < requestedWeight;
-    }
-
     // When the primary typeface is not found, find a fallback typeface for font metrics used by
     // special characters (newline, tab) that do not go through per-character glyph fallback.
     auto metricsTypeface = primaryTypeface;
@@ -405,10 +391,10 @@ class TextLayoutContext {
 
     float effectiveFontSize = glyph.fontSize * textScale;
     tgfx::Font primaryFont(primaryTypeface, effectiveFontSize);
-    primaryFont.setFauxBold(fauxBold);
+    primaryFont.setFauxBold(glyph.fauxBold);
     primaryFont.setFauxItalic(glyph.fauxItalic);
     tgfx::Font metricsFont(metricsTypeface, effectiveFontSize);
-    metricsFont.setFauxBold(fauxBold);
+    metricsFont.setFauxBold(glyph.fauxBold);
     metricsFont.setFauxItalic(glyph.fauxItalic);
     float currentX = 0;
     const std::string& content = glyph.text;

--- a/src/pagx/html/importer/HTMLBoxAttributes.h
+++ b/src/pagx/html/importer/HTMLBoxAttributes.h
@@ -40,8 +40,8 @@ static constexpr const char* HTML_DEFAULT_FONT_FAMILY = "Arial";
 
 /**
  * Default font style/variant name written to every imported `Text` node. The synthesis in
- * `ResolveFontStyleSynthesis` leaves the style label empty for the plain base face (bold / italic
- * are carried by `fauxBold` / `fauxItalic`); this constant substitutes the canonical "Regular"
+ * `ResolveFontStyleSynthesis` leaves the style label empty for the plain Regular-weight upright
+ * face (italic is carried by `fauxItalic`); this constant substitutes the canonical "Regular"
  * name so every HTML-imported `Text` node always carries a concrete `fontStyle`.
  */
 static constexpr const char* HTML_DEFAULT_FONT_STYLE = "Regular";
@@ -74,12 +74,13 @@ struct HTMLInheritedStyle {
   std::string fontSize = {};
   std::string fontWeight = {};
   std::string fontStyle = {};
-  std::string fontStyleName = {};  // real-face style label, e.g. "Light" / "Medium" / ""
-  // Synthetic weight / slant the renderer must emboss on top of the resolved face. Set by
-  // `resolveInheritedStyle` for bold (CSS weight >= 600) and italic/oblique requests whose axis is
-  // dropped from `fontStyleName` (see `ResolveFontStyleSynthesis`). Carried through to
-  // `Text::fauxBold` / `Text::fauxItalic` so authored weight / slant survives even when the styled
-  // web face is not installed on the render host.
+  std::string fontStyleName = {};  // real-face style label, e.g. "Light" / "Bold" / "Black" / ""
+  // Synthetic slant the renderer must emboss on top of the resolved face. Set by
+  // `resolveInheritedStyle` for italic/oblique requests, whose axis is dropped from `fontStyleName`
+  // (see `ResolveFontStyleSynthesis`) and carried through to `Text::fauxItalic` so the authored
+  // slant survives even when the styled italic face is not installed on the render host. The weight
+  // axis is never synthesised (it stays in `fontStyleName` as a real-face keyword), so `fauxBold`
+  // is always false here.
   bool fauxBold = false;
   bool fauxItalic = false;
   std::string letterSpacing = {};

--- a/src/pagx/html/importer/HTMLBoxAttributes.h
+++ b/src/pagx/html/importer/HTMLBoxAttributes.h
@@ -78,9 +78,10 @@ struct HTMLInheritedStyle {
   // Synthetic slant the renderer must emboss on top of the resolved face. Set by
   // `resolveInheritedStyle` for italic/oblique requests, whose axis is dropped from `fontStyleName`
   // (see `ResolveFontStyleSynthesis`) and carried through to `Text::fauxItalic` so the authored
-  // slant survives even when the styled italic face is not installed on the render host. The weight
-  // axis is never synthesised (it stays in `fontStyleName` as a real-face keyword), so `fauxBold`
-  // is always false here.
+  // slant survives even when the styled italic face is not installed on the render host. The
+  // importer never pre-synthesises the weight axis: it stays in `fontStyleName` as a real-face
+  // keyword, so `fauxBold` is false here. TextLayout may add faux bold later if font lookup resolves
+  // a face that is lighter than requested.
   bool fauxBold = false;
   bool fauxItalic = false;
   std::string letterSpacing = {};

--- a/src/pagx/html/importer/HTMLBoxAttributes.h
+++ b/src/pagx/html/importer/HTMLBoxAttributes.h
@@ -80,8 +80,7 @@ struct HTMLInheritedStyle {
   // (see `ResolveFontStyleSynthesis`) and carried through to `Text::fauxItalic` so the authored
   // slant survives even when the styled italic face is not installed on the render host. The
   // importer never pre-synthesises the weight axis: it stays in `fontStyleName` as a real-face
-  // keyword, so `fauxBold` is false here. TextLayout may add faux bold later if font lookup resolves
-  // a face that is lighter than requested.
+  // keyword, so `fauxBold` remains false even if font lookup later falls back to a lighter face.
   bool fauxBold = false;
   bool fauxItalic = false;
   std::string letterSpacing = {};

--- a/src/pagx/html/importer/HTMLElementEmitter.cpp
+++ b/src/pagx/html/importer/HTMLElementEmitter.cpp
@@ -697,8 +697,8 @@ void HTMLParserContext::applyMaskOrClip(Layer* layer, const HTMLBoxAttributes& b
   float intrinsicH = svgDoc->height;
 
   // The mask SVG produces one or more content layers (a single drawn shape in the common case).
-  // Wrap them under one invisible, layout-excluded mask layer so a multi-shape clip-path also
-  // works, then transplant every node from the temporary SVG document into ours.
+  // Wrap them under one layout-excluded mask layer so a multi-shape clip-path also works, then
+  // transplant every node from the temporary SVG document into ours.
   Layer* maskLayer = nullptr;
   if (svgDoc->layers.size() == 1) {
     maskLayer = svgDoc->layers[0];
@@ -708,7 +708,6 @@ void HTMLParserContext::applyMaskOrClip(Layer* layer, const HTMLBoxAttributes& b
       maskLayer->children.push_back(l);
     }
   }
-  maskLayer->visible = false;
   maskLayer->includeInLayout = false;
   // CSS `mask-size` / `mask-position` scale and offset the intrinsic mask box onto the masked
   // element; replay that transform onto the mask layer. Contour clip-paths are framed to the box
@@ -730,9 +729,9 @@ void HTMLParserContext::applyMaskOrClip(Layer* layer, const HTMLBoxAttributes& b
   layer->mask = maskLayer;
   layer->maskType = maskType;
   // The mask layer must be reachable in the display list for the renderer's mask lookup, and must
-  // share the masked layer's local coordinate origin. Adding it as an invisible, layout-excluded
-  // child satisfies both: it is walked by LayerBuilder but neither drawn (maskOwner is set) nor
-  // laid out (includeInLayout is false).
+  // share the masked layer's local coordinate origin. Adding it as a layout-excluded child
+  // satisfies both: it is walked by LayerBuilder but neither drawn (maskOwner is set on the tgfx
+  // side) nor laid out (includeInLayout is false).
   layer->children.push_back(maskLayer);
 }
 
@@ -767,7 +766,6 @@ void HTMLParserContext::applyRoundedOverflowClip(Layer* layer, const HTMLBoxAttr
   // resolved by layout. A Contour mask reads only the shape's coverage, clipping descendants to
   // the rounded outline instead of the layer's rectangle.
   auto* maskLayer = _document->makeNode<Layer>();
-  maskLayer->visible = false;
   maskLayer->includeInLayout = false;
   maskLayer->percentWidth = 100.0f;
   maskLayer->percentHeight = 100.0f;
@@ -782,8 +780,8 @@ void HTMLParserContext::applyRoundedOverflowClip(Layer* layer, const HTMLBoxAttr
   // The rounded mask now performs the clip; drop the rectangular scrollRect so it does not also
   // square off the corners the mask just rounded.
   layer->clipToBounds = false;
-  // Invisible, layout-excluded child so it shares the masked layer's local coordinate origin and
-  // stays reachable by the renderer's mask lookup (mirrors `applyMaskOrClip`).
+  // Layout-excluded child so it shares the masked layer's local coordinate origin and stays
+  // reachable by the renderer's mask lookup (mirrors `applyMaskOrClip`).
   layer->children.push_back(maskLayer);
 }
 

--- a/src/pagx/html/importer/HTMLParserContext.h
+++ b/src/pagx/html/importer/HTMLParserContext.h
@@ -124,7 +124,7 @@ class HTMLParserContext {
   // equivalent SVG geometry — and attaches it to `layer` as `layer->mask` / `maskType`
   // (the inverse of `HTMLWriter::writeMaskCSS` / `writeClipDef`). The mask geometry SVG is parsed
   // through `SVGImporter`, and its nodes are transplanted into `_document`. The mask layer is added
-  // as an invisible, layout-excluded child of `layer` so it shares the masked layer's local
+  // as a layout-excluded child of `layer` so it shares the masked layer's local
   // coordinate space and is reachable by the renderer's mask lookup. No-op when the box carries
   // neither a mask nor a clip-path reference. `box` supplies the masked layer's resolved size used
   // to frame a contour clip-path SVG.

--- a/src/pagx/html/importer/HTMLStyleCascade.cpp
+++ b/src/pagx/html/importer/HTMLStyleCascade.cpp
@@ -548,8 +548,8 @@ HTMLInheritedStyle HTMLStyleCascade::resolveInheritedStyle(const std::shared_ptr
   // resolves plus the synthetic (faux) italic axis the renderer embosses on top. The weight axis
   // is always written as a real-face keyword (Bold / SemiBold / Black) so the renderer resolves the
   // authored heavy face when it is installed or embedded and preserves the SemiBold / Bold / Black
-  // distinction, falling back to host faux emboldening only for a missing face. Italic stays a faux
-  // flag so an oblique slant survives when the styled italic face is unavailable.
+  // distinction. TextLayout adds faux emboldening only when font lookup resolves a lighter face.
+  // Italic stays a faux flag so an oblique slant survives when the styled italic face is unavailable.
   FontStyleSynthesis fontSynthesis = ResolveFontStyleSynthesis(out.fontWeight, out.fontStyle);
   out.fontStyleName = fontSynthesis.fontStyleName;
   out.fauxBold = fontSynthesis.fauxBold;

--- a/src/pagx/html/importer/HTMLStyleCascade.cpp
+++ b/src/pagx/html/importer/HTMLStyleCascade.cpp
@@ -545,11 +545,11 @@ HTMLInheritedStyle HTMLStyleCascade::resolveInheritedStyle(const std::shared_ptr
     out.textFillImage = ownBgImage;
   }
   // Split the CSS font-weight / font-style request into the real-face style label PAGX Text
-  // resolves plus the synthetic (faux) axes the renderer embosses on top. Bold (weight >= 600) and
-  // italic/oblique are baked as faux flags and dropped from the label so an uninstalled web face
-  // (e.g. "Noto Sans SC Black Italic") still renders at the authored weight and slant instead of
-  // collapsing to a thin upright fallback. Lighter weights (Light / Medium) cannot be synthesised
-  // and stay in the label.
+  // resolves plus the synthetic (faux) italic axis the renderer embosses on top. The weight axis
+  // is always written as a real-face keyword (Bold / SemiBold / Black) so the renderer resolves the
+  // authored heavy face when it is installed or embedded and preserves the SemiBold / Bold / Black
+  // distinction, falling back to host faux emboldening only for a missing face. Italic stays a faux
+  // flag so an oblique slant survives when the styled italic face is unavailable.
   FontStyleSynthesis fontSynthesis = ResolveFontStyleSynthesis(out.fontWeight, out.fontStyle);
   out.fontStyleName = fontSynthesis.fontStyleName;
   out.fauxBold = fontSynthesis.fauxBold;

--- a/src/pagx/html/importer/HTMLStyleCascade.cpp
+++ b/src/pagx/html/importer/HTMLStyleCascade.cpp
@@ -548,8 +548,9 @@ HTMLInheritedStyle HTMLStyleCascade::resolveInheritedStyle(const std::shared_ptr
   // resolves plus the synthetic (faux) italic axis the renderer embosses on top. The weight axis
   // is always written as a real-face keyword (Bold / SemiBold / Black) so the renderer resolves the
   // authored heavy face when it is installed or embedded and preserves the SemiBold / Bold / Black
-  // distinction. TextLayout adds faux emboldening only when font lookup resolves a lighter face.
-  // Italic stays a faux flag so an oblique slant survives when the styled italic face is unavailable.
+  // distinction. If that face is unavailable, normal font lookup fallback applies without faux
+  // bold. Italic stays a faux flag so an oblique slant survives when the styled italic face is
+  // unavailable.
   FontStyleSynthesis fontSynthesis = ResolveFontStyleSynthesis(out.fontWeight, out.fontStyle);
   out.fontStyleName = fontSynthesis.fontStyleName;
   out.fauxBold = fontSynthesis.fauxBold;

--- a/src/pagx/html/importer/HTMLTextFragmentBuilder.h
+++ b/src/pagx/html/importer/HTMLTextFragmentBuilder.h
@@ -58,10 +58,11 @@ class HTMLTextFragmentBuilder {
   struct TextFragment {
     std::string text = {};
     std::string fontFamily = {};
-    std::string fontStyleName = {};  // real-face style label, e.g. "Light" / "Medium" / ""
-    // Synthetic weight / slant baked in from the CSS request (see `ResolveFontStyleSynthesis`).
-    // Surface as `Text::fauxBold` / `Text::fauxItalic` so authored bold / italic survives a
-    // missing styled face on the render host.
+    std::string fontStyleName = {};  // real-face style label, e.g. "Light" / "Bold" / "Black" / ""
+    // Synthetic slant baked in from the CSS request (see `ResolveFontStyleSynthesis`). Surfaces as
+    // `Text::fauxItalic` so an authored oblique slant survives a missing styled italic face on the
+    // render host. The weight axis is never synthesised (it stays in `fontStyleName`), so
+    // `fauxBold` is always false.
     bool fauxBold = false;
     bool fauxItalic = false;
     float fontSize = HTML_DEFAULT_FONT_SIZE;

--- a/src/pagx/html/importer/HTMLTextFragmentBuilder.h
+++ b/src/pagx/html/importer/HTMLTextFragmentBuilder.h
@@ -61,8 +61,9 @@ class HTMLTextFragmentBuilder {
     std::string fontStyleName = {};  // real-face style label, e.g. "Light" / "Bold" / "Black" / ""
     // Synthetic slant baked in from the CSS request (see `ResolveFontStyleSynthesis`). Surfaces as
     // `Text::fauxItalic` so an authored oblique slant survives a missing styled italic face on the
-    // render host. The weight axis is never synthesised (it stays in `fontStyleName`), so
-    // `fauxBold` is always false.
+    // render host. The importer does not pre-synthesise the weight axis (it stays in
+    // `fontStyleName`), so `fauxBold` is false here; TextLayout may add it after resolving a lighter
+    // face at runtime.
     bool fauxBold = false;
     bool fauxItalic = false;
     float fontSize = HTML_DEFAULT_FONT_SIZE;

--- a/src/pagx/html/importer/HTMLTextFragmentBuilder.h
+++ b/src/pagx/html/importer/HTMLTextFragmentBuilder.h
@@ -62,8 +62,8 @@ class HTMLTextFragmentBuilder {
     // Synthetic slant baked in from the CSS request (see `ResolveFontStyleSynthesis`). Surfaces as
     // `Text::fauxItalic` so an authored oblique slant survives a missing styled italic face on the
     // render host. The importer does not pre-synthesise the weight axis (it stays in
-    // `fontStyleName`), so `fauxBold` is false here; TextLayout may add it after resolving a lighter
-    // face at runtime.
+    // `fontStyleName`), so `fauxBold` remains false even if font lookup later falls back to a
+    // lighter face.
     bool fauxBold = false;
     bool fauxItalic = false;
     float fontSize = HTML_DEFAULT_FONT_SIZE;

--- a/src/pagx/html/importer/HTMLValueParser.cpp
+++ b/src/pagx/html/importer/HTMLValueParser.cpp
@@ -643,10 +643,10 @@ bool IsRadialExtentKeyword(const std::string& token) {
 // edges.
 float CircleExtentRadiusPx(const std::string& keyword, float cxPx, float cyPx, float boxWidth,
                            float boxHeight) {
-  float left = cxPx;
-  float right = boxWidth - cxPx;
-  float top = cyPx;
-  float bottom = boxHeight - cyPx;
+  float left = std::abs(cxPx);
+  float right = std::abs(boxWidth - cxPx);
+  float top = std::abs(cyPx);
+  float bottom = std::abs(boxHeight - cyPx);
   float dx = std::max(left, right);
   float dy = std::max(top, bottom);
   if (keyword == "closest-side") {
@@ -961,10 +961,11 @@ void HTMLValueParser::parseRadialDescriptor(const std::string& descriptor, float
     }
   }
 
-  // A circle keeps one uniform radius; an ellipse (explicit, or the shapeless default) stretches
-  // per axis. Detected up front because extent-keyword and omitted sizes resolve the radius from
-  // the center, which the position pass below establishes first.
-  bool isCircle = explicitCircle || (!explicitEllipse && sizeTokens.size() == 1);
+  // A single explicit length implies a circle. An extent keyword without a shape still uses CSS's
+  // default ellipse, so it must not enter the circle-only pixel-radius path below.
+  bool implicitCircle =
+      !explicitEllipse && sizeTokens.size() == 1 && !IsRadialExtentKeyword(sizeTokens[0]);
+  bool isCircle = explicitCircle || implicitCircle;
 
   // Position: `at <x> <y>`. Axis-locked keywords (left/right -> x, top/bottom -> y) are assigned
   // first so author order is irrelevant (`at top left` == `at left top`); the remaining `center`
@@ -1156,7 +1157,8 @@ bool HTMLValueParser::finaliseGradientStops(GradientStops& stops) {
   // interpolates unpremultiplied, where a keyword `transparent` carries black RGB and would drag
   // the ramp toward grey/black. Rewrite each fully transparent stop's RGB to that of its nearest
   // opaque neighbour (alpha kept at 0) so the unpremultiplied interpolation matches CSS. A stop
-  // between two opaque colours prefers the earlier neighbour, matching the premultiplied midpoint.
+  // between two opaque colours prefers the earlier neighbour to avoid tinting the visible,
+  // higher-alpha side of the fade.
   for (size_t i = 0; i < stops.size(); ++i) {
     if (stops[i].second.alpha > 0.0f) continue;
     size_t donor = stops.size();

--- a/src/pagx/html/importer/HTMLValueParser.cpp
+++ b/src/pagx/html/importer/HTMLValueParser.cpp
@@ -627,6 +627,43 @@ Color SampleRepeatingPeriod(const HTMLValueParser::GradientStops& stops, float f
   return stops.back().second;
 }
 
+// CSS radial extent keywords control how far the ending shape reaches; they carry no scalar radius
+// in the token itself (the radius is derived from the center and box). Returns true for any of the
+// four keywords so the caller can compute the corresponding px radius from the center position.
+bool IsRadialExtentKeyword(const std::string& token) {
+  return token == "closest-side" || token == "closest-corner" || token == "farthest-side" ||
+         token == "farthest-corner";
+}
+
+// Computes the px radius of a CSS `circle` ending shape for the given extent keyword, measured from
+// a center at (cxPx, cyPx) within a (0,0)-(boxWidth,boxHeight) box. An empty/unknown keyword
+// defaults to `farthest-corner`, matching CSS when the size is omitted. `closest-corner` /
+// `farthest-corner` are the Euclidean distances to the nearest / farthest box corner;
+// `closest-side` / `farthest-side` are the min / max of the perpendicular distances to the four
+// edges.
+float CircleExtentRadiusPx(const std::string& keyword, float cxPx, float cyPx, float boxWidth,
+                           float boxHeight) {
+  float left = cxPx;
+  float right = boxWidth - cxPx;
+  float top = cyPx;
+  float bottom = boxHeight - cyPx;
+  float dx = std::max(left, right);
+  float dy = std::max(top, bottom);
+  if (keyword == "closest-side") {
+    return std::min(std::min(left, right), std::min(top, bottom));
+  }
+  if (keyword == "farthest-side") {
+    return std::max(dx, dy);
+  }
+  if (keyword == "closest-corner") {
+    float nx = std::min(left, right);
+    float ny = std::min(top, bottom);
+    return std::sqrt(nx * nx + ny * ny);
+  }
+  // farthest-corner (also the default when the size is omitted).
+  return std::sqrt(dx * dx + dy * dy);
+}
+
 }  // namespace
 
 ColorSource* HTMLValueParser::parseRepeatingLinearGradientPattern(const std::string& value,
@@ -924,24 +961,10 @@ void HTMLValueParser::parseRadialDescriptor(const std::string& descriptor, float
     }
   }
 
-  // Radius: the exporter writes `rx = radius * boxWidth` (and an ellipse's `ry` is implied by the
-  // box height under PAGX's single-radius + fitsToGeometry model), so a length token divided by
-  // boxWidth recovers the normalised radius. A bare `<pct>%` is already box-relative. Track whether
-  // the radius came from an explicit px length so a circle on a non-square box can later switch to
-  // the fitsToGeometry=false pixel model (see below).
-  bool radiusFromPxLength = false;
-  if (!sizeTokens.empty() && boxWidth > 0) {
-    float radius = resolveRadialLength(sizeTokens[0], boxWidth);
-    if (!std::isnan(radius)) {
-      grad->radius = radius;
-      radiusFromPxLength = !sizeTokens[0].empty() && sizeTokens[0].back() != '%';
-    } else {
-      // Extent keywords (closest-side / farthest-corner / ...) have no scalar PAGX radius; keep
-      // the box-filling default and surface a diagnostic instead of silently mis-sizing.
-      _diagnostics.warn("html: radial-gradient size '" + sizeTokens[0] +
-                        "' not supported; using box-filling radius");
-    }
-  }
+  // A circle keeps one uniform radius; an ellipse (explicit, or the shapeless default) stretches
+  // per axis. Detected up front because extent-keyword and omitted sizes resolve the radius from
+  // the center, which the position pass below establishes first.
+  bool isCircle = explicitCircle || (!explicitEllipse && sizeTokens.size() == 1);
 
   // Position: `at <x> <y>`. Axis-locked keywords (left/right -> x, top/bottom -> y) are assigned
   // first so author order is irrelevant (`at top left` == `at left top`); the remaining `center`
@@ -972,15 +995,58 @@ void HTMLValueParser::parseRadialDescriptor(const std::string& descriptor, float
   if (!std::isnan(cx)) grad->center.x = cx;
   if (!std::isnan(cy)) grad->center.y = cy;
 
-  // A CSS `circle <r>px` keeps a single uniform radius regardless of box aspect ratio. PAGX's
-  // default fitsToGeometry=true model stretches the normalised radius by box width and height
-  // independently, so on a non-square box it would render the circle as an ellipse. Switch such a
-  // circle to the fitsToGeometry=false pixel model (center/radius in the geometry's local px
-  // space, where the box spans (0,0)-(boxWidth,boxHeight)) so the radius stays isotropic. Square
-  // boxes, ellipses, and percentage/extent sizes keep the compact normalised representation.
-  bool isCircle = explicitCircle || (!explicitEllipse && sizeTokens.size() == 1);
-  if (isCircle && radiusFromPxLength && boxWidth > 0 && boxHeight > 0 &&
-      std::abs(boxWidth - boxHeight) > 0.01f) {
+  // Radius: a length token divided by boxWidth recovers the normalised radius (a bare `<pct>%` is
+  // already box-relative); track whether it came from an explicit px length so a circle on a
+  // non-square box can later switch to the fitsToGeometry=false pixel model. An extent keyword
+  // (or, for a circle, an omitted size — CSS defaults it to farthest-corner) has no scalar radius
+  // in the token, so a circle derives the px radius from its center and the box; `circleExtentPx`
+  // then routes it through the pixel model below since the value is already in px.
+  bool radiusFromPxLength = false;
+  bool circleExtentPx = false;
+  if (!sizeTokens.empty() && boxWidth > 0) {
+    float radius = resolveRadialLength(sizeTokens[0], boxWidth);
+    if (!std::isnan(radius)) {
+      grad->radius = radius;
+      radiusFromPxLength = !sizeTokens[0].empty() && sizeTokens[0].back() != '%';
+    } else if (IsRadialExtentKeyword(sizeTokens[0])) {
+      // Only an explicit `circle` maps cleanly to PAGX's single radius. An implicit shape with an
+      // extent keyword (or an explicit ellipse) is an ellipse in CSS and needs per-axis radii the
+      // model can't represent, so keep the box-filling default and surface a diagnostic.
+      if (explicitCircle && boxHeight > 0) {
+        grad->radius = CircleExtentRadiusPx(sizeTokens[0], grad->center.x * boxWidth,
+                                            grad->center.y * boxHeight, boxWidth, boxHeight);
+        circleExtentPx = true;
+      } else {
+        _diagnostics.warn("html: radial-gradient size '" + sizeTokens[0] +
+                          "' not supported; using box-filling radius");
+      }
+    } else {
+      _diagnostics.warn("html: radial-gradient size '" + sizeTokens[0] +
+                        "' not supported; using box-filling radius");
+    }
+  } else if (sizeTokens.empty() && explicitCircle && boxWidth > 0 && boxHeight > 0) {
+    // A `circle` with no size defaults to farthest-corner in CSS.
+    grad->radius = CircleExtentRadiusPx("", grad->center.x * boxWidth, grad->center.y * boxHeight,
+                                        boxWidth, boxHeight);
+    circleExtentPx = true;
+  }
+
+  // Keep a circle's single radius isotropic. The default fitsToGeometry=true model scales the
+  // normalised radius by box width and height independently, so on a non-square box it would render
+  // a circle as an ellipse; such circles switch to the fitsToGeometry=false pixel model (center /
+  // radius in the geometry's local px space, where the box spans (0,0)-(boxWidth,boxHeight)). On a
+  // square box the normalised model is already isotropic, so keep the compact representation:
+  // extent/omitted sizes carry a px radius that is normalised back by boxWidth, while an explicit
+  // px length was already normalised above. Ellipses and percentage sizes stay normalised too.
+  bool nonSquare = boxWidth > 0 && boxHeight > 0 && std::abs(boxWidth - boxHeight) > 0.01f;
+  if (circleExtentPx) {
+    if (nonSquare) {
+      grad->center = {grad->center.x * boxWidth, grad->center.y * boxHeight};
+      grad->fitsToGeometry = false;
+    } else {
+      grad->radius = grad->radius / boxWidth;
+    }
+  } else if (isCircle && radiusFromPxLength && nonSquare) {
     grad->center = {grad->center.x * boxWidth, grad->center.y * boxHeight};
     grad->radius = grad->radius * boxWidth;
     grad->fitsToGeometry = false;
@@ -1082,6 +1148,37 @@ bool HTMLValueParser::finaliseGradientStops(GradientStops& stops) {
     float nextOffset = next < stops.size() ? stops[next].first : 1.0f;
     float steps = static_cast<float>(next - (i - 1));
     stops[i].first = prevOffset + (nextOffset - prevOffset) / steps;
+  }
+
+  // CSS interpolates gradient stops in premultiplied-alpha space, so a `transparent` (or any
+  // alpha=0) stop contributes only its neighbour's colour as the alpha fades — e.g. a
+  // `rgba(220,210,255,0.4) -> transparent` ramp stays purple while vanishing. The renderer
+  // interpolates unpremultiplied, where a keyword `transparent` carries black RGB and would drag
+  // the ramp toward grey/black. Rewrite each fully transparent stop's RGB to that of its nearest
+  // opaque neighbour (alpha kept at 0) so the unpremultiplied interpolation matches CSS. A stop
+  // between two opaque colours prefers the earlier neighbour, matching the premultiplied midpoint.
+  for (size_t i = 0; i < stops.size(); ++i) {
+    if (stops[i].second.alpha > 0.0f) continue;
+    size_t donor = stops.size();
+    for (size_t back = i; back-- > 0;) {
+      if (stops[back].second.alpha > 0.0f) {
+        donor = back;
+        break;
+      }
+    }
+    if (donor == stops.size()) {
+      for (size_t fwd = i + 1; fwd < stops.size(); ++fwd) {
+        if (stops[fwd].second.alpha > 0.0f) {
+          donor = fwd;
+          break;
+        }
+      }
+    }
+    if (donor != stops.size()) {
+      stops[i].second.red = stops[donor].second.red;
+      stops[i].second.green = stops[donor].second.green;
+      stops[i].second.blue = stops[donor].second.blue;
+    }
   }
   return true;
 }

--- a/src/pagx/ppt/PPTTextWriter.cpp
+++ b/src/pagx/ppt/PPTTextWriter.cpp
@@ -97,6 +97,75 @@ bool HasOnlyEmbeddedEmojiGlyphs(const Text* text) {
   return hasEmojiGlyph;
 }
 
+constexpr float LineCoordinateEpsilon = 0.5f;
+
+static void AddDistinctLineCoordinate(std::vector<float>* coordinates, float coordinate) {
+  for (float existing : *coordinates) {
+    if (std::fabs(existing - coordinate) < LineCoordinateEpsilon) {
+      return;
+    }
+  }
+  coordinates->push_back(coordinate);
+}
+
+// Embedded GlyphRun positions are the authoring layout's source of truth. Horizontal glyphs on
+// the same visual line share a baseline (run->y + positions[i].y), even when FontEmbedder split
+// them into several font/bitmap runs. A single embedded baseline is especially useful because it
+// proves that the authored text is one line without requiring a glyph-to-UTF-8 cluster mapping.
+// Multi-line byte boundaries cannot be reconstructed generically from GlyphRun alone (ligatures,
+// BiDi and fallback-font splits make glyph counts differ from character counts), so callers retain
+// PowerPoint's bounded-wrap fallback for those cases.
+static bool HasSingleEmbeddedHorizontalLine(const std::vector<const Text*>& texts) {
+  std::vector<float> baselines;
+  bool hasRenderedGlyph = false;
+  for (const auto* text : texts) {
+    if (text == nullptr || text->glyphRuns.empty()) {
+      return false;
+    }
+    bool textHasRenderedGlyph = false;
+    for (const auto* run : text->glyphRuns) {
+      // A missing position would make every such glyph appear to share run->y and could turn an
+      // incomplete multi-line run into a false single-line result. Only trust complete authoring
+      // coordinates; the caller will retain bounded PowerPoint wrapping otherwise.
+      if (run == nullptr || run->glyphs.empty() || run->positions.size() < run->glyphs.size()) {
+        return false;
+      }
+      for (size_t i = 0; i < run->glyphs.size(); ++i) {
+        if (run->glyphs[i] == 0) {
+          continue;
+        }
+        float baseline = run->y + run->positions[i].y;
+        if (!std::isfinite(baseline)) {
+          return false;
+        }
+        AddDistinctLineCoordinate(&baselines, baseline);
+        textHasRenderedGlyph = true;
+        hasRenderedGlyph = true;
+        if (baselines.size() > 1) {
+          return false;
+        }
+      }
+    }
+    if (!textHasRenderedGlyph) {
+      return false;
+    }
+  }
+  return hasRenderedGlyph && baselines.size() == 1;
+}
+
+static size_t CountNonEmptyLayoutLines(const std::vector<TextLayoutLineInfo>* lines) {
+  if (lines == nullptr) {
+    return 0;
+  }
+  size_t count = 0;
+  for (const auto& line : *lines) {
+    if (line.byteStart < line.byteEnd) {
+      ++count;
+    }
+  }
+  return count;
+}
+
 }  // namespace
 
 // Returns the baseline of the first rendered glyph in the embedded run coordinate system.
@@ -438,14 +507,12 @@ void PPTWriter::emitTextShapeEnvelope(XMLBuilder& out, const Xform& xf, const Te
 }
 
 void PPTWriter::emitNativeTextShapeFrame(XMLBuilder& out, const Matrix& m,
-                                         const NativeTextGeometry& geom, const TextBox* textBox) {
+                                         const NativeTextGeometry& geom, const TextBox* textBox,
+                                         bool disableAutoWrap) {
   auto xf = DecomposeXform(geom.posX, geom.posY, geom.estWidth, geom.estHeight, m);
-  // A fixed inline extent is an authored wrapping boundary. Keep native
-  // PowerPoint wrapping enabled even when PAGX supplied line metadata and we
-  // also emit soft breaks: Web/WASM may shape with a different or unavailable
-  // fallback font and report one oversized line, while PowerPoint can still
-  // wrap that line against the authored TextBox extent. Auto-sized and
-  // zero-extent anchor boxes remain unbounded.
+  // A fixed inline extent remains a wrapping boundary unless the caller has an authoritative
+  // reason to disable PowerPoint's metric-dependent wrapping: PAGX supplied explicit line
+  // boundaries, wordWrap is false, or complete embedded positions prove an authored single line.
   bool hasInlineExtent = false;
   if (textBox != nullptr) {
     float inlineExtent = textBox->writingMode == WritingMode::Vertical
@@ -461,7 +528,7 @@ void PPTWriter::emitNativeTextShapeFrame(XMLBuilder& out, const Matrix& m,
   // it needs no such fallback.
   bool justifyAlign =
       textBox != nullptr && textBox->textAlign == TextAlign::Justify && !geom.originFromGlyphRun;
-  const char* wrap = (hasInlineExtent || justifyAlign) ? "square" : "none";
+  const char* wrap = (justifyAlign || (!disableAutoWrap && hasInlineExtent)) ? "square" : "none";
   emitTextShapeEnvelope(out, xf, textBox, wrap, geom.originFromGlyphRun,
                         !geom.originFromGlyphRun || geom.frameUsesLineBox);
 }
@@ -554,6 +621,7 @@ void PPTWriter::writeNativeText(XMLBuilder& out, const Text* text, const FillStr
   auto* mutableText = const_cast<Text*>(text);
   float boxWidth = fs.textBox ? EffectiveTextBoxWidth(fs.textBox) : NAN;
   bool hasTextBox = fs.textBox && !std::isnan(boxWidth) && boxWidth > 0;
+  bool isVertical = fs.textBox && fs.textBox->writingMode == WritingMode::Vertical;
 
   TextLayoutResult localResult;
   if (!precomputed) {
@@ -568,16 +636,43 @@ void PPTWriter::writeNativeText(XMLBuilder& out, const Text* text, const FillStr
   }
   auto* lines = precomputed->getTextLines(mutableText);
 
+  // Embedded GlyphRun data is authoritative for PAGX rendering, so TextLayout::Layout normally
+  // returns only its stored bounds. Native PPT text cannot replay those glyph IDs; reshape the
+  // editable Text attributes here as a best-effort source of byte ranges. Embedded positions are
+  // checked separately below before those environment-dependent ranges are allowed to disable
+  // PowerPoint's bounded fallback.
+  TextLayoutResult editableTextResult;
+  if (lines == nullptr) {
+    auto params = hasTextBox ? MakeTextBoxParams(fs.textBox) : MakeStandaloneParams(text);
+    editableTextResult = TextLayout::Layout({{mutableText, MakeGlyphParams(mutableText)}}, params,
+                                            _layoutContext, false);
+    lines = editableTextResult.getTextLines(mutableText);
+  }
+
   auto geom = computeNativeTextGeometry(text, mutableText, fs, precomputed);
 
-  // When PAGX layout produced explicit per-line byte ranges we emit them as
-  // soft <a:br/> breaks within a single paragraph ourselves, so PowerPoint
-  // shouldn't perform additional line-wrapping on top (its font metrics differ
-  // slightly from PAGX's, which would shift the break points). Vertical layout
-  // has no line info; fall back to PowerPoint-driven wrapping in that case.
+  // Line byte ranges are emitted as soft <a:br/> breaks within one paragraph. For ordinary text
+  // they come from the same PAGX layout that renders the document and are authoritative. For
+  // embedded text, fresh shaping is only a best-effort editable fallback and is validated against
+  // the authoring positions below.
   bool useLineLayout = (lines != nullptr) && !lines->empty();
+  bool hasEmbeddedGlyphRuns = !text->glyphRuns.empty();
+  bool hasSingleEmbeddedLine = hasEmbeddedGlyphRuns && !isVertical &&
+                               HasSingleEmbeddedHorizontalLine(std::vector<const Text*>{text});
+  // If the embedded authoring data proves this is a single line but the export environment's
+  // fallback font wrapped it, those fresh byte ranges are not authoritative. Stream the readable
+  // text without inferred soft breaks and keep PowerPoint wrapping disabled so the authored
+  // single-line contract wins.
+  if (hasSingleEmbeddedLine && CountNonEmptyLayoutLines(lines) != 1) {
+    useLineLayout = false;
+  }
+  // For ordinary text, the fresh layout is the same source of truth PAGX renders. Embedded text
+  // is environment-dependent after it is made editable, so only a proven single authored line (or
+  // an explicit wordWrap=false contract) is strong enough to disable PowerPoint's bounded fallback.
+  bool disableAutoWrap = (fs.textBox != nullptr && !fs.textBox->wordWrap) ||
+                         (!hasEmbeddedGlyphRuns && useLineLayout) || hasSingleEmbeddedLine;
 
-  emitNativeTextShapeFrame(out, m, geom, fs.textBox);
+  emitNativeTextShapeFrame(out, m, geom, fs.textBox, disableAutoWrap);
 
   // Paragraph base direction by UBA P2/P3. Emitted via pPr@rtl so PowerPoint
   // runs BiDi with the correct base direction and reproduces the same visual
@@ -635,7 +730,6 @@ void PPTWriter::writeNativeText(XMLBuilder& out, const Text* text, const FillStr
   // vertical mode under the assumption that lnSpc only ever drives the inline axis, which left
   // PowerPoint to fall back to its default ~1.2x font-size column width regardless of the
   // PAGX-authored lineHeight.
-  bool isVertical = fs.textBox && fs.textBox->writingMode == WritingMode::Vertical;
   int64_t lnSpcPts = fs.textBox ? LineHeightToSpcPts(fs.textBox->lineHeight) : 0;
 
   // Vertical writing mode ignores BiDi base direction; suppress the rtl
@@ -819,7 +913,7 @@ void PPTWriter::ParagraphEmitter::emitLineBreak(const PPTRunStyle& style) {
 }
 
 void PPTWriter::emitTextBoxShapeFrame(XMLBuilder& out, const TextBox* box, const Matrix& transform,
-                                      float estWidth, float estHeight) {
+                                      float estWidth, float estHeight, bool disableAutoWrap) {
   // `transform` already incorporates BuildGroupMatrix(box) (applied by the
   // caller in writeElements), so the local origin here is (0, 0). Adding
   // box->position again would double-offset the shape, pushing the text-box
@@ -866,10 +960,8 @@ void PPTWriter::emitTextBoxShapeFrame(XMLBuilder& out, const TextBox* box, const
     }
   }
   auto xf = DecomposeXform(anchorOffsetX, anchorOffsetY, estWidth, estHeight, transform);
-  // Preserve the authored inline wrapping boundary as a native PowerPoint
-  // fallback even when PAGX line metadata is available. This keeps Web/WASM
-  // output usable when its font environment computes fewer line breaks than
-  // the environment that authored the PAGX file.
+  // Preserve the authored inline wrapping boundary unless the caller has an authoritative reason
+  // to disable PowerPoint's independent wrapping pass.
   float inlineExtent = isVertical ? EffectiveTextBoxHeight(box) : EffectiveTextBoxWidth(box);
   bool hasInlineExtent = !std::isnan(inlineExtent) && inlineExtent > 0;
   // Justify alignment requires PowerPoint to know a target line width; with
@@ -877,7 +969,7 @@ void PPTWriter::emitTextBoxShapeFrame(XMLBuilder& out, const TextBox* box, const
   // alignment. Force wrap="square" in that case so PPT can justify within the
   // shape's text area even when the box is auto-sized in the inline axis.
   bool justifyAlign = box->textAlign == TextAlign::Justify;
-  const char* wrap = (hasInlineExtent || justifyAlign) ? "square" : "none";
+  const char* wrap = (justifyAlign || (!disableAutoWrap && hasInlineExtent)) ? "square" : "none";
   emitTextShapeEnvelope(out, xf, box, wrap);
 }
 
@@ -1009,6 +1101,7 @@ void PPTWriter::writeTextBoxGroup(XMLBuilder& out, const Group* textBox,
   if (runs.empty()) {
     return;
   }
+  bool isVertical = box->writingMode == WritingMode::Vertical;
 
   // Run a layout pass to obtain the textbox's resolved bounds AND its
   // per-Text line-break decisions. We use those line breaks as paragraph
@@ -1031,16 +1124,20 @@ void PPTWriter::writeTextBoxGroup(XMLBuilder& out, const Group* textBox,
   // authoring layout's block bounds, so keep those dimensions for the PowerPoint envelope while
   // still using the fresh result above for line entries and editable runs.
   Rect embeddedBounds = {};
-  bool allHaveEmbeddedGlyphRuns = _ignoreGlyphRuns;
+  bool allHaveEmbeddedGlyphRuns = true;
+  std::vector<const Text*> embeddedTexts;
+  embeddedTexts.reserve(runs.size());
   for (const auto& run : runs) {
+    embeddedTexts.push_back(run.text);
     if (run.text->glyphRuns.empty()) {
       allHaveEmbeddedGlyphRuns = false;
-      break;
     }
   }
-  if (allHaveEmbeddedGlyphRuns) {
+  if (_ignoreGlyphRuns && allHaveEmbeddedGlyphRuns) {
     embeddedBounds = TextLayout::Layout(textElements, params, _layoutContext, true).bounds;
   }
+  bool hasSingleEmbeddedLine =
+      allHaveEmbeddedGlyphRuns && !isVertical && HasSingleEmbeddedHorizontalLine(embeddedTexts);
   float boxWidth = EffectiveTextBoxWidth(box);
   float boxHeight = EffectiveTextBoxHeight(box);
   bool hasBoxWidth = !std::isnan(boxWidth) && boxWidth > 0;
@@ -1062,13 +1159,31 @@ void PPTWriter::writeTextBoxGroup(XMLBuilder& out, const Group* textBox,
   // vertical mode each entry is a column instead of a row (baselineY stores -columnX so the
   // ascending sort below maps to right-to-left source order); columns dropped by
   // overflow="hidden" are absent from the layout result and therefore omitted from the PPT output
-  // automatically. `getTextLines` only returns nullptr for layouts where line info isn't tracked
-  // (e.g. embedded glyph runs); those fall back to legacy '\n'-splitting.
+  // automatically. Embedded glyph runs only store bounds, so native PPT output reshapes their
+  // editable Text attributes below to recover the missing byte-range metadata.
   std::vector<LineEntry> lineEntries;
   bool useLineLayout = true;
+  TextLayoutResult editableTextResult;
+  bool needsEditableTextLayout = false;
   for (size_t i = 0; i < runs.size(); ++i) {
     auto* mt = const_cast<Text*>(runs[i].text);
     auto* lines = layoutResult.getTextLines(mt);
+    if (lines == nullptr) {
+      needsEditableTextLayout = true;
+      break;
+    }
+  }
+  if (needsEditableTextLayout) {
+    // See writeNativeText: all-embedded TextBox content has stored bounds but no byte-range line
+    // metadata. Reshape once as a best-effort source of editable byte ranges; the embedded
+    // positions below decide whether those ranges are authoritative enough to disable auto-wrap.
+    editableTextResult = TextLayout::Layout(textElements, params, _layoutContext, false);
+  }
+  const TextLayoutResult* lineLayoutResult =
+      needsEditableTextLayout ? &editableTextResult : &layoutResult;
+  for (size_t i = 0; i < runs.size(); ++i) {
+    auto* mt = const_cast<Text*>(runs[i].text);
+    auto* lines = lineLayoutResult->getTextLines(mt);
     if (lines == nullptr) {
       useLineLayout = false;
       lineEntries.clear();
@@ -1085,7 +1200,22 @@ void PPTWriter::writeTextBoxGroup(XMLBuilder& out, const Group* textBox,
     useLineLayout = false;
   }
 
-  emitTextBoxShapeFrame(out, box, transform, estWidth, estHeight);
+  if (hasSingleEmbeddedLine && useLineLayout) {
+    std::vector<float> freshBaselines;
+    for (const auto& entry : lineEntries) {
+      AddDistinctLineCoordinate(&freshBaselines, entry.baselineY);
+    }
+    if (freshBaselines.size() != 1) {
+      // The export host wrapped a source that the embedded authoring layout proves is one line.
+      // Do not serialize those inferred breaks; emit the source runs continuously instead.
+      useLineLayout = false;
+      lineEntries.clear();
+    }
+  }
+  bool disableAutoWrap =
+      !box->wordWrap || (!allHaveEmbeddedGlyphRuns && useLineLayout) || hasSingleEmbeddedLine;
+
+  emitTextBoxShapeFrame(out, box, transform, estWidth, estHeight, disableAutoWrap);
 
   // Paragraph base direction by UBA P2/P3. A TextBox carries a single pPr so
   // all runs share one base direction; concatenating the run text in source
@@ -1093,7 +1223,6 @@ void PPTWriter::writeTextBoxGroup(XMLBuilder& out, const Group* textBox,
   // directional character, matching the paragraph-level rule that PAGX's ICU
   // BiDi uses. Vertical writing mode ignores rtl per OOXML, so we suppress it
   // in that case to avoid emitting a no-op attribute.
-  bool isVertical = box->writingMode == WritingMode::Vertical;
   bool rtl = false;
   if (!isVertical) {
     std::string combined;

--- a/src/pagx/ppt/PPTTextWriter.cpp
+++ b/src/pagx/ppt/PPTTextWriter.cpp
@@ -97,11 +97,11 @@ bool HasOnlyEmbeddedEmojiGlyphs(const Text* text) {
   return hasEmojiGlyph;
 }
 
-constexpr float LineCoordinateEpsilon = 0.5f;
+constexpr float LINE_COORDINATE_EPSILON = 0.5f;
 
-static void AddDistinctLineCoordinate(std::vector<float>* coordinates, float coordinate) {
+void AddDistinctLineCoordinate(std::vector<float>* coordinates, float coordinate) {
   for (float existing : *coordinates) {
-    if (std::fabs(existing - coordinate) < LineCoordinateEpsilon) {
+    if (std::fabs(existing - coordinate) < LINE_COORDINATE_EPSILON) {
       return;
     }
   }
@@ -109,13 +109,13 @@ static void AddDistinctLineCoordinate(std::vector<float>* coordinates, float coo
 }
 
 // Embedded GlyphRun positions are the authoring layout's source of truth. Horizontal glyphs on
-// the same visual line share a baseline (run->y + positions[i].y), even when FontEmbedder split
-// them into several font/bitmap runs. A single embedded baseline is especially useful because it
-// proves that the authored text is one line without requiring a glyph-to-UTF-8 cluster mapping.
-// Multi-line byte boundaries cannot be reconstructed generically from GlyphRun alone (ligatures,
-// BiDi and fallback-font splits make glyph counts differ from character counts), so callers retain
-// PowerPoint's bounded-wrap fallback for those cases.
-static bool HasSingleEmbeddedHorizontalLine(const std::vector<const Text*>& texts) {
+// the same visual line share a final baseline (text->renderPosition().y + run->y + positions[i].y),
+// even when FontEmbedder split them into several font/bitmap runs. A single embedded baseline is
+// especially useful because it proves that the authored text is one line without requiring a
+// glyph-to-UTF-8 cluster mapping. Multi-line byte boundaries cannot be reconstructed generically
+// from GlyphRun alone (ligatures, BiDi and fallback-font splits make glyph counts differ from
+// character counts), so callers retain PowerPoint's bounded-wrap fallback for those cases.
+bool HasSingleEmbeddedHorizontalLine(const std::vector<const Text*>& texts) {
   std::vector<float> baselines;
   bool hasRenderedGlyph = false;
   for (const auto* text : texts) {
@@ -134,7 +134,7 @@ static bool HasSingleEmbeddedHorizontalLine(const std::vector<const Text*>& text
         if (run->glyphs[i] == 0) {
           continue;
         }
-        float baseline = run->y + run->positions[i].y;
+        float baseline = text->renderPosition().y + run->y + run->positions[i].y;
         if (!std::isfinite(baseline)) {
           return false;
         }
@@ -153,7 +153,7 @@ static bool HasSingleEmbeddedHorizontalLine(const std::vector<const Text*>& text
   return hasRenderedGlyph && baselines.size() == 1;
 }
 
-static size_t CountNonEmptyLayoutLines(const std::vector<TextLayoutLineInfo>* lines) {
+size_t CountNonEmptyLayoutLines(const std::vector<TextLayoutLineInfo>* lines) {
   if (lines == nullptr) {
     return 0;
   }
@@ -666,11 +666,10 @@ void PPTWriter::writeNativeText(XMLBuilder& out, const Text* text, const FillStr
   if (hasSingleEmbeddedLine && CountNonEmptyLayoutLines(lines) != 1) {
     useLineLayout = false;
   }
-  // For ordinary text, the fresh layout is the same source of truth PAGX renders. Embedded text
-  // is environment-dependent after it is made editable, so only a proven single authored line (or
-  // an explicit wordWrap=false contract) is strong enough to disable PowerPoint's bounded fallback.
-  bool disableAutoWrap = (fs.textBox != nullptr && !fs.textBox->wordWrap) ||
-                         (!hasEmbeddedGlyphRuns && useLineLayout) || hasSingleEmbeddedLine;
+  // Only an explicit wordWrap=false contract or complete embedded positions proving one authored
+  // line are strong enough to disable PowerPoint's bounded fallback. Even ordinary PAGX line
+  // metadata can be platform-dependent when the export host lacks the authored font.
+  bool disableAutoWrap = (fs.textBox != nullptr && !fs.textBox->wordWrap) || hasSingleEmbeddedLine;
 
   emitNativeTextShapeFrame(out, m, geom, fs.textBox, disableAutoWrap);
 
@@ -1212,8 +1211,7 @@ void PPTWriter::writeTextBoxGroup(XMLBuilder& out, const Group* textBox,
       lineEntries.clear();
     }
   }
-  bool disableAutoWrap =
-      !box->wordWrap || (!allHaveEmbeddedGlyphRuns && useLineLayout) || hasSingleEmbeddedLine;
+  bool disableAutoWrap = !box->wordWrap || hasSingleEmbeddedLine;
 
   emitTextBoxShapeFrame(out, box, transform, estWidth, estHeight, disableAutoWrap);
 

--- a/src/pagx/ppt/PPTWriter.h
+++ b/src/pagx/ppt/PPTWriter.h
@@ -804,7 +804,7 @@ class PPTWriter {
                                                const FillStrokeInfo& fs,
                                                const TextLayoutResult* precomputed);
   void emitNativeTextShapeFrame(XMLBuilder& out, const Matrix& m, const NativeTextGeometry& geom,
-                                const TextBox* textBox);
+                                const TextBox* textBox, bool disableAutoWrap);
   void emitNativeTextBody(XMLBuilder& out, const Text* text,
                           const std::vector<TextLayoutLineInfo>* lines, const PPTRunStyle& style,
                           int64_t lnSpcPts, bool rtl, bool useLineLayout, int64_t defTabSzEMU,
@@ -859,7 +859,7 @@ class PPTWriter {
   };
 
   void emitTextBoxShapeFrame(XMLBuilder& out, const TextBox* box, const Matrix& transform,
-                             float estWidth, float estHeight);
+                             float estWidth, float estHeight, bool disableAutoWrap);
   void emitTextBoxBody(const std::vector<RichTextRun>& runs,
                        const std::vector<PPTRunStyle>& runStyles,
                        std::vector<LineEntry>& lineEntries, bool useLineLayout,

--- a/src/pagx/utils/CSSFontStyle.cpp
+++ b/src/pagx/utils/CSSFontStyle.cpp
@@ -134,10 +134,9 @@ FontStyleSynthesis ResolveFontStyleSynthesis(const std::string& cssFontWeight,
                                              const std::string& cssFontStyle) {
   FontStyleSynthesis out;
   int numericWeight = CssFontWeightToNumeric(cssFontWeight);
-  // The weight axis is always carried as a real-face style label (Bold / SemiBold / Black / etc.),
-  // not pre-synthesised: this lets TextLayout resolve the authored heavy face when it is installed
-  // or embedded, then apply faux emboldening only if the resolved face is lighter than requested.
-  // This preserves distinct face selection without losing weight when a face is missing.
+  // The weight axis is always carried as a real-face style label (Bold / SemiBold / Black / etc.)
+  // and is never pre-synthesised. This preserves precise face selection when the requested face is
+  // available. If it is unavailable, normal font lookup fallback applies without faux emboldening.
   out.fauxBold = false;
   const char* weightKeyword = WeightKeywordForRoundedHundreds(numericWeight);
   if (weightKeyword) {

--- a/src/pagx/utils/CSSFontStyle.cpp
+++ b/src/pagx/utils/CSSFontStyle.cpp
@@ -134,20 +134,18 @@ FontStyleSynthesis ResolveFontStyleSynthesis(const std::string& cssFontWeight,
                                              const std::string& cssFontStyle) {
   FontStyleSynthesis out;
   int numericWeight = CssFontWeightToNumeric(cssFontWeight);
-  bool italic = IsItalicCssStyle(cssFontStyle);
-  // Threshold mirrors CSS bold synthesis: SemiBold-or-heavier (>= 600) is treated as a faux-bold
-  // request because the renderer's faux emboldening is a single fixed step and cannot distinguish
-  // SemiBold from Black anyway.
-  out.fauxBold = numericWeight >= 600;
-  out.fauxItalic = italic;
-  // Keep only the real-face axes in the style label: a synthesised axis is dropped so the renderer
-  // resolves a base (Regular / lighter) face and faux adds the missing weight / slant on top,
-  // instead of resolving the styled face and doubling up.
-  const char* weightKeyword =
-      out.fauxBold ? nullptr : WeightKeywordForRoundedHundreds(numericWeight);
+  // The weight axis is always carried as a real-face style label (Bold / SemiBold / Black / etc.),
+  // not synthesised: this lets the renderer resolve the authored heavy face when it is installed or
+  // embedded, and only fall back to faux emboldening (applied by the render host on a missing face)
+  // without collapsing SemiBold / Bold / Black into one indistinguishable step.
+  out.fauxBold = false;
+  const char* weightKeyword = WeightKeywordForRoundedHundreds(numericWeight);
   if (weightKeyword) {
     out.fontStyleName = weightKeyword;
   }
+  // Italic is kept as a faux axis: an oblique slant can be synthesised on top of any upright face,
+  // so it survives even when the styled italic face is unavailable.
+  out.fauxItalic = IsItalicCssStyle(cssFontStyle);
   return out;
 }
 

--- a/src/pagx/utils/CSSFontStyle.cpp
+++ b/src/pagx/utils/CSSFontStyle.cpp
@@ -135,9 +135,9 @@ FontStyleSynthesis ResolveFontStyleSynthesis(const std::string& cssFontWeight,
   FontStyleSynthesis out;
   int numericWeight = CssFontWeightToNumeric(cssFontWeight);
   // The weight axis is always carried as a real-face style label (Bold / SemiBold / Black / etc.),
-  // not synthesised: this lets the renderer resolve the authored heavy face when it is installed or
-  // embedded, and only fall back to faux emboldening (applied by the render host on a missing face)
-  // without collapsing SemiBold / Bold / Black into one indistinguishable step.
+  // not pre-synthesised: this lets TextLayout resolve the authored heavy face when it is installed
+  // or embedded, then apply faux emboldening only if the resolved face is lighter than requested.
+  // This preserves distinct face selection without losing weight when a face is missing.
   out.fauxBold = false;
   const char* weightKeyword = WeightKeywordForRoundedHundreds(numericWeight);
   if (weightKeyword) {

--- a/src/pagx/utils/CSSFontStyle.h
+++ b/src/pagx/utils/CSSFontStyle.h
@@ -42,10 +42,9 @@ std::string ResolveFontStyleName(const std::string& cssFontWeight, const std::st
 // The weight axis is always emitted as a real-face style label (Bold / SemiBold / Black / etc. per
 // the numeric weight rounded to the nearest hundred; 400 leaves the weight portion empty), never as
 // a faux flag. This lets the renderer resolve the authored heavy face when it is installed or
-// embedded (preserving the distinction between SemiBold, Bold and Black). During layout, the
-// resolved face's actual weight is compared with this requested label and faux emboldening is added
-// only when the resolved face is lighter, instead of always synthesising a single fixed step on a
-// Regular base.
+// embedded, preserving the distinction between SemiBold, Bold and Black. If the requested face is
+// unavailable, normal font lookup fallback applies without faux emboldening; the importer favours
+// precise real-face selection over synthesising a missing weight.
 //
 // Italic stays a synthetic axis (`fauxItalic`): an oblique slant can be synthesised on top of any
 // upright face, so it survives even when the styled italic face is unavailable.

--- a/src/pagx/utils/CSSFontStyle.h
+++ b/src/pagx/utils/CSSFontStyle.h
@@ -37,27 +37,26 @@ namespace pagx {
 std::string ResolveFontStyleName(const std::string& cssFontWeight, const std::string& cssFontStyle);
 
 // Splits a CSS font-weight / font-style request into the real face style the renderer should
-// resolve plus the synthetic (faux) axes it must emboss on top. This lets an importer bake the
-// authored weight / slant into a `.pagx` without relying on render-time face introspection:
-// uninstalled web faces (the common case for HTML / SVG imports such as "Noto Sans SC Black
-// Italic") still render at the authored weight and slant via faux synthesis.
+// resolve plus the synthetic (faux) italic axis it may emboss on top.
 //
-// The synthesised axes are *removed* from `fontStyleName` rather than kept alongside the faux
-// flags. A host that does ship the real heavy / italic face must not be emboldened twice
-// (faux-on-top-of-real, which the renderer layers additively), and keeping the styled name would
-// trigger exactly that whenever the styled face is resolvable. Stripping it makes the rendered
-// result identical whether or not the styled face is installed. Weights below the bold threshold
-// (Thin / ExtraLight / Light / Medium) cannot be synthesised — faux only adds weight, never
-// removes it — so those keywords are preserved in `fontStyleName` and carry no faux flag.
+// The weight axis is always emitted as a real-face style label (Bold / SemiBold / Black / etc. per
+// the numeric weight rounded to the nearest hundred; 400 leaves the weight portion empty), never as
+// a faux flag. This lets the renderer resolve the authored heavy face when it is installed or
+// embedded (preserving the distinction between SemiBold, Bold and Black) and only fall back to host
+// faux emboldening for a genuinely missing face, instead of always synthesising a single fixed step
+// on a Regular base.
 //
-// Examples (threshold mirrors CSS bold synthesis at weight >= 600):
-//   ("900", "italic") -> {fontStyleName: "",       fauxBold: true,  fauxItalic: true}
-//   ("700", "")       -> {fontStyleName: "",       fauxBold: true,  fauxItalic: false}
-//   ("600", "italic") -> {fontStyleName: "",       fauxBold: true,  fauxItalic: true}
-//   ("500", "italic") -> {fontStyleName: "Medium", fauxBold: false, fauxItalic: true}
-//   ("300", "")       -> {fontStyleName: "Light",  fauxBold: false, fauxItalic: false}
-//   ("400", "italic") -> {fontStyleName: "",       fauxBold: false, fauxItalic: true}
-//   ("400", "")       -> {fontStyleName: "",       fauxBold: false, fauxItalic: false}
+// Italic stays a synthetic axis (`fauxItalic`): an oblique slant can be synthesised on top of any
+// upright face, so it survives even when the styled italic face is unavailable.
+//
+// Examples:
+//   ("900", "italic") -> {fontStyleName: "Black",    fauxBold: false, fauxItalic: true}
+//   ("700", "")       -> {fontStyleName: "Bold",     fauxBold: false, fauxItalic: false}
+//   ("600", "italic") -> {fontStyleName: "SemiBold", fauxBold: false, fauxItalic: true}
+//   ("500", "italic") -> {fontStyleName: "Medium",   fauxBold: false, fauxItalic: true}
+//   ("300", "")       -> {fontStyleName: "Light",    fauxBold: false, fauxItalic: false}
+//   ("400", "italic") -> {fontStyleName: "",         fauxBold: false, fauxItalic: true}
+//   ("400", "")       -> {fontStyleName: "",         fauxBold: false, fauxItalic: false}
 struct FontStyleSynthesis {
   std::string fontStyleName = {};
   bool fauxBold = false;

--- a/src/pagx/utils/CSSFontStyle.h
+++ b/src/pagx/utils/CSSFontStyle.h
@@ -42,9 +42,10 @@ std::string ResolveFontStyleName(const std::string& cssFontWeight, const std::st
 // The weight axis is always emitted as a real-face style label (Bold / SemiBold / Black / etc. per
 // the numeric weight rounded to the nearest hundred; 400 leaves the weight portion empty), never as
 // a faux flag. This lets the renderer resolve the authored heavy face when it is installed or
-// embedded (preserving the distinction between SemiBold, Bold and Black) and only fall back to host
-// faux emboldening for a genuinely missing face, instead of always synthesising a single fixed step
-// on a Regular base.
+// embedded (preserving the distinction between SemiBold, Bold and Black). During layout, the
+// resolved face's actual weight is compared with this requested label and faux emboldening is added
+// only when the resolved face is lighter, instead of always synthesising a single fixed step on a
+// Regular base.
 //
 // Italic stays a synthetic axis (`fauxItalic`): an oblique slant can be synthesised on top of any
 // upright face, so it survives even when the styled italic face is unavailable.

--- a/test/src/PAGXCSSFontStyleTest.cpp
+++ b/test/src/PAGXCSSFontStyleTest.cpp
@@ -82,27 +82,27 @@ CLI_TEST(PAGXCSSFontStyleTest, ResolveName_WhitespaceAndCaseNormalised) {
   EXPECT_EQ(pagx::ResolveFontStyleName("  BOLD  ", "  ITALIC "), "Bold Italic");
 }
 
-// ResolveFontStyleSynthesis: splits the request into a real-face label plus faux axes. The bold
-// synthesis threshold is weight >= 600; weights below stay as keywords with no faux flag.
+// ResolveFontStyleSynthesis: splits the request into a real-face label plus a faux italic axis. The
+// weight axis is always a real-face keyword (never faux); only italic is synthesised.
 
-CLI_TEST(PAGXCSSFontStyleTest, Synthesis_BlackItalicIsAllFaux) {
+CLI_TEST(PAGXCSSFontStyleTest, Synthesis_BlackItalicKeepsRealWeightFauxItalic) {
   auto out = pagx::ResolveFontStyleSynthesis("900", "italic");
-  EXPECT_EQ(out.fontStyleName, "");
-  EXPECT_TRUE(out.fauxBold);
+  EXPECT_EQ(out.fontStyleName, "Black");
+  EXPECT_FALSE(out.fauxBold);
   EXPECT_TRUE(out.fauxItalic);
 }
 
-CLI_TEST(PAGXCSSFontStyleTest, Synthesis_BoldOnly) {
+CLI_TEST(PAGXCSSFontStyleTest, Synthesis_BoldKeepsRealWeight) {
   auto out = pagx::ResolveFontStyleSynthesis("700", "");
-  EXPECT_EQ(out.fontStyleName, "");
-  EXPECT_TRUE(out.fauxBold);
+  EXPECT_EQ(out.fontStyleName, "Bold");
+  EXPECT_FALSE(out.fauxBold);
   EXPECT_FALSE(out.fauxItalic);
 }
 
-CLI_TEST(PAGXCSSFontStyleTest, Synthesis_SemiBoldThresholdIsFauxBold) {
+CLI_TEST(PAGXCSSFontStyleTest, Synthesis_SemiBoldKeepsRealWeightFauxItalic) {
   auto out = pagx::ResolveFontStyleSynthesis("600", "italic");
-  EXPECT_EQ(out.fontStyleName, "");
-  EXPECT_TRUE(out.fauxBold);
+  EXPECT_EQ(out.fontStyleName, "SemiBold");
+  EXPECT_FALSE(out.fauxBold);
   EXPECT_TRUE(out.fauxItalic);
 }
 

--- a/test/src/PAGXCliTest.cpp
+++ b/test/src/PAGXCliTest.cpp
@@ -2707,6 +2707,46 @@ CLI_TEST(PAGXCliTest, Resolve_MultiLayerPreservesIsolation) {
   EXPECT_TRUE(RenderAndCompare({"render", pagxPath}, "PAGXCliTest/ImportResolve_MultiLayer"));
 }
 
+CLI_TEST(PAGXCliTest, Resolve_SkewSiblingKeepsAllLayers) {
+  // The first sibling has both a tiny scale and a real skew. Skew detection must be
+  // scale-independent, and one non-downgradable matrix must keep every sibling in children so
+  // contents/children paint ordering cannot reverse them.
+  auto pagxPath = CopyToTemp("import_resolve_skew_siblings.pagx", "resolve_skew_siblings.pagx");
+  auto ret = CallRun(pagx::cli::RunResolve, {"resolve", pagxPath});
+  EXPECT_EQ(ret, 0);
+
+  auto doc = pagx::PAGXImporter::FromFile(pagxPath);
+  ASSERT_NE(doc, nullptr);
+  ASSERT_EQ(doc->layers.size(), 1u);
+  auto* hostLayer = doc->layers[0];
+  EXPECT_TRUE(hostLayer->contents.empty());
+  ASSERT_EQ(hostLayer->children.size(), 2u);
+  EXPECT_FALSE(hostLayer->children[0]->matrix.isIdentity());
+  EXPECT_TRUE(hostLayer->children[1]->matrix.isIdentity());
+}
+
+CLI_TEST(PAGXCliTest, Resolve_TransformableSiblingMatricesBecomeGroups) {
+  auto pagxPath =
+      CopyToTemp("import_resolve_transformed_siblings.pagx", "resolve_transformed_siblings.pagx");
+  auto ret = CallRun(pagx::cli::RunResolve, {"resolve", pagxPath});
+  EXPECT_EQ(ret, 0);
+
+  auto doc = pagx::PAGXImporter::FromFile(pagxPath);
+  ASSERT_NE(doc, nullptr);
+  ASSERT_EQ(doc->layers.size(), 1u);
+  auto* hostLayer = doc->layers[0];
+  EXPECT_TRUE(hostLayer->children.empty());
+  ASSERT_EQ(hostLayer->contents.size(), 2u);
+  ASSERT_EQ(hostLayer->contents[0]->nodeType(), pagx::NodeType::Group);
+  auto* transformed = static_cast<pagx::Group*>(hostLayer->contents[0]);
+  EXPECT_FLOAT_EQ(transformed->position.x, 4.0f);
+  EXPECT_FLOAT_EQ(transformed->position.y, 5.0f);
+  EXPECT_FLOAT_EQ(transformed->rotation, 30.0f);
+  EXPECT_FLOAT_EQ(transformed->scale.x, 2.0f);
+  EXPECT_FLOAT_EQ(transformed->scale.y, 3.0f);
+  EXPECT_EQ(hostLayer->contents[1]->nodeType(), pagx::NodeType::Group);
+}
+
 CLI_TEST(PAGXCliTest, Resolve_DeduplicatesInlineSvgImageIds) {
   // Each inline <svg> is imported by its own SVGImporter, which restarts auto-generated id
   // numbering from scratch, so two unrelated <image> elements both become Image id="image1".

--- a/test/src/PAGXCliTest.cpp
+++ b/test/src/PAGXCliTest.cpp
@@ -38,6 +38,7 @@
 #include "pagx/PAGXExporter.h"
 #include "pagx/PAGXImporter.h"
 #include "pagx/nodes/Font.h"
+#include "pagx/nodes/Group.h"
 #include "pagx/nodes/Image.h"
 #include "pagx/nodes/ImagePattern.h"
 #include "tgfx/core/Bitmap.h"
@@ -2679,8 +2680,9 @@ CLI_TEST(PAGXCliTest, Resolve_MissingFile) {
 }
 
 CLI_TEST(PAGXCliTest, Resolve_MultiLayerPreservesIsolation) {
-  // Verifies that resolving an inline SVG with multiple elements preserves each SVG element
-  // in a separate painter scope, preventing painter accumulation bugs.
+  // Resolving an inline SVG with two sibling paths must preserve their common source depth:
+  // each path and its painter live in a separate peer Group. Flattening only the first path while
+  // grouping the second would make the output asymmetric and can change painter accumulation.
   auto pagxPath = CopyToTemp("import_resolve_multi_layer.pagx", "resolve_multi_layer.pagx");
   auto ret = CallRun(pagx::cli::RunResolve, {"resolve", pagxPath});
   EXPECT_EQ(ret, 0);
@@ -2691,14 +2693,15 @@ CLI_TEST(PAGXCliTest, Resolve_MultiLayerPreservesIsolation) {
 
   ASSERT_EQ(doc->layers.size(), 1u);
   auto* hostLayer = doc->layers[0];
-  EXPECT_FALSE(hostLayer->contents.empty());
-  size_t groupCount = 0;
+  EXPECT_TRUE(hostLayer->children.empty());
+  ASSERT_EQ(hostLayer->contents.size(), 2u);
   for (auto* element : hostLayer->contents) {
-    if (element->nodeType() == pagx::NodeType::Group) {
-      groupCount++;
-    }
+    ASSERT_EQ(element->nodeType(), pagx::NodeType::Group);
+    auto* group = static_cast<pagx::Group*>(element);
+    ASSERT_EQ(group->elements.size(), 2u);
+    EXPECT_EQ(group->elements[0]->nodeType(), pagx::NodeType::Path);
+    EXPECT_EQ(group->elements[1]->nodeType(), pagx::NodeType::Stroke);
   }
-  EXPECT_GE(groupCount, 1u);
 
   // Screenshot test: render the resolved file and compare against baseline.
   EXPECT_TRUE(RenderAndCompare({"render", pagxPath}, "PAGXCliTest/ImportResolve_MultiLayer"));

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -1199,6 +1199,27 @@ PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleExtentKeywordsUseDistanceFrom
   }
 }
 
+PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleClosestSideOutsideBoxUsesPositiveDistance) {
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:400px;height:400px">
+      <div style="width:400px;height:200px;background-image:radial-gradient(
+        circle closest-side at -80px -138px, #FFFFFF 0%, transparent 100%)"></div>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* div = doc->layers.front()->children.front();
+  auto* fill = FindElementOfType<pagx::Fill>(div);
+  ASSERT_NE(fill, nullptr);
+  auto* rg = As<pagx::RadialGradient>(fill->color);
+  ASSERT_NE(rg, nullptr);
+  // The center is outside the box, but closest-side is still the positive geometric distance to
+  // the nearest edge: min(80, 480, 138, 338) = 80px.
+  EXPECT_FALSE(rg->fitsToGeometry);
+  EXPECT_TRUE(NearlyEqual(rg->center.x, -80.0f, 0.01f));
+  EXPECT_TRUE(NearlyEqual(rg->center.y, -138.0f, 0.01f));
+  EXPECT_TRUE(NearlyEqual(rg->radius, 80.0f, 0.01f));
+}
+
 PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleExtentOnSquareBoxKeepsNormalised) {
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:200px;height:200px">
@@ -1327,8 +1348,9 @@ PAG_TEST(PAGXHTMLImporterTest, RoundedOverflowClipUsesContourMaskForNonImageChil
   // `border-radius: 50%` inscribes an ellipse, so the mask geometry is an Ellipse.
   auto* ellipse = FindElementOfType<pagx::Ellipse>(wrapper->mask);
   EXPECT_NE(ellipse, nullptr);
-  // The mask is an invisible, layout-excluded child that shares the container's coordinate space.
-  EXPECT_FALSE(wrapper->mask->visible);
+  // The mask stays visible at the PAGX level so the renderer can resolve it; mask ownership
+  // suppresses normal drawing. It is excluded only from layout.
+  EXPECT_TRUE(wrapper->mask->visible);
   EXPECT_FALSE(wrapper->mask->includeInLayout);
 }
 
@@ -8125,7 +8147,7 @@ PAG_TEST(PAGXHTMLImporterTest, BackgroundDataImageExplicitSizeUsesNativeDimensio
 
 // CSS `mask-image: url(data:image/svg+xml,...)` with `mask-mode: alpha` rebuilds an alpha mask
 // layer (the inverse of HTMLWriter::writeMaskCSS). The ellipse geometry round-trips and the mask
-// layer is attached invisibly and excluded from layout.
+// layer stays renderer-visible for mask lookup and is excluded from layout.
 PAG_TEST(PAGXHTMLImporterTest, MaskImageAlphaRebuildsMaskLayer) {
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:110px;height:110px">
@@ -8138,7 +8160,7 @@ PAG_TEST(PAGXHTMLImporterTest, MaskImageAlphaRebuildsMaskLayer) {
   auto* masked = doc->layers.front()->children.front();
   ASSERT_NE(masked->mask, nullptr);
   EXPECT_EQ(masked->maskType, pagx::MaskType::Alpha);
-  EXPECT_FALSE(masked->mask->visible);
+  EXPECT_TRUE(masked->mask->visible);
   EXPECT_FALSE(masked->mask->includeInLayout);
   auto* ellipse = FindElementOfType<pagx::Ellipse>(masked->mask);
   ASSERT_NE(ellipse, nullptr);

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -31,6 +31,7 @@
 #include "pagx/PAGXExporter.h"
 #include "pagx/PAGXImporter.h"
 #include "pagx/PAGXOptimizer.h"
+#include "pagx/TextLayout.h"
 #include "pagx/html/importer/HTMLDetail.h"
 #include "pagx/html/importer/HTMLDiagnosticSink.h"
 #include "pagx/html/importer/HTMLIdAllocator.h"
@@ -2992,8 +2993,8 @@ PAG_TEST(PAGXHTMLImporterTest, HeadingDefaultFontSizes) {
     ASSERT_NE(text, nullptr) << r.tag;
     EXPECT_FLOAT_EQ(text->fontSize, r.size) << r.tag;
     // Headings default to font-weight:bold, which is written as a real-face "Bold" style label so
-    // the renderer resolves the authored heavy face (falling back to host faux emboldening only for
-    // a missing face). No faux flag is baked into the Text node.
+    // the renderer resolves the authored heavy face. If that face is missing, TextLayout adds faux
+    // emboldening after lookup; no faux flag is baked into the Text node.
     EXPECT_EQ(text->fontStyle, "Bold") << r.tag;
     EXPECT_FALSE(text->fauxBold) << r.tag;
     EXPECT_FALSE(text->fauxItalic) << r.tag;
@@ -3016,6 +3017,39 @@ PAG_TEST(PAGXHTMLImporterTest, FontWeightNumericMapsToBold) {
   EXPECT_FALSE(text->fauxItalic);
 }
 
+PAG_TEST(PAGXHTMLImporterTest, MissingBoldFaceUsesRuntimeFauxBold) {
+  constexpr const char* family = "HTML Missing Bold Test";
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:200px;height:40px">
+      <span style="font-family:'HTML Missing Bold Test';font-weight:700">Heavy</span>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* text = FindElementOfType<pagx::Text>(doc->layers.front()->children.front());
+  ASSERT_NE(text, nullptr);
+  ASSERT_EQ(text->fontFamily, family);
+  ASSERT_EQ(text->fontStyle, "Bold");
+  ASSERT_FALSE(text->fauxBold);
+
+  // Register only a Regular face under the requested family. Font lookup therefore falls back to
+  // that face, and TextLayout must preserve the authored weight by enabling runtime faux bold on
+  // the glyph run without changing the imported Text node.
+  pagx::FontConfig fontConfig;
+  fontConfig.registerFont(ProjectPath::Absolute("resources/font/NotoSansSC-Regular.otf"), 0, family,
+                          "Regular");
+  doc->applyLayout(&fontConfig);
+
+  ASSERT_NE(text->glyphData, nullptr);
+  ASSERT_FALSE(text->glyphData->layoutRuns.empty());
+  for (const auto& run : text->glyphData->layoutRuns) {
+    auto typeface = run.font.getTypeface();
+    ASSERT_NE(typeface, nullptr);
+    EXPECT_EQ(typeface->fontStyle(), "Regular");
+    EXPECT_TRUE(run.font.isFauxBold());
+  }
+  EXPECT_FALSE(text->fauxBold);
+}
+
 PAG_TEST(PAGXHTMLImporterTest, FontWeight500MapsToMedium) {
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:200px;height:40px">
@@ -3025,7 +3059,8 @@ PAG_TEST(PAGXHTMLImporterTest, FontWeight500MapsToMedium) {
   ASSERT_NE(doc, nullptr);
   auto* text = FindElementOfType<pagx::Text>(doc->layers.front()->children.front());
   ASSERT_NE(text, nullptr);
-  // Medium (weight < 600) cannot be synthesised, so it stays a real-face style label with no faux.
+  // Medium stays a real-face style label so font lookup can select it precisely. The importer does
+  // not bake a faux flag; TextLayout decides at runtime whether the resolved face is too light.
   EXPECT_EQ(text->fontStyle, "Medium");
   EXPECT_FALSE(text->fauxBold);
   EXPECT_FALSE(text->fauxItalic);

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -1164,10 +1164,45 @@ PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleOmittedSizeUsesFarthestCorner
   EXPECT_TRUE(NearlyEqual(rg->radius, 335.41f, 0.5f));
 }
 
-PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleClosestSideExtent) {
+PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleExtentKeywordsUseDistanceFromCenter) {
+  struct ExtentCase {
+    const char* keyword;
+    float radius;
+  };
+  // Center (100,50) in a 400x200 box gives side distances 100, 300, 50, 150.
+  // Corner radii are therefore hypot(100,50) and hypot(300,150).
+  const std::vector<ExtentCase> cases = {
+      {"closest-side", 50.0f},
+      {"farthest-side", 300.0f},
+      {"closest-corner", 111.80f},
+      {"farthest-corner", 335.41f},
+  };
+  for (const auto& extent : cases) {
+    SCOPED_TRACE(extent.keyword);
+    auto html = std::string(
+                    "<html><body style=\"width:400px;height:400px\">"
+                    "<div style=\"width:400px;height:200px;background-image:radial-gradient("
+                    "circle ") +
+                extent.keyword +
+                " at 25% 25%, #FFFFFF 0%, transparent 100%)\"></div></body></html>";
+    auto doc = ParseFromString(html);
+    ASSERT_NE(doc, nullptr);
+    auto* div = doc->layers.front()->children.front();
+    auto* fill = FindElementOfType<pagx::Fill>(div);
+    ASSERT_NE(fill, nullptr);
+    auto* rg = As<pagx::RadialGradient>(fill->color);
+    ASSERT_NE(rg, nullptr);
+    EXPECT_FALSE(rg->fitsToGeometry);
+    EXPECT_TRUE(NearlyEqual(rg->center.x, 100.0f, 0.01f));
+    EXPECT_TRUE(NearlyEqual(rg->center.y, 50.0f, 0.01f));
+    EXPECT_TRUE(NearlyEqual(rg->radius, extent.radius, 0.01f));
+  }
+}
+
+PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleExtentOnSquareBoxKeepsNormalised) {
   auto doc = ParseFromString(R"HTML(
-    <html><body style="width:400px;height:400px">
-      <div style="width:400px;height:200px;background-image:radial-gradient(circle closest-side at 25% 50%, #FFFFFF 0%, transparent 100%)"></div>
+    <html><body style="width:200px;height:200px">
+      <div style="width:100px;height:100px;background-image:radial-gradient(circle farthest-corner at center, #FFFFFF 0%, transparent 100%)"></div>
     </body></html>
   )HTML");
   ASSERT_NE(doc, nullptr);
@@ -1176,12 +1211,34 @@ PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleClosestSideExtent) {
   ASSERT_NE(fill, nullptr);
   auto* rg = As<pagx::RadialGradient>(fill->color);
   ASSERT_NE(rg, nullptr);
-  // closest-side: center (100,100) on a 400x200 box; nearest edge distances are left=100,
-  // right=300, top=100, bottom=100, so the radius is 100px in the isotropic pixel model.
-  EXPECT_FALSE(rg->fitsToGeometry);
-  EXPECT_TRUE(NearlyEqual(rg->center.x, 100.0f, 0.5f));
-  EXPECT_TRUE(NearlyEqual(rg->center.y, 100.0f, 0.5f));
-  EXPECT_TRUE(NearlyEqual(rg->radius, 100.0f, 0.5f));
+  // A square box is already isotropic in geometry space, so the farthest-corner radius
+  // hypot(50,50) is stored as hypot(0.5,0.5) instead of switching to pixel coordinates.
+  EXPECT_TRUE(rg->fitsToGeometry);
+  EXPECT_TRUE(NearlyEqual(rg->center.x, 0.5f, 0.01f));
+  EXPECT_TRUE(NearlyEqual(rg->center.y, 0.5f, 0.01f));
+  EXPECT_TRUE(NearlyEqual(rg->radius, 0.7071f, 0.001f));
+}
+
+PAG_TEST(PAGXHTMLImporterTest, GradientTransparentStopsBorrowOpaqueNeighborRGB) {
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:100px;height:50px">
+      <div style="width:100px;height:50px;background-image:linear-gradient(
+        90deg, transparent 0%, rgba(220, 210, 255, 0.4) 50%, transparent 100%)"></div>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* div = doc->layers.front()->children.front();
+  auto* fill = FindElementOfType<pagx::Fill>(div);
+  ASSERT_NE(fill, nullptr);
+  auto* lg = As<pagx::LinearGradient>(fill->color);
+  ASSERT_NE(lg, nullptr);
+  ASSERT_EQ(lg->colorStops.size(), 3u);
+
+  // The renderer interpolates unpremultiplied colors. Giving both transparent edge stops the
+  // purple neighbor's RGB preserves a purple fade instead of blending through transparent black.
+  EXPECT_TRUE(ColorNear(lg->colorStops[0]->color, HexColor(0xDCD2FF, 0.0f)));
+  EXPECT_TRUE(ColorNear(lg->colorStops[1]->color, HexColor(0xDCD2FF, 0.4f)));
+  EXPECT_TRUE(ColorNear(lg->colorStops[2]->color, HexColor(0xDCD2FF, 0.0f)));
 }
 
 PAG_TEST(PAGXHTMLImporterTest, ConicGradientAngleOffset) {

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -1143,6 +1143,47 @@ PAG_TEST(PAGXHTMLImporterTest, RadialGradientEllipseOnNonSquareBoxKeepsNormalise
   EXPECT_TRUE(rg->fitsToGeometry);
 }
 
+PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleOmittedSizeUsesFarthestCorner) {
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:400px;height:400px">
+      <div style="width:400px;height:200px;background-image:radial-gradient(circle at 25% 25%, #FFFFFF 0%, transparent 100%)"></div>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* div = doc->layers.front()->children.front();
+  auto* fill = FindElementOfType<pagx::Fill>(div);
+  ASSERT_NE(fill, nullptr);
+  auto* rg = As<pagx::RadialGradient>(fill->color);
+  ASSERT_NE(rg, nullptr);
+  // A `circle` with no size defaults to farthest-corner: center (100,50) on a 400x200 box reaches
+  // the farthest corner (400,200) at sqrt(300^2 + 150^2) ~= 335.4px. The pixel model keeps the
+  // radius isotropic, so center/radius are stored in px with fitsToGeometry disabled.
+  EXPECT_FALSE(rg->fitsToGeometry);
+  EXPECT_TRUE(NearlyEqual(rg->center.x, 100.0f, 0.5f));
+  EXPECT_TRUE(NearlyEqual(rg->center.y, 50.0f, 0.5f));
+  EXPECT_TRUE(NearlyEqual(rg->radius, 335.41f, 0.5f));
+}
+
+PAG_TEST(PAGXHTMLImporterTest, RadialGradientCircleClosestSideExtent) {
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:400px;height:400px">
+      <div style="width:400px;height:200px;background-image:radial-gradient(circle closest-side at 25% 50%, #FFFFFF 0%, transparent 100%)"></div>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* div = doc->layers.front()->children.front();
+  auto* fill = FindElementOfType<pagx::Fill>(div);
+  ASSERT_NE(fill, nullptr);
+  auto* rg = As<pagx::RadialGradient>(fill->color);
+  ASSERT_NE(rg, nullptr);
+  // closest-side: center (100,100) on a 400x200 box; nearest edge distances are left=100,
+  // right=300, top=100, bottom=100, so the radius is 100px in the isotropic pixel model.
+  EXPECT_FALSE(rg->fitsToGeometry);
+  EXPECT_TRUE(NearlyEqual(rg->center.x, 100.0f, 0.5f));
+  EXPECT_TRUE(NearlyEqual(rg->center.y, 100.0f, 0.5f));
+  EXPECT_TRUE(NearlyEqual(rg->radius, 100.0f, 0.5f));
+}
+
 PAG_TEST(PAGXHTMLImporterTest, ConicGradientAngleOffset) {
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:50px;height:50px">

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -2993,8 +2993,7 @@ PAG_TEST(PAGXHTMLImporterTest, HeadingDefaultFontSizes) {
     ASSERT_NE(text, nullptr) << r.tag;
     EXPECT_FLOAT_EQ(text->fontSize, r.size) << r.tag;
     // Headings default to font-weight:bold, which is written as a real-face "Bold" style label so
-    // the renderer resolves the authored heavy face. If that face is missing, TextLayout adds faux
-    // emboldening after lookup; no faux flag is baked into the Text node.
+    // the renderer resolves the authored heavy face; no faux flag is baked into the Text node.
     EXPECT_EQ(text->fontStyle, "Bold") << r.tag;
     EXPECT_FALSE(text->fauxBold) << r.tag;
     EXPECT_FALSE(text->fauxItalic) << r.tag;
@@ -3017,7 +3016,7 @@ PAG_TEST(PAGXHTMLImporterTest, FontWeightNumericMapsToBold) {
   EXPECT_FALSE(text->fauxItalic);
 }
 
-PAG_TEST(PAGXHTMLImporterTest, MissingBoldFaceUsesRuntimeFauxBold) {
+PAG_TEST(PAGXHTMLImporterTest, MissingBoldFaceFallsBackWithoutFauxBold) {
   constexpr const char* family = "HTML Missing Bold Test";
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:200px;height:40px">
@@ -3032,8 +3031,7 @@ PAG_TEST(PAGXHTMLImporterTest, MissingBoldFaceUsesRuntimeFauxBold) {
   ASSERT_FALSE(text->fauxBold);
 
   // Register only a Regular face under the requested family. Font lookup therefore falls back to
-  // that face, and TextLayout must preserve the authored weight by enabling runtime faux bold on
-  // the glyph run without changing the imported Text node.
+  // that face without synthesising the unavailable Bold weight.
   pagx::FontConfig fontConfig;
   fontConfig.registerFont(ProjectPath::Absolute("resources/font/NotoSansSC-Regular.otf"), 0, family,
                           "Regular");
@@ -3045,7 +3043,7 @@ PAG_TEST(PAGXHTMLImporterTest, MissingBoldFaceUsesRuntimeFauxBold) {
     auto typeface = run.font.getTypeface();
     ASSERT_NE(typeface, nullptr);
     EXPECT_EQ(typeface->fontStyle(), "Regular");
-    EXPECT_TRUE(run.font.isFauxBold());
+    EXPECT_FALSE(run.font.isFauxBold());
   }
   EXPECT_FALSE(text->fauxBold);
 }
@@ -3060,7 +3058,7 @@ PAG_TEST(PAGXHTMLImporterTest, FontWeight500MapsToMedium) {
   auto* text = FindElementOfType<pagx::Text>(doc->layers.front()->children.front());
   ASSERT_NE(text, nullptr);
   // Medium stays a real-face style label so font lookup can select it precisely. The importer does
-  // not bake a faux flag; TextLayout decides at runtime whether the resolved face is too light.
+  // not bake a faux flag when that face is unavailable.
   EXPECT_EQ(text->fontStyle, "Medium");
   EXPECT_FALSE(text->fauxBold);
   EXPECT_FALSE(text->fauxItalic);

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -2969,16 +2969,16 @@ PAG_TEST(PAGXHTMLImporterTest, HeadingDefaultFontSizes) {
     auto* text = FindElementOfType<pagx::Text>(leaf);
     ASSERT_NE(text, nullptr) << r.tag;
     EXPECT_FLOAT_EQ(text->fontSize, r.size) << r.tag;
-    // Headings default to font-weight:bold, which is baked as faux bold (synthesised on a base
-    // face) rather than a "Bold" style label so the authored weight survives a missing styled face.
-    // The base-face label surfaces as the canonical "Regular" so every Text node carries a style.
-    EXPECT_EQ(text->fontStyle, "Regular") << r.tag;
-    EXPECT_TRUE(text->fauxBold) << r.tag;
+    // Headings default to font-weight:bold, which is written as a real-face "Bold" style label so
+    // the renderer resolves the authored heavy face (falling back to host faux emboldening only for
+    // a missing face). No faux flag is baked into the Text node.
+    EXPECT_EQ(text->fontStyle, "Bold") << r.tag;
+    EXPECT_FALSE(text->fauxBold) << r.tag;
     EXPECT_FALSE(text->fauxItalic) << r.tag;
   }
 }
 
-PAG_TEST(PAGXHTMLImporterTest, FontWeightNumericMapsToFauxBold) {
+PAG_TEST(PAGXHTMLImporterTest, FontWeightNumericMapsToBold) {
   auto doc = ParseFromString(R"HTML(
     <html><body style="width:200px;height:40px">
       <span style="font-weight:700">Heavy</span>
@@ -2987,10 +2987,10 @@ PAG_TEST(PAGXHTMLImporterTest, FontWeightNumericMapsToFauxBold) {
   ASSERT_NE(doc, nullptr);
   auto* text = FindElementOfType<pagx::Text>(doc->layers.front()->children.front());
   ASSERT_NE(text, nullptr);
-  // Bold (weight >= 600) is synthesised via faux bold rather than locking onto a "Bold" face; the
-  // base-face label surfaces as the canonical "Regular".
-  EXPECT_EQ(text->fontStyle, "Regular");
-  EXPECT_TRUE(text->fauxBold);
+  // Weight 700 is written as a real-face "Bold" style label so the renderer can resolve the
+  // authored heavy face; no faux flag is baked in.
+  EXPECT_EQ(text->fontStyle, "Bold");
+  EXPECT_FALSE(text->fauxBold);
   EXPECT_FALSE(text->fauxItalic);
 }
 
@@ -3018,10 +3018,10 @@ PAG_TEST(PAGXHTMLImporterTest, BoldItalicCombined) {
   ASSERT_NE(doc, nullptr);
   auto* text = FindElementOfType<pagx::Text>(doc->layers.front()->children.front());
   ASSERT_NE(text, nullptr);
-  // Both axes are synthesised: the style label drops to the canonical "Regular" base face and both
-  // faux flags are set so the run renders bold + italic even when the styled face is unavailable.
-  EXPECT_EQ(text->fontStyle, "Regular");
-  EXPECT_TRUE(text->fauxBold);
+  // The weight axis becomes a real-face "Bold" style label; only the italic axis is synthesised via
+  // faux italic so the slant survives a missing styled italic face.
+  EXPECT_EQ(text->fontStyle, "Bold");
+  EXPECT_FALSE(text->fauxBold);
   EXPECT_TRUE(text->fauxItalic);
 }
 

--- a/test/src/PAGXPPTTest.cpp
+++ b/test/src/PAGXPPTTest.cpp
@@ -912,6 +912,18 @@ PAGX_TEST(PAGXPPTTest, NativeTextWithTextBox) {
 
   pagx::PPTExportOptions options;
   options.convertTextToPath = false;
+  doc->applyLayout();
+  pagx::PPTWriterContext writerContext;
+  pagx::FontConfig fontConfig;
+  pagx::LayoutContext layoutContext(&fontConfig);
+  pagx::PPTWriter writer(&writerContext, doc.get(), options, &layoutContext);
+  pagx::XMLBuilder xml;
+  writer.writeDocument(xml);
+  auto body = xml.release();
+  // Ordinary editable text keeps PowerPoint's bounded wrapping as a cross-platform fallback when
+  // the export host cannot reproduce the authored font metrics.
+  EXPECT_NE(body.find("<a:bodyPr wrap=\"square\""), std::string::npos);
+  EXPECT_EQ(body.find("<a:bodyPr wrap=\"none\""), std::string::npos);
   ASSERT_TRUE(ExportAndVerify(*doc, "native_text_textbox", options));
 }
 
@@ -4887,6 +4899,10 @@ PAGX_TEST(PAGXPPTTest, TextBoxContainerSingleText) {
 
   layer->contents.push_back(textBox);
   doc->layers.push_back(layer);
+  doc->applyLayout();
+  auto body = WritePPTDocumentXML(doc.get(), {});
+  EXPECT_NE(body.find("<a:bodyPr wrap=\"square\""), std::string::npos);
+  EXPECT_EQ(body.find("<a:bodyPr wrap=\"none\""), std::string::npos);
   ASSERT_TRUE(ExportAndVerify(*doc, "textbox_container_single"));
 }
 
@@ -5043,6 +5059,41 @@ PAGX_TEST(PAGXPPTTest, ModifierTextBoxEmbeddedMultipleLinesKeepsBoundedWrapFallb
   pagx::PPTExportOptions options;
   options.ignoreGlyphRuns = true;
   auto body = WritePPTDocumentXML(doc.get(), options);
+  EXPECT_NE(body.find("<a:bodyPr wrap=\"square\""), std::string::npos);
+  EXPECT_EQ(body.find("<a:bodyPr wrap=\"none\""), std::string::npos);
+}
+
+PAGX_TEST(PAGXPPTTest, ModifierTextBoxSiblingRenderPositionsRemainSeparateLines) {
+  auto doc = pagx::PAGXDocument::Make(400, 240);
+  auto* layer = doc->makeNode<pagx::Layer>();
+
+  auto makeText = [&](const char* content, float y) {
+    auto* text = doc->makeNode<pagx::Text>();
+    text->text = content;
+    text->position = {40.0f, y};
+    text->fontFamily = "Arial";
+    text->fontSize = 32.0f;
+    text->glyphRuns.push_back(MakeEmbeddedGlyphRun(
+        doc.get(), {{0.0f, 0.0f}}, pagx::Rect::MakeXYWH(0, 0, 32, 40), 36.0f, text->fontSize));
+    layer->contents.push_back(text);
+  };
+  makeText("A", 40.0f);
+  makeText("B", 120.0f);
+  layer->contents.push_back(MakeSolidFill(doc.get(), {0.0f, 0.0f, 0.0f, 1.0f}));
+
+  auto* textBox = doc->makeNode<pagx::TextBox>();
+  textBox->position = {40.0f, 40.0f};
+  textBox->width = 200.0f;
+  textBox->height = 160.0f;
+  layer->contents.push_back(textBox);
+  doc->layers.push_back(layer);
+  doc->applyLayout();
+
+  pagx::PPTExportOptions options;
+  options.ignoreGlyphRuns = true;
+  auto body = WritePPTDocumentXML(doc.get(), options);
+  // Both runs use the same GlyphRun-local baseline, but their Text render positions place them on
+  // different visual lines. Comparing absolute baselines must retain bounded wrapping.
   EXPECT_NE(body.find("<a:bodyPr wrap=\"square\""), std::string::npos);
   EXPECT_EQ(body.find("<a:bodyPr wrap=\"none\""), std::string::npos);
 }

--- a/test/src/PAGXPPTTest.cpp
+++ b/test/src/PAGXPPTTest.cpp
@@ -23,10 +23,12 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include "pagx/LayoutContext.h"
 #include "pagx/PAGXExporter.h"
 #include "pagx/PAGXImporter.h"
 #include "pagx/PPTExporter.h"
 #include "pagx/SVGImporter.h"
+#include "pagx/TextLayout.h"
 #include "pagx/nodes/BackgroundBlurStyle.h"
 #include "pagx/nodes/BlendFilter.h"
 #include "pagx/nodes/BlurFilter.h"
@@ -1547,6 +1549,8 @@ PAGX_TEST(PAGXPPTTest, TextIgnoreGlyphRunsPreservesLineBoxVerticalAlignment) {
   run->glyphs = {1, 1, 1, 1, 1, 1, 1};
   run->x = 21.5f;
   run->y = 28.0f;
+  run->positions = {{0.0f, 0.0f},  {16.0f, 0.0f}, {32.0f, 0.0f}, {48.0f, 0.0f},
+                    {64.0f, 0.0f}, {80.0f, 0.0f}, {96.0f, 0.0f}};
   run->bounds = pagx::Rect::MakeXYWH(0, 0, 120, 40);
   text->glyphRuns.push_back(run);
 
@@ -1579,9 +1583,9 @@ PAGX_TEST(PAGXPPTTest, TextIgnoreGlyphRunsPreservesLineBoxVerticalAlignment) {
   writer.writeDocument(xml);
   auto body = xml.release();
 
-  // A fixed-width TextBox keeps PowerPoint auto-wrap enabled as a cross-platform
-  // fallback even when the exporter also has authoritative PAGX line metadata.
-  EXPECT_NE(body.find("<a:bodyPr wrap=\"square\" lIns=\"0\" tIns=\"0\" rIns=\"0\" "
+  // Complete single-baseline GlyphRun positions disable PowerPoint's metric-dependent second
+  // wrapping pass.
+  EXPECT_NE(body.find("<a:bodyPr wrap=\"none\" lIns=\"0\" tIns=\"0\" rIns=\"0\" "
                       "bIns=\"0\" anchor=\"ctr\"/>"),
             std::string::npos);
   // Horizontal textAlign is already encoded by run->x, so centering must not
@@ -1728,7 +1732,7 @@ PAGX_TEST(PAGXPPTTest, TextIgnoreGlyphRunsCombinesModifierTextBoxRuns) {
   auto firstShape = body.find("<p:sp>");
   ASSERT_NE(firstShape, std::string::npos);
   EXPECT_EQ(body.find("<p:sp>", firstShape + 1), std::string::npos);
-  EXPECT_NE(body.find("<a:bodyPr wrap=\"square\""), std::string::npos);
+  EXPECT_NE(body.find("<a:bodyPr wrap=\"none\""), std::string::npos);
   auto titleText = body.find("<a:t>云原生架构</a:t>");
   auto emojiText = body.find("<a:t>🤣</a:t>");
   ASSERT_NE(titleText, std::string::npos);
@@ -3918,6 +3922,37 @@ static pagx::Fill* MakeSolidFill(pagx::PAGXDocument* doc, pagx::Color color) {
   return fill;
 }
 
+static pagx::GlyphRun* MakeEmbeddedGlyphRun(pagx::PAGXDocument* doc,
+                                            const std::vector<pagx::Point>& positions,
+                                            const pagx::Rect& bounds, float baseline,
+                                            float fontSize) {
+  auto* font = doc->makeNode<pagx::Font>();
+  font->unitsPerEm = 1000;
+  auto* glyph = doc->makeNode<pagx::Glyph>();
+  glyph->advance = 1000;
+  font->glyphs.push_back(glyph);
+
+  auto* run = doc->makeNode<pagx::GlyphRun>();
+  run->font = font;
+  run->fontSize = fontSize;
+  run->glyphs.assign(positions.size(), 1);
+  run->y = baseline;
+  run->positions = positions;
+  run->bounds = bounds;
+  return run;
+}
+
+static std::string WritePPTDocumentXML(pagx::PAGXDocument* doc,
+                                       const pagx::PPTExportOptions& options) {
+  pagx::PPTWriterContext writerContext;
+  pagx::FontConfig fontConfig;
+  pagx::LayoutContext layoutContext(&fontConfig);
+  pagx::PPTWriter writer(&writerContext, doc, options, &layoutContext);
+  pagx::XMLBuilder xml;
+  writer.writeDocument(xml);
+  return xml.release();
+}
+
 PAGX_TEST(PAGXPPTTest, PolystarStarShape) {
   auto doc = pagx::PAGXDocument::Make(400, 300);
   auto* layer = doc->makeNode<pagx::Layer>();
@@ -4853,6 +4888,163 @@ PAGX_TEST(PAGXPPTTest, TextBoxContainerSingleText) {
   layer->contents.push_back(textBox);
   doc->layers.push_back(layer);
   ASSERT_TRUE(ExportAndVerify(*doc, "textbox_container_single"));
+}
+
+PAGX_TEST(PAGXPPTTest, TextBoxEmbeddedSingleLineDisablesAutoWrap) {
+  auto doc = pagx::PAGXDocument::Make(400, 200);
+  auto* layer = doc->makeNode<pagx::Layer>();
+  auto* textBox = doc->makeNode<pagx::TextBox>();
+  textBox->position = {40, 40};
+  textBox->width = 120;
+  textBox->height = 60;
+
+  auto* text = doc->makeNode<pagx::Text>();
+  text->text = "ABCD";
+  text->fontFamily = "Arial";
+  text->fontSize = 32;
+  text->letterSpacing = 8;
+
+  // Embedded text normally takes the bounds-only TextLayout path. Complete glyph positions prove
+  // that this authored text has one horizontal baseline, so native PPT export can safely suppress
+  // PowerPoint's independent wrapping pass.
+  auto* glyphRun =
+      MakeEmbeddedGlyphRun(doc.get(), {{0.0f, 0.0f}, {30.0f, 0.0f}, {60.0f, 0.0f}, {90.0f, 0.0f}},
+                           pagx::Rect::MakeXYWH(0, 0, 120, 40), 36.0f, text->fontSize);
+  text->glyphRuns.push_back(glyphRun);
+
+  pagx::TextLayoutParams params = {};
+  params.boxWidth = textBox->width;
+  params.boxHeight = textBox->height;
+  pagx::LayoutContext layoutContext(nullptr);
+  auto textElements = pagx::TextLayout::MakeElements({text});
+  auto embeddedLayout = pagx::TextLayout::Layout(textElements, params, &layoutContext);
+  EXPECT_EQ(embeddedLayout.getTextLines(text), nullptr);
+  auto editableLayout = pagx::TextLayout::Layout(textElements, params, &layoutContext, false);
+  auto* editableLines = editableLayout.getTextLines(text);
+  ASSERT_NE(editableLines, nullptr);
+  ASSERT_EQ(editableLines->size(), 1u);
+  EXPECT_EQ(editableLines->front().byteStart, 0u);
+  EXPECT_EQ(editableLines->front().byteEnd, text->text.size());
+
+  textBox->elements.push_back(text);
+  textBox->elements.push_back(MakeSolidFill(doc.get(), {0.0f, 0.0f, 0.0f, 1.0f}));
+  layer->contents.push_back(textBox);
+  doc->layers.push_back(layer);
+  doc->applyLayout();
+
+  pagx::PPTExportOptions options;
+  options.ignoreGlyphRuns = true;
+  auto body = WritePPTDocumentXML(doc.get(), options);
+  EXPECT_NE(body.find("<a:t>ABCD</a:t>"), std::string::npos);
+  EXPECT_NE(body.find("<a:bodyPr wrap=\"none\""), std::string::npos);
+  EXPECT_EQ(body.find("<a:bodyPr wrap=\"square\""), std::string::npos);
+  ASSERT_TRUE(ExportAndVerify(*doc, "textbox_embedded_editable_lines", options));
+}
+
+PAGX_TEST(PAGXPPTTest, TextBoxEmbeddedSingleLineRejectsHostInferredBreaks) {
+  auto doc = pagx::PAGXDocument::Make(400, 240);
+  auto* layer = doc->makeNode<pagx::Layer>();
+  auto* textBox = doc->makeNode<pagx::TextBox>();
+  textBox->position = {40, 40};
+  textBox->width = 100;
+  textBox->height = 180;
+
+  auto* text = doc->makeNode<pagx::Text>();
+  text->text = "石破天惊";
+  text->fontFamily = "Noto Serif SC";
+  text->fontStyle = "Black";
+  text->fontSize = 72;
+  text->letterSpacing = 8;
+  text->glyphRuns.push_back(
+      MakeEmbeddedGlyphRun(doc.get(), {{0.0f, 0.0f}, {80.0f, 0.0f}, {160.0f, 0.0f}, {240.0f, 0.0f}},
+                           pagx::Rect::MakeXYWH(0, 0, 320, 103), 83.0f, text->fontSize));
+
+  pagx::TextLayoutParams params = {};
+  params.boxWidth = textBox->width;
+  params.boxHeight = textBox->height;
+  pagx::LayoutContext layoutContext(nullptr);
+  auto editableLayout = pagx::TextLayout::Layout(pagx::TextLayout::MakeElements({text}), params,
+                                                 &layoutContext, false);
+  auto* editableLines = editableLayout.getTextLines(text);
+  ASSERT_NE(editableLines, nullptr);
+  ASSERT_GT(editableLines->size(), 1u);
+
+  textBox->elements.push_back(text);
+  textBox->elements.push_back(MakeSolidFill(doc.get(), {0.0f, 0.0f, 0.0f, 1.0f}));
+  layer->contents.push_back(textBox);
+  doc->layers.push_back(layer);
+  doc->applyLayout();
+
+  pagx::PPTExportOptions options;
+  options.ignoreGlyphRuns = true;
+  auto body = WritePPTDocumentXML(doc.get(), options);
+  EXPECT_NE(body.find("<a:bodyPr wrap=\"none\""), std::string::npos);
+  EXPECT_NE(body.find("<a:t>石破天惊</a:t>"), std::string::npos);
+  EXPECT_EQ(body.find("<a:br"), std::string::npos);
+}
+
+PAGX_TEST(PAGXPPTTest, ModifierTextBoxEmbeddedSingleLineDisablesAutoWrap) {
+  auto doc = pagx::PAGXDocument::Make(1200, 240);
+  auto* layer = doc->makeNode<pagx::Layer>();
+  auto* group = doc->makeNode<pagx::Group>();
+
+  auto* text = doc->makeNode<pagx::Text>();
+  text->text = "石破天惊";
+  text->fontFamily = "Noto Serif SC";
+  text->fontStyle = "Black";
+  text->fontSize = 72;
+  text->letterSpacing = 8;
+  text->glyphRuns.push_back(
+      MakeEmbeddedGlyphRun(doc.get(), {{0.0f, 0.0f}, {80.0f, 0.0f}, {160.0f, 0.0f}, {240.0f, 0.0f}},
+                           pagx::Rect::MakeXYWH(0, 0, 940, 103), 83.0f, text->fontSize));
+  group->elements.push_back(text);
+  group->elements.push_back(MakeSolidFill(doc.get(), {0.1f, 0.1f, 0.1f, 1.0f}));
+  layer->contents.push_back(group);
+
+  // This sibling TextBox is a modifier for the preceding Text group, matching the imported PAGX
+  // structure that exposed the 石破天惊 3+1 line split in PowerPoint/LibreOffice.
+  auto* textBox = doc->makeNode<pagx::TextBox>();
+  textBox->width = 940;
+  layer->contents.push_back(textBox);
+  doc->layers.push_back(layer);
+  doc->applyLayout();
+
+  pagx::PPTExportOptions options;
+  options.ignoreGlyphRuns = true;
+  auto body = WritePPTDocumentXML(doc.get(), options);
+  EXPECT_NE(body.find("<a:bodyPr wrap=\"none\""), std::string::npos);
+  EXPECT_NE(body.find("<a:t>石破天惊</a:t>"), std::string::npos);
+  EXPECT_EQ(body.find("<a:br"), std::string::npos);
+  ASSERT_TRUE(ExportAndVerify(*doc, "modifier_textbox_embedded_single_line", options));
+}
+
+PAGX_TEST(PAGXPPTTest, ModifierTextBoxEmbeddedMultipleLinesKeepsBoundedWrapFallback) {
+  auto doc = pagx::PAGXDocument::Make(1200, 240);
+  auto* layer = doc->makeNode<pagx::Layer>();
+  auto* group = doc->makeNode<pagx::Group>();
+
+  auto* text = doc->makeNode<pagx::Text>();
+  text->text = "石破天惊";
+  text->fontFamily = "Noto Serif SC";
+  text->fontSize = 72;
+  text->glyphRuns.push_back(
+      MakeEmbeddedGlyphRun(doc.get(), {{0.0f, 0.0f}, {80.0f, 0.0f}, {0.0f, 96.0f}, {80.0f, 96.0f}},
+                           pagx::Rect::MakeXYWH(0, 0, 940, 206), 83.0f, text->fontSize));
+  group->elements.push_back(text);
+  group->elements.push_back(MakeSolidFill(doc.get(), {0.1f, 0.1f, 0.1f, 1.0f}));
+  layer->contents.push_back(group);
+
+  auto* textBox = doc->makeNode<pagx::TextBox>();
+  textBox->width = 940;
+  layer->contents.push_back(textBox);
+  doc->layers.push_back(layer);
+  doc->applyLayout();
+
+  pagx::PPTExportOptions options;
+  options.ignoreGlyphRuns = true;
+  auto body = WritePPTDocumentXML(doc.get(), options);
+  EXPECT_NE(body.find("<a:bodyPr wrap=\"square\""), std::string::npos);
+  EXPECT_EQ(body.find("<a:bodyPr wrap=\"none\""), std::string::npos);
 }
 
 PAGX_TEST(PAGXPPTTest, TextBoxContainerMultipleTexts) {

--- a/tools/html-snapshot/README.md
+++ b/tools/html-snapshot/README.md
@@ -146,7 +146,9 @@ Tabler, …) deliver their glyphs through `@font-face` plus
 walks every PUA pseudo whose `font-family` resolves to a registered
 `@font-face` rule, downloads the font file (WOFF2 → `wawoff2` → TTF →
 `opentype.js`), extracts the glyph as a vector path, and emits it as an
-inline `<svg><path fill="currentColor"/></svg>`. The resulting PAGX:
+inline `<svg><path fill="currentColor"/></svg>`. Families with multiple
+physical faces are matched by computed `font-weight` and `font-style` (for
+example Font Awesome Free Regular/400 versus Solid/900). The resulting PAGX:
 
 - no longer depends on the icon font being installed on the rendering
   machine (the legacy path emits `<Text fontFamily="Phosphor"/>` which

--- a/tools/html-snapshot/build-browser-bundle.js
+++ b/tools/html-snapshot/build-browser-bundle.js
@@ -71,7 +71,7 @@ const banner = `/*!
  *   materializeDecorativePseudoElements()   -> Promise<void>
  *   collectIconFontTargets()                -> Promise<target[]>
  *   applyIconFontSvgs(target_svg_pairs)     -> void
- *   collectFontFaceMap()                    -> Promise<{family:{url,format}}>
+ *   collectFontFaceMap()                    -> Promise<{family:[{url,format,weight,style}, ...]}>
  *
  * The \`*IconFont*\` hooks let a node-side resolver (or a custom in-browser
  * font-parsing pass) replace webfont glyph pseudos with inline <svg>; see

--- a/tools/html-snapshot/lib/icon-font.ts
+++ b/tools/html-snapshot/lib/icon-font.ts
@@ -127,6 +127,24 @@ export function normalizeFontFaceStyle(value: string): string {
   return 'normal';
 }
 
+// Return the CSS Fonts weight-search phase and distance for a face range. The
+// phase captures the spec's directional preference: below 400 search downward
+// first, from 400 through 500 search upward to 500 then downward, and above 500
+// search upward first. This also makes equidistant choices independent of
+// @font-face declaration order (for example 650 chooses 900 over 400).
+function fontWeightPreference(requested: number, lo: number, hi: number): [number, number] {
+  if (requested >= lo && requested <= hi) return [0, 0];
+  if (requested < 400) {
+    return hi < requested ? [1, requested - hi] : [2, lo - requested];
+  }
+  if (requested > 500) {
+    return lo > requested ? [1, lo - requested] : [2, requested - hi];
+  }
+  if (lo > requested && lo <= 500) return [1, lo - requested];
+  if (hi < requested) return [2, requested - hi];
+  return [3, lo - requested];
+}
+
 // Pick the @font-face that best matches a pseudo-element's computed style.
 // A family may expose several physical files under one name (Font Awesome's
 // "Font Awesome 6 Free" uses Regular/400 and Solid/900). Treating a family as
@@ -143,21 +161,30 @@ export function selectFontFace(
   const reqWeight = reqWeightMatch ? Number(reqWeightMatch[0]) : 400;
   const reqStyle = normalizeFontFaceStyle(requestedStyle);
   let best: FontFaceEntry | null = null;
-  let bestScore = Infinity;
+  let bestPreference: [number, number, number] | null = null;
   for (const face of faces) {
     if (!face) continue;
     const nums = normalizeFontFaceWeight(face.weight).match(/\d+(?:\.\d+)?/g) || [];
     let lo = nums.length > 0 ? Number(nums[0]) : 400;
     let hi = nums.length > 1 ? Number(nums[1]) : lo;
     if (lo > hi) { const tmp = lo; lo = hi; hi = tmp; }
-    const weightDistance = reqWeight < lo ? lo - reqWeight : reqWeight > hi ? reqWeight - hi : 0;
-    // Style should dominate weight proximity: an italic face at the exact
+    const [weightPhase, weightDistance] = fontWeightPreference(reqWeight, lo, hi);
+    // Style should dominate weight preference: an italic face at the exact
     // weight is a worse match than a nearby upright face for normal text.
-    const stylePenalty = normalizeFontFaceStyle(face.style) === reqStyle ? 0 : 10_000;
-    const score = stylePenalty + weightDistance;
-    if (score < bestScore) {
+    const preference: [number, number, number] = [
+      normalizeFontFaceStyle(face.style) === reqStyle ? 0 : 1,
+      weightPhase,
+      weightDistance,
+    ];
+    if (
+      bestPreference === null ||
+      preference[0] < bestPreference[0] ||
+      (preference[0] === bestPreference[0] && preference[1] < bestPreference[1]) ||
+      (preference[0] === bestPreference[0] && preference[1] === bestPreference[1] &&
+        preference[2] < bestPreference[2])
+    ) {
       best = face;
-      bestScore = score;
+      bestPreference = preference;
     }
   }
   return best;

--- a/tools/html-snapshot/lib/icon-font.ts
+++ b/tools/html-snapshot/lib/icon-font.ts
@@ -104,6 +104,63 @@ interface FontFaceEntry {
   family: string;
   url: string;
   format: string;
+  weight: string;
+  style: string;
+}
+
+// Normalise the two @font-face descriptors that affect which physical face
+// Chromium selects. Computed `font-weight` is normally numeric while
+// @font-face commonly uses the `normal` / `bold` keywords, so canonicalise
+// those keywords before comparing. Variable-font ranges (for example
+// `100 900`) are deliberately kept intact for the distance matcher below.
+export function normalizeFontFaceWeight(value: string): string {
+  const v = String(value || '').trim().toLowerCase();
+  if (!v || v === 'normal') return '400';
+  if (v === 'bold') return '700';
+  return v;
+}
+
+export function normalizeFontFaceStyle(value: string): string {
+  const v = String(value || '').trim().toLowerCase();
+  if (v.startsWith('italic')) return 'italic';
+  if (v.startsWith('oblique')) return 'oblique';
+  return 'normal';
+}
+
+// Pick the @font-face that best matches a pseudo-element's computed style.
+// A family may expose several physical files under one name (Font Awesome's
+// "Font Awesome 6 Free" uses Regular/400 and Solid/900). Treating a family as
+// a single URL silently chooses the first declaration and makes every glyph
+// that exists only in another weight disappear.
+export function selectFontFace(
+  faces: FontFaceEntry[] | null | undefined,
+  requestedWeight: string,
+  requestedStyle: string,
+): FontFaceEntry | null {
+  if (!faces || faces.length === 0) return null;
+  const reqWeightText = normalizeFontFaceWeight(requestedWeight);
+  const reqWeightMatch = reqWeightText.match(/\d+(?:\.\d+)?/);
+  const reqWeight = reqWeightMatch ? Number(reqWeightMatch[0]) : 400;
+  const reqStyle = normalizeFontFaceStyle(requestedStyle);
+  let best: FontFaceEntry | null = null;
+  let bestScore = Infinity;
+  for (const face of faces) {
+    if (!face) continue;
+    const nums = normalizeFontFaceWeight(face.weight).match(/\d+(?:\.\d+)?/g) || [];
+    let lo = nums.length > 0 ? Number(nums[0]) : 400;
+    let hi = nums.length > 1 ? Number(nums[1]) : lo;
+    if (lo > hi) { const tmp = lo; lo = hi; hi = tmp; }
+    const weightDistance = reqWeight < lo ? lo - reqWeight : reqWeight > hi ? reqWeight - hi : 0;
+    // Style should dominate weight proximity: an italic face at the exact
+    // weight is a worse match than a nearby upright face for normal text.
+    const stylePenalty = normalizeFontFaceStyle(face.style) === reqStyle ? 0 : 10_000;
+    const score = stylePenalty + weightDistance;
+    if (score < bestScore) {
+      best = face;
+      bestScore = score;
+    }
+  }
+  return best;
 }
 
 // Parse `@font-face { ... }` blocks out of a raw CSS string. Used as a
@@ -126,7 +183,17 @@ export function parseFontFaceFromText(cssText: string, sheetBase: string): FontF
     if (!fm || !sm) continue;
     const family = fm[1].trim().replace(/^["']|["']$/g, '');
     const parsed = parseSrcList(sm[1], sheetBase);
-    if (family && parsed) out.push({ family: family, url: parsed.url, format: parsed.format });
+    const wm = body.match(/font-weight\s*:\s*([^;]+)/i);
+    const stm = body.match(/font-style\s*:\s*([^;]+)/i);
+    if (family && parsed) {
+      out.push({
+        family: family,
+        url: parsed.url,
+        format: parsed.format,
+        weight: normalizeFontFaceWeight(wm ? wm[1] : ''),
+        style: normalizeFontFaceStyle(stm ? stm[1] : ''),
+      });
+    }
   }
   return out;
 }
@@ -139,8 +206,10 @@ export function parseFontFaceFromText(cssText: string, sheetBase: string): FontF
 // `.toString()`, not the surrounding module scope).
 declare const DROP_TAGS_UPPER: Set<string>;
 
-// Walk `document.styleSheets` for `@font-face` rules and return a
-// JSON-safe `{ family: { url, format } }` map.
+// Walk `document.styleSheets` for `@font-face` rules and return a JSON-safe
+// `{ family: [{ url, format, weight, style }, ...] }` map. Keeping every face
+// is essential for families such as Font Awesome Free that use one family
+// name for both Regular/400 and Solid/900 font files.
 //
 // `cssRules` access throws `SecurityError` on cross-origin stylesheets that
 // did not opt in via `crossorigin="anonymous"` — which is most stylesheets
@@ -152,12 +221,8 @@ declare const DROP_TAGS_UPPER: Set<string>;
 // paths are silently skipped (the snapshot will keep emitting a font-named
 // span for those glyphs).
 //
-// First-write wins: a duplicate `@font-face` (e.g. weight variants sharing
-// the same family) keeps the first source — good enough for icon fonts
-// (single regular weight) and avoids round-tripping a heavier italic/bold
-// variant.
-async function collectFontFaceMap(): Promise<Record<string, ParsedSrc>> {
-  const map: Record<string, ParsedSrc> = {};
+async function collectFontFaceMap(): Promise<Record<string, FontFaceEntry[]>> {
+  const map: Record<string, FontFaceEntry[]> = {};
   const inaccessible: string[] = [];
   const sheets = document.styleSheets ? Array.from(document.styleSheets) : [];
   for (const sheet of sheets) {
@@ -179,7 +244,16 @@ async function collectFontFaceMap(): Promise<Record<string, ParsedSrc>> {
       if (!familyRaw || !srcRaw) continue;
       const family = familyRaw.replace(/^["']|["']$/g, '');
       const parsed = parseSrcList(srcRaw, sheetBase);
-      if (parsed && !map[family]) map[family] = parsed;
+      if (parsed) {
+        if (!map[family]) map[family] = [];
+        map[family].push({
+          family: family,
+          url: parsed.url,
+          format: parsed.format,
+          weight: normalizeFontFaceWeight(r.style.getPropertyValue('font-weight') || ''),
+          style: normalizeFontFaceStyle(r.style.getPropertyValue('font-style') || ''),
+        });
+      }
     }
   }
   for (const href of inaccessible) {
@@ -189,7 +263,8 @@ async function collectFontFaceMap(): Promise<Record<string, ParsedSrc>> {
       const css = await res.text();
       const entries = parseFontFaceFromText(css, href);
       for (const e of entries) {
-        if (!map[e.family]) map[e.family] = { url: e.url, format: e.format };
+        if (!map[e.family]) map[e.family] = [];
+        map[e.family].push(e);
       }
     } catch (_) { /* CORS or network — skip */ }
   }
@@ -226,9 +301,10 @@ function isIconScanSkippedTag(tag: string): boolean {
 // closure for `page.evaluate`; the standalone browser bundle does the same
 // inside its UMD/ESM factory.
 
-// Walk styleSheets and return the JSON-safe `@font-face` family→{url,format}
-// map. Async because the cross-origin CSS fallback uses `fetch`.
-async function browserCollectFontFaceMap(): Promise<Record<string, ParsedSrc>> {
+// Walk styleSheets and return the JSON-safe `@font-face`
+// family→[{url,format,weight,style}, ...] map. Async because the cross-origin
+// CSS fallback uses `fetch`.
+async function browserCollectFontFaceMap(): Promise<Record<string, FontFaceEntry[]>> {
   return await collectFontFaceMap();
 }
 
@@ -290,13 +366,16 @@ async function browserCollectIconFontTargets(): Promise<IconFontTarget[]> {
       const cp = ch.codePointAt(0)!;
       if (!isPuaCodepoint(cp)) continue;
       const fontFamilyRaw = (cs.getPropertyValue('font-family') || '').trim();
+      const fontWeight = cs.getPropertyValue('font-weight') || '';
+      const fontStyle = cs.getPropertyValue('font-style') || '';
       const families = fontFamilyRaw
         .split(',')
         .map(function (s) { return s.trim().replace(/^["']|["']$/g, ''); });
-      let entry: ParsedSrc | null = null;
+      let entry: FontFaceEntry | null = null;
       let matchedFamily = '';
       for (const fam of families) {
-        if (fontFaceMap[fam]) { entry = fontFaceMap[fam]; matchedFamily = fam; break; }
+        const matched = selectFontFace(fontFaceMap[fam], fontWeight, fontStyle);
+        if (matched) { entry = matched; matchedFamily = fam; break; }
       }
       if (!entry) continue;
       const id = '__pagx_icon_' + (counter++) + '__';
@@ -369,6 +448,9 @@ function browserApplyIconFontSvgs(results: IconFontResult[] | null | undefined):
 const ICON_FONT_HELPER_FNS: Function[] = [
   formatRank,
   parseSrcList,
+  normalizeFontFaceWeight,
+  normalizeFontFaceStyle,
+  selectFontFace,
   parseFontFaceFromText,
   collectFontFaceMap,
   isPuaCodepoint,

--- a/tools/html-snapshot/test/icon-font-browser.test.js
+++ b/tools/html-snapshot/test/icon-font-browser.test.js
@@ -28,12 +28,15 @@ function makeSheet({ href = null, rules = null, throwOnRules = false } = {}) {
   };
 }
 
-function fontFaceRule(family, src) {
+function fontFaceRule(family, src, { weight = '', style = '' } = {}) {
   return {
     type: 5,
     style: {
       getPropertyValue: (k) =>
-        k === 'font-family' ? family : k === 'src' ? src : '',
+        k === 'font-family' ? family
+          : k === 'src' ? src
+            : k === 'font-weight' ? weight
+              : k === 'font-style' ? style : '',
     },
   };
 }
@@ -43,13 +46,17 @@ function nonFontRule(type = 1) {
 }
 
 // Build an element stub mirroring the slice of the DOM API the walker touches.
-// `before` / `after` are `{ content, family }` specs for the matching pseudo.
+// `before` / `after` are `{ content, family, weight, style }` specs for the
+// matching pseudo.
 function makeEl({ tag = 'I', childCount = 0, text = [], before = null, after = null, attrs = {} } = {}) {
   const a = { ...attrs };
   const childNodes = text.map((t) => ({ nodeType: 3, nodeValue: t }));
   const csFor = (spec) => ({
     getPropertyValue: (k) =>
-      k === 'content' ? (spec && spec.content) || '' : k === 'font-family' ? (spec && spec.family) || '' : '',
+      k === 'content' ? (spec && spec.content) || ''
+        : k === 'font-family' ? (spec && spec.family) || ''
+          : k === 'font-weight' ? (spec && spec.weight) || ''
+            : k === 'font-style' ? (spec && spec.style) || '' : '',
   });
   return {
     tagName: tag,
@@ -92,7 +99,7 @@ describe('browserCollectFontFaceMap', () => {
     expect(await browserCollectFontFaceMap()).toEqual({});
   });
 
-  test('reads @font-face rules from an accessible sheet, first-write wins', async () => {
+  test('reads every weight of a family from an accessible sheet', async () => {
     global.document = {
       baseURI: 'https://x/',
       styleSheets: [
@@ -100,18 +107,23 @@ describe('browserCollectFontFaceMap', () => {
           href: 'https://cdn.example/css/sheet.css',
           rules: [
             nonFontRule(1), // CSSStyleRule — ignored
-            fontFaceRule('"Phosphor"', "url('p.woff2') format('woff2')"),
+            fontFaceRule('"Phosphor"', "url('p.woff2') format('woff2')", { weight: '400' }),
             fontFaceRule('NoSrc', ''), // missing src — skipped
-            // Duplicate family: the first source must win.
-            fontFaceRule('Phosphor', "url('p-bold.woff2') format('woff2')"),
+            fontFaceRule('Phosphor', "url('p-bold.woff2') format('woff2')", { weight: '700' }),
           ],
         }),
       ],
     };
     const map = await browserCollectFontFaceMap();
     expect(Object.keys(map)).toEqual(['Phosphor']);
-    expect(map.Phosphor.url).toBe('https://cdn.example/css/p.woff2');
-    expect(map.Phosphor.format).toBe('woff2');
+    expect(map.Phosphor).toHaveLength(2);
+    expect(map.Phosphor[0]).toMatchObject({
+      url: 'https://cdn.example/css/p.woff2',
+      format: 'woff2',
+      weight: '400',
+      style: 'normal',
+    });
+    expect(map.Phosphor[1].url).toBe('https://cdn.example/css/p-bold.woff2');
   });
 
   test('skips a sheet whose cssRules is null', async () => {
@@ -137,7 +149,7 @@ describe('browserCollectFontFaceMap', () => {
         `@font-face { font-family: "Remix"; src: url(remix.woff2) format("woff2"); }`,
     });
     const map = await browserCollectFontFaceMap();
-    expect(map.Remix.url).toBe('https://cdn.example/remix.woff2');
+    expect(map.Remix[0].url).toBe('https://cdn.example/remix.woff2');
   });
 
   test('ignores a cross-origin fallback that returns non-OK', async () => {
@@ -232,6 +244,35 @@ describe('browserCollectIconFontTargets', () => {
     const targets = await browserCollectIconFontTargets();
     expect(targets).toHaveLength(2);
     expect(targets[0].id).not.toBe(targets[1].id);
+  });
+
+  test('selects Font Awesome Solid/900 instead of the first Regular/400 face', async () => {
+    const hit = makeEl({
+      tag: 'I',
+      before: {
+        content: '"\uf1ad"',
+        family: '"Font Awesome 6 Free"',
+        weight: '900',
+        style: 'normal',
+      },
+    });
+    global.document = {
+      baseURI: 'https://x/',
+      styleSheets: [
+        makeSheet({
+          href: 'https://cdn.example/fontawesome/all.css',
+          rules: [
+            fontFaceRule('"Font Awesome 6 Free"', "url('fa-regular-400.woff2') format('woff2')", { weight: '400' }),
+            fontFaceRule('"Font Awesome 6 Free"', "url('fa-solid-900.woff2') format('woff2')", { weight: '900' }),
+          ],
+        }),
+      ],
+      body: { querySelectorAll: () => [hit] },
+    };
+
+    const targets = await browserCollectIconFontTargets();
+    expect(targets).toHaveLength(1);
+    expect(targets[0].fontUrl).toBe('https://cdn.example/fontawesome/fa-solid-900.woff2');
   });
 });
 

--- a/tools/html-snapshot/test/icon-font.test.js
+++ b/tools/html-snapshot/test/icon-font.test.js
@@ -177,7 +177,7 @@ describe('selectFontFace', () => {
     expect(normalizeFontFaceStyle('oblique 10deg')).toBe('oblique');
   });
 
-  test('selects the face nearest to the computed weight', () => {
+  test('selects exact computed weights', () => {
     expect(selectFontFace(faces, '900', 'normal').url).toBe('solid.woff2');
     expect(selectFontFace(faces, '400', 'normal').url).toBe('regular.woff2');
   });
@@ -187,8 +187,34 @@ describe('selectFontFace', () => {
   });
 
   test('supports variable-font weight ranges', () => {
-    const variable = [{ family: 'Icons', url: 'variable.woff2', format: 'woff2', weight: '100 900', style: 'normal' }];
-    expect(selectFontFace(variable, '725', 'normal').url).toBe('variable.woff2');
+    const variable = [
+      { family: 'Icons', url: 'low.woff2', format: 'woff2', weight: '100 400', style: 'normal' },
+      { family: 'Icons', url: 'high.woff2', format: 'woff2', weight: '500 900', style: 'normal' },
+      { family: 'Icons', url: 'fixed.woff2', format: 'woff2', weight: '700', style: 'normal' },
+    ];
+    expect(selectFontFace(variable, '725', 'normal').url).toBe('high.woff2');
+    expect(selectFontFace(variable, '200', 'normal').url).toBe('low.woff2');
+  });
+
+  test('uses CSS directional weight matching independent of declaration order', () => {
+    const regular = {
+      family: 'Icons', url: 'regular.woff2', format: 'woff2', weight: '400', style: 'normal',
+    };
+    const semibold = {
+      family: 'Icons', url: 'semibold.woff2', format: 'woff2', weight: '600', style: 'normal',
+    };
+    const black = {
+      family: 'Icons', url: 'black.woff2', format: 'woff2', weight: '900', style: 'normal',
+    };
+    expect(selectFontFace([regular, black], '650', 'normal').url).toBe('black.woff2');
+    expect(selectFontFace([black, regular], '650', 'normal').url).toBe('black.woff2');
+    expect(selectFontFace([semibold, regular], '500', 'normal').url).toBe('regular.woff2');
+    expect(selectFontFace([regular, semibold], '500', 'normal').url).toBe('regular.woff2');
+  });
+
+  test('falls back deterministically to weight 400 for an unknown request', () => {
+    expect(selectFontFace([faces[1], faces[0]], 'not-a-weight', 'normal').url)
+      .toBe('regular.woff2');
   });
 });
 

--- a/tools/html-snapshot/test/icon-font.test.js
+++ b/tools/html-snapshot/test/icon-font.test.js
@@ -8,6 +8,9 @@ const {
   formatRank,
   parseSrcList,
   parseFontFaceFromText,
+  normalizeFontFaceWeight,
+  normalizeFontFaceStyle,
+  selectFontFace,
   isPuaCodepoint,
   roundTo,
   fetchFontBytes,
@@ -131,6 +134,23 @@ describe('parseFontFaceFromText', () => {
     expect(out[0].family).toBe('Phosphor');
     expect(out[0].url).toBe('https://cdn.example/phosphor.woff2');
     expect(out[0].format).toBe('woff2');
+    expect(out[0].weight).toBe('400');
+    expect(out[0].style).toBe('normal');
+  });
+
+  test('extracts font weight and style descriptors', () => {
+    const css = `
+      @font-face {
+        font-family: "Font Awesome 6 Free";
+        font-style: normal;
+        font-weight: 900;
+        src: url(fa-solid-900.woff2) format("woff2");
+      }`;
+    expect(parseFontFaceFromText(css, 'https://cdn.example/css/all.css')[0]).toMatchObject({
+      weight: '900',
+      style: 'normal',
+      url: 'https://cdn.example/css/fa-solid-900.woff2',
+    });
   });
 
   test('ignores @font-face inside CSS comments', () => {
@@ -141,6 +161,34 @@ describe('parseFontFaceFromText', () => {
   test('skips blocks missing font-family or src', () => {
     const css = `@font-face { font-family: "NoSrc"; }`;
     expect(parseFontFaceFromText(css, 'https://cdn/sheet.css')).toEqual([]);
+  });
+});
+
+describe('selectFontFace', () => {
+  const faces = [
+    { family: 'Icons', url: 'regular.woff2', format: 'woff2', weight: 'normal', style: 'normal' },
+    { family: 'Icons', url: 'solid.woff2', format: 'woff2', weight: '900', style: 'normal' },
+    { family: 'Icons', url: 'italic.woff2', format: 'woff2', weight: '400', style: 'italic' },
+  ];
+
+  test('normalises CSS weight/style keywords', () => {
+    expect(normalizeFontFaceWeight('normal')).toBe('400');
+    expect(normalizeFontFaceWeight('bold')).toBe('700');
+    expect(normalizeFontFaceStyle('oblique 10deg')).toBe('oblique');
+  });
+
+  test('selects the face nearest to the computed weight', () => {
+    expect(selectFontFace(faces, '900', 'normal').url).toBe('solid.woff2');
+    expect(selectFontFace(faces, '400', 'normal').url).toBe('regular.woff2');
+  });
+
+  test('prefers a matching style over a closer mismatched style', () => {
+    expect(selectFontFace(faces, '500', 'italic').url).toBe('italic.woff2');
+  });
+
+  test('supports variable-font weight ranges', () => {
+    const variable = [{ family: 'Icons', url: 'variable.woff2', format: 'woff2', weight: '100 900', style: 'normal' }];
+    expect(selectFontFace(variable, '725', 'normal').url).toBe('variable.woff2');
   });
 });
 


### PR DESCRIPTION
本 PR 提升 PAGX 的 HTML 导入和 PPT 文本导出保真度，并补充相应的回归测试。

## HTML 导入

- 按 CSS `font-weight` 和 `font-style` 精确匹配 `@font-face`，保留 SemiBold、Bold、Black 等真实字面；当目标字面缺失并回退到较轻字重时，不再合成伪粗体。
- 按计算后的字重和样式匹配图标字体，使 Font Awesome Free 等字体族能够正确选择 Solid 字面，而不是固定使用首个 Regular 字面。
- 修复 `radial-gradient` 圆形范围的尺寸计算，包括圆心位于盒子外的情况；透明色标会借用相邻颜色的 RGB，避免导出后透过黑色渐隐。
- 在 resolve 阶段将同级 SVG 元素图层统一转换为对等 Group，并以不受缩放影响的方式检测斜切，保留源层级和变换关系。
- 不再为 HTML importer 的 mask 图层输出冗余的 `visible=false`。

## PPT 文本导出

- 当内嵌 glyph 的位置能够确认原始文本为单行时，禁用 PowerPoint 自动换行，避免宿主字体度量差异导致文本被重新折行。

## 测试

- 补充字体匹配、渐变解析、图层 resolve、图标字体和 PPT 单行文本导出的单元测试及测试资源。