### PR TITLE
Fix duplicate windows and canvas sizing issues in the PAGViewer

### DIFF
--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -29,6 +29,12 @@ PAGWindow {
 
     property int windowTitleBarHeight: isWindows ? 32 : 22
 
+    // Minimum window height while the side edit panel is open, so the panel stays usable.
+    property int minWindowHeightWithEditPanel: 650
+
+    // Window height before the side panel opened, restored when the panel closes (-1 = none).
+    property int heightBeforePanelOpen: -1
+
     property var contentView: mainForm.contentView
     property var connectedContentView: null
 
@@ -161,7 +167,13 @@ PAGWindow {
         // the file and the aspect-fit rendering leaves blank margins on the left and right.
         let height = computeContentWindowHeight(preferredSize.height);
         if (mainForm.rightItemLoader.status === Loader.Ready) {
-            width += mainForm.rightItemLoader.width + mainForm.splitHandleWidth;
+            // The side panel is open: keep the window tall enough for the panel and fit the
+            // canvas width to the file aspect ratio so the canvas fills the area without
+            // letterboxing.
+            height = Math.max(height, minWindowHeightWithEditPanel);
+            let canvasHeight = height - windowTitleBarHeight - controlForm.height;
+            width = computePanelWindowWidth(preferredSize, canvasHeight,
+                                            mainForm.rightItemLoader.width);
         }
         let x = Math.max(0, oldX - ((width - oldWidth) / 2));
         let y = Math.max(50, oldY - ((height - oldHeight) / 2));
@@ -477,22 +489,29 @@ PAGWindow {
             if (viewWindow.visibility === Window.FullScreen) {
                 mainForm.centerItem.width = viewWindow.width - widthChange;
             } else {
-                // The canvas width is unchanged after widening (the added width is occupied by
-                // the panel), so resize the window height so the canvas height matches the file
-                // aspect ratio and the rendered image is not letterboxed.
-                let canvasWidth = mainForm.centerItem.width;
-                viewWindow.width = viewWindow.width + widthChange + mainForm.splitHandleWidth;
+                // Remember the height before the panel resizes the window so closing the panel
+                // can restore it.
+                if (heightBeforePanelOpen < 0) {
+                    heightBeforePanelOpen = viewWindow.height;
+                }
+                // Raise the window to the panel minimum height so the edit panel stays usable.
+                if (viewWindow.height < minWindowHeightWithEditPanel) {
+                    viewWindow.height = minWindowHeightWithEditPanel;
+                }
                 if (contentView) {
                     let preferredSize = contentView.viewModel.preferredSize;
                     if (preferredSize.width > 0 && preferredSize.height > 0) {
-                        let targetHeight = computeContentWindowHeight(
-                            canvasWidth * preferredSize.height / preferredSize.width);
-                        // Avoid abruptly overriding a manually resized window; only correct the
-                        // height when the current height deviates noticeably.
-                        if (Math.abs(viewWindow.height - targetHeight) > 40) {
-                            viewWindow.height = targetHeight;
-                        }
+                        // Size the canvas width from the file aspect ratio so the canvas fills
+                        // the area below the title bar and control bar without letterboxing,
+                        // then widen the window by the panel width.
+                        let canvasHeight = viewWindow.height - windowTitleBarHeight - controlForm.height;
+                        viewWindow.width = computePanelWindowWidth(preferredSize, canvasHeight,
+                                                                  widthChange);
+                    } else {
+                        viewWindow.width = viewWindow.width + widthChange + mainForm.splitHandleWidth;
                     }
+                } else {
+                    viewWindow.width = viewWindow.width + widthChange + mainForm.splitHandleWidth;
                 }
             }
         } else {
@@ -503,6 +522,11 @@ PAGWindow {
                 viewWindow.width = viewWindow.minimumWidth;
             } else {
                 viewWindow.width = viewWindow.width + widthChange - mainForm.splitHandleWidth;
+            }
+            // Restore the window height captured before the panel opened.
+            if (heightBeforePanelOpen >= 0) {
+                viewWindow.height = heightBeforePanelOpen;
+                heightBeforePanelOpen = -1;
             }
         }
     }
@@ -522,6 +546,14 @@ PAGWindow {
     function computeContentWindowHeight(canvasHeight) {
         return Math.max(viewWindow.minimumHeight,
                         canvasHeight + windowTitleBarHeight + controlForm.height);
+    }
+
+    // Returns the window width that fits a canvas of the given height at the file aspect ratio,
+    // plus the side panel width and the split handle.
+    function computePanelWindowWidth(preferredSize, canvasHeight, widthChange) {
+        return Math.max(viewWindow.minimumWidth,
+                        canvasHeight * preferredSize.width / preferredSize.height + widthChange +
+                            mainForm.splitHandleWidth);
     }
 
     function updateAvailable(hasNewVersion) {

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -29,8 +29,6 @@ PAGWindow {
 
     property int windowTitleBarHeight: isWindows ? 32 : 22
 
-    property int minWindowHeightWithEditPanel: 650
-
     property var contentView: mainForm.contentView
     property var connectedContentView: null
 
@@ -480,10 +478,9 @@ PAGWindow {
             if (viewWindow.visibility === Window.FullScreen) {
                 mainForm.centerItem.width = viewWindow.width - widthChange;
             } else {
+                // Only widen the window for the panel; keep the height unchanged so the content
+                // canvas keeps its aspect ratio and the rendered image is not letterboxed.
                 viewWindow.width = viewWindow.width + widthChange + mainForm.splitHandleWidth;
-            }
-            if (viewWindow.height < minWindowHeightWithEditPanel) {
-                viewWindow.height = minWindowHeightWithEditPanel;
             }
         } else {
             let widthChange = -1 * mainForm.rightItemLoader.width;
@@ -500,12 +497,28 @@ PAGWindow {
     function resizeContentView() {
         if (!contentView)
             return;
-        let windowWidth = mainForm.centerItem.width;
-        let windowHeight = mainForm.centerItem.height - mainForm.controlForm.height;
-        mainForm.contentViewLoader.item.width = windowWidth;
-        mainForm.contentViewLoader.item.height = windowHeight;
-        mainForm.contentViewLoader.item.x = 0;
-        mainForm.contentViewLoader.item.y = 0;
+        let areaWidth = mainForm.centerItem.width;
+        let areaHeight = mainForm.centerItem.height - mainForm.controlForm.height;
+        let preferredSize = contentView.viewModel.preferredSize;
+        let canvasWidth = areaWidth;
+        let canvasHeight = areaHeight;
+        let canvasX = 0;
+        let canvasY = 0;
+        if (preferredSize.width > 0 && preferredSize.height > 0) {
+            // Keep the canvas at the file aspect ratio and center it inside the content area.
+            // Stretching the canvas to fill the area would distort the aspect ratio and leave
+            // blank margins around the rendered content whenever the window is resized or the
+            // side panel is toggled.
+            let scale = Math.min(areaWidth / preferredSize.width, areaHeight / preferredSize.height);
+            canvasWidth = preferredSize.width * scale;
+            canvasHeight = preferredSize.height * scale;
+            canvasX = (areaWidth - canvasWidth) / 2;
+            canvasY = (areaHeight - canvasHeight) / 2;
+        }
+        mainForm.contentViewLoader.item.width = canvasWidth;
+        mainForm.contentViewLoader.item.height = canvasHeight;
+        mainForm.contentViewLoader.item.x = canvasX;
+        mainForm.contentViewLoader.item.y = canvasY;
     }
 
     function updateAvailable(hasNewVersion) {

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -168,9 +168,15 @@ PAGWindow {
             // canvas width to the file aspect ratio so the canvas fills the area without
             // letterboxing.
             height = Math.max(height, minWindowHeightWithEditPanel);
-            let canvasHeight = height - windowTitleBarHeight - controlForm.height;
-            width = computePanelWindowWidth(preferredSize, canvasHeight,
-                                            mainForm.rightItemLoader.width);
+            if (preferredSize.width > 0 && preferredSize.height > 0) {
+                let canvasHeight = height - windowTitleBarHeight - controlForm.height;
+                width = computePanelWindowWidth(preferredSize, canvasHeight,
+                                                mainForm.rightItemLoader.width);
+            } else {
+                // preferredSize can be {0,0} before the GPU drawable/window is attached;
+                // avoid dividing by zero and just widen by the panel and split handle.
+                width += mainForm.rightItemLoader.width + mainForm.splitHandleWidth;
+            }
         }
         let x = Math.max(0, oldX - ((width - oldWidth) / 2));
         let y = Math.max(50, oldY - ((height - oldHeight) / 2));

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -478,9 +478,18 @@ PAGWindow {
             if (viewWindow.visibility === Window.FullScreen) {
                 mainForm.centerItem.width = viewWindow.width - widthChange;
             } else {
-                // Only widen the window for the panel; keep the height unchanged so the content
-                // canvas keeps its aspect ratio and the rendered image is not letterboxed.
+                // The canvas width is unchanged after widening (the added width is occupied by
+                // the panel), so resize the window height so the canvas height matches the file
+                // aspect ratio and the rendered image is not letterboxed.
+                let canvasWidth = mainForm.centerItem.width;
                 viewWindow.width = viewWindow.width + widthChange + mainForm.splitHandleWidth;
+                let preferredSize = contentView.viewModel.preferredSize;
+                if (preferredSize.width > 0 && preferredSize.height > 0) {
+                    let targetCanvasHeight = canvasWidth * preferredSize.height / preferredSize.width;
+                    viewWindow.height = Math.max(viewWindow.minimumHeight,
+                                                 targetCanvasHeight + windowTitleBarHeight +
+                                                     controlForm.height);
+                }
             }
         } else {
             let widthChange = -1 * mainForm.rightItemLoader.width;
@@ -497,28 +506,12 @@ PAGWindow {
     function resizeContentView() {
         if (!contentView)
             return;
-        let areaWidth = mainForm.centerItem.width;
-        let areaHeight = mainForm.centerItem.height - mainForm.controlForm.height;
-        let preferredSize = contentView.viewModel.preferredSize;
-        let canvasWidth = areaWidth;
-        let canvasHeight = areaHeight;
-        let canvasX = 0;
-        let canvasY = 0;
-        if (preferredSize.width > 0 && preferredSize.height > 0) {
-            // Keep the canvas at the file aspect ratio and center it inside the content area.
-            // Stretching the canvas to fill the area would distort the aspect ratio and leave
-            // blank margins around the rendered content whenever the window is resized or the
-            // side panel is toggled.
-            let scale = Math.min(areaWidth / preferredSize.width, areaHeight / preferredSize.height);
-            canvasWidth = preferredSize.width * scale;
-            canvasHeight = preferredSize.height * scale;
-            canvasX = (areaWidth - canvasWidth) / 2;
-            canvasY = (areaHeight - canvasHeight) / 2;
-        }
-        mainForm.contentViewLoader.item.width = canvasWidth;
-        mainForm.contentViewLoader.item.height = canvasHeight;
-        mainForm.contentViewLoader.item.x = canvasX;
-        mainForm.contentViewLoader.item.y = canvasY;
+        let windowWidth = mainForm.centerItem.width;
+        let windowHeight = mainForm.centerItem.height - mainForm.controlForm.height;
+        mainForm.contentViewLoader.item.width = windowWidth;
+        mainForm.contentViewLoader.item.height = windowHeight;
+        mainForm.contentViewLoader.item.x = 0;
+        mainForm.contentViewLoader.item.y = 0;
     }
 
     function updateAvailable(hasNewVersion) {

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -534,12 +534,12 @@ PAGWindow {
         if (!(preferredSize.width > 0) || !(preferredSize.height > 0)) {
             // preferredSize can be {0,0} before the file is loaded or the window has no screen
             // yet; avoid dividing by zero and just fall back to the minimum plus the panel.
-            let fallbackW = Math.max(viewWindow.minimumWidth, viewWindow.minimumWidth + panelWidth);
+            let fallbackW = viewWindow.minimumWidth + panelWidth;
             let fallbackH = panelOpen ? Math.max(viewWindow.minimumHeight, minWindowHeightWithEditPanel)
                 : viewWindow.minimumHeight;
             return {
-                "width": Math.min(fallbackW, availW),
-                "height": Math.min(fallbackH, availH)
+                "width": Math.round(Math.min(fallbackW, availW)),
+                "height": Math.round(Math.min(fallbackH, availH))
             };
         }
 

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -571,19 +571,26 @@ PAGWindow {
         }
 
         // Minimum width clamp: keep the ratio by reverse-deriving the height, so the clamp does
-        // not reintroduce top/bottom letterboxing for narrow-tall files.
+        // not reintroduce top/bottom letterboxing for narrow-tall files. The reverse-derived
+        // height is still bounded by the screen: when the minimum width and the screen height
+        // cannot both hold at the file ratio, we accept the screen bound (some letterboxing)
+        // rather than let the window run off-screen.
         if (winW < viewWindow.minimumWidth) {
             winW = viewWindow.minimumWidth;
             canvasWidth = winW - panelWidth - windowPadding;
             canvasHeight = canvasWidth / ratio;
             winH = canvasHeight + chromeHeight + contentHeightPadding;
+            winH = Math.min(winH, availH);
         }
-        // Minimum height clamp: reverse-derive the width for the same reason.
+        // Minimum height clamp: reverse-derive the width for the same reason, and likewise bound
+        // the reverse-derived width by the screen so the window never exceeds it (dropping the
+        // ratio only when the minimum height and the screen width cannot both hold).
         if (winH < viewWindow.minimumHeight) {
             winH = viewWindow.minimumHeight;
             canvasHeight = winH - chromeHeight - contentHeightPadding;
             canvasWidth = canvasHeight * ratio;
             winW = canvasWidth + panelWidth + windowPadding;
+            winW = Math.min(winW, availW);
         }
 
         return {

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -159,8 +159,7 @@ PAGWindow {
         // The window height must include the title bar and the control bar so that the content
         // canvas below them exactly matches preferredSize. Otherwise the canvas is shorter than
         // the file and the aspect-fit rendering leaves blank margins on the left and right.
-        let height = Math.max(viewWindow.minimumHeight,
-                              preferredSize.height + windowTitleBarHeight + controlForm.height);
+        let height = computeContentWindowHeight(preferredSize.height);
         if (mainForm.rightItemLoader.status === Loader.Ready) {
             width += mainForm.rightItemLoader.width + mainForm.splitHandleWidth;
         }
@@ -483,12 +482,17 @@ PAGWindow {
                 // aspect ratio and the rendered image is not letterboxed.
                 let canvasWidth = mainForm.centerItem.width;
                 viewWindow.width = viewWindow.width + widthChange + mainForm.splitHandleWidth;
-                let preferredSize = contentView.viewModel.preferredSize;
-                if (preferredSize.width > 0 && preferredSize.height > 0) {
-                    let targetCanvasHeight = canvasWidth * preferredSize.height / preferredSize.width;
-                    viewWindow.height = Math.max(viewWindow.minimumHeight,
-                                                 targetCanvasHeight + windowTitleBarHeight +
-                                                     controlForm.height);
+                if (contentView) {
+                    let preferredSize = contentView.viewModel.preferredSize;
+                    if (preferredSize.width > 0 && preferredSize.height > 0) {
+                        let targetHeight = computeContentWindowHeight(
+                            canvasWidth * preferredSize.height / preferredSize.width);
+                        // Avoid abruptly overriding a manually resized window; only correct the
+                        // height when the current height deviates noticeably.
+                        if (Math.abs(viewWindow.height - targetHeight) > 40) {
+                            viewWindow.height = targetHeight;
+                        }
+                    }
                 }
             }
         } else {
@@ -512,6 +516,12 @@ PAGWindow {
         mainForm.contentViewLoader.item.height = windowHeight;
         mainForm.contentViewLoader.item.x = 0;
         mainForm.contentViewLoader.item.y = 0;
+    }
+
+    // Returns the window height that makes the content canvas of the given height exactly fit.
+    function computeContentWindowHeight(canvasHeight) {
+        return Math.max(viewWindow.minimumHeight,
+                        canvasHeight + windowTitleBarHeight + controlForm.height);
     }
 
     function updateAvailable(hasNewVersion) {

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -484,9 +484,9 @@ PAGWindow {
 
         let preferredSize = contentView ? contentView.viewModel.preferredSize : Qt.size(0, 0);
         if (viewWindow.visibility === Window.FullScreen) {
-            // Full screen: the window size is fixed, so fit the canvas inside the available
-            // content area at the file aspect ratio instead of resizing the window.
-            applyFullScreenCanvas(preferredSize, willOpen);
+            // Full screen: the window size is fixed, so only reserve horizontal room for the
+            // panel instead of resizing the window.
+            applyFullScreenCanvas(willOpen);
             return;
         }
         // Recompute the whole window geometry so that both dimensions stay consistent with the
@@ -497,10 +497,10 @@ PAGWindow {
         viewWindow.height = geometry.height;
     }
 
-    // Fits the canvas inside the available content area when the window size is fixed (full
-    // screen). The window cannot be resized, so the canvas itself is sized to the file aspect
-    // ratio within the area left of the panel; MainForm centers the content inside centerItem.
-    function applyFullScreenCanvas(preferredSize, panelOpen) {
+    // In full screen the window size is fixed and cannot be resized, so this only reserves
+    // horizontal room for the side panel by shrinking centerItem.width; the content view keeps
+    // aspect-fit rendering within whatever area is left.
+    function applyFullScreenCanvas(panelOpen) {
         let panelWidth = panelOpen ? Math.max(mainForm.rightItemLoader.width, mainForm.minPanelWidth)
             + mainForm.splitHandleWidth : 0;
         mainForm.centerItem.width = viewWindow.width - panelWidth;

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -1,6 +1,7 @@
 import PAG
 import QtCore
 import QtQuick
+import QtQuick.Window
 import QtQuick.Dialogs
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -15,7 +16,7 @@ PAGWindow {
     width: isWindows ? 520 : 500
     height: 360
     minimumWidth: 400 + windowPadding
-    minimumHeight: 320 + windowTitleBarHeight
+    minimumHeight: 320 + windowTitleBarHeight + contentHeightPadding
     hasMenu: true
     resizeHandleSize: 5
     titleBarHeight: windowTitleBarHeight
@@ -28,6 +29,15 @@ PAGWindow {
     property int windowPadding: isWindows ? 2 : 0
 
     property int windowTitleBarHeight: isWindows ? 32 : 22
+
+    // Chrome = title bar + control bar. The content canvas below them has a height of
+    // (window height - chromeHeight), so window/canvas conversions go through this single value.
+    readonly property int chromeHeight: windowTitleBarHeight + controlForm.height
+
+    // On Windows the placeholder is inset by 1px at the bottom (see components/PAGWindow.qml),
+    // so the window must be 1px taller than chrome + canvas for the canvas to match the file
+    // exactly. This mirrors windowPadding, which compensates the 1px left/right insets.
+    readonly property int contentHeightPadding: isWindows ? 1 : 0
 
     // Minimum window height while the side edit panel is open, so the panel stays usable.
     property int minWindowHeightWithEditPanel: 650
@@ -158,33 +168,17 @@ PAGWindow {
         let oldWidth = viewWindow.width;
         let oldHeight = viewWindow.height;
         let preferredSize = contentView.viewModel.preferredSize;
-        let width = Math.max(viewWindow.minimumWidth, preferredSize.width);
-        // The window height must include the title bar and the control bar so that the content
-        // canvas below them exactly matches preferredSize. Otherwise the canvas is shorter than
-        // the file and the aspect-fit rendering leaves blank margins on the left and right.
-        let height = computeContentWindowHeight(preferredSize.height);
-        if (mainForm.rightItemLoader.status === Loader.Ready) {
-            // The side panel is open: keep the window tall enough for the panel and fit the
-            // canvas width to the file aspect ratio so the canvas fills the area without
-            // letterboxing.
-            height = Math.max(height, minWindowHeightWithEditPanel);
-            if (preferredSize.width > 0 && preferredSize.height > 0) {
-                let canvasHeight = height - windowTitleBarHeight - controlForm.height;
-                width = computePanelWindowWidth(preferredSize, canvasHeight,
-                                                mainForm.rightItemLoader.width);
-            } else {
-                // preferredSize can be {0,0} before the GPU drawable/window is attached;
-                // avoid dividing by zero and just widen by the panel and split handle.
-                width += mainForm.rightItemLoader.width + mainForm.splitHandleWidth;
-            }
-        }
+        let panelOpen = mainForm.rightItemLoader.status === Loader.Ready;
+        let geometry = computeWindowGeometry(preferredSize, panelOpen);
+        let width = geometry.width;
+        let height = geometry.height;
         let x = Math.max(0, oldX - ((width - oldWidth) / 2));
         let y = Math.max(50, oldY - ((height - oldHeight) / 2));
         settings.lastX = x;
         settings.lastY = y;
         viewWindow.x = x;
         viewWindow.y = y;
-        viewWindow.width = width + windowPadding;
+        viewWindow.width = width;
         viewWindow.height = height;
     }
 
@@ -487,43 +481,29 @@ PAGWindow {
 
         settings.isEditPanelOpen = willOpen;
         mainForm.isEditPanelOpen = willOpen;
-        if (willOpen) {
-            let widthChange = Math.max(mainForm.rightItemLoader.width, mainForm.minPanelWidth);
-            if (viewWindow.visibility === Window.FullScreen) {
-                mainForm.centerItem.width = viewWindow.width - widthChange;
-            } else {
-                // Raise the window to the panel minimum height so the edit panel stays usable.
-                // The height is kept when the panel closes: restoring the pre-panel height would
-                // shrink the window even though the user did not ask for a resize.
-                if (viewWindow.height < minWindowHeightWithEditPanel) {
-                    viewWindow.height = minWindowHeightWithEditPanel;
-                }
-                if (contentView) {
-                    let preferredSize = contentView.viewModel.preferredSize;
-                    if (preferredSize.width > 0 && preferredSize.height > 0) {
-                        // Size the canvas width from the file aspect ratio so the canvas fills
-                        // the area below the title bar and control bar without letterboxing,
-                        // then widen the window by the panel width.
-                        let canvasHeight = viewWindow.height - windowTitleBarHeight - controlForm.height;
-                        viewWindow.width = computePanelWindowWidth(preferredSize, canvasHeight,
-                                                                  widthChange);
-                    } else {
-                        viewWindow.width = viewWindow.width + widthChange + mainForm.splitHandleWidth;
-                    }
-                } else {
-                    viewWindow.width = viewWindow.width + widthChange + mainForm.splitHandleWidth;
-                }
-            }
-        } else {
-            let widthChange = -1 * mainForm.rightItemLoader.width;
-            if (viewWindow.visibility === Window.FullScreen) {
-                mainForm.centerItem.width = viewWindow.width;
-            } else if ((viewWindow.width + widthChange) < viewWindow.minimumWidth) {
-                viewWindow.width = viewWindow.minimumWidth;
-            } else {
-                viewWindow.width = viewWindow.width + widthChange - mainForm.splitHandleWidth;
-            }
+
+        let preferredSize = contentView ? contentView.viewModel.preferredSize : Qt.size(0, 0);
+        if (viewWindow.visibility === Window.FullScreen) {
+            // Full screen: the window size is fixed, so fit the canvas inside the available
+            // content area at the file aspect ratio instead of resizing the window.
+            applyFullScreenCanvas(preferredSize, willOpen);
+            return;
         }
+        // Recompute the whole window geometry so that both dimensions stay consistent with the
+        // file aspect ratio. Opening or closing the panel goes through the same path, which
+        // avoids the letterboxing that a linear width add/subtract reintroduced on close.
+        let geometry = computeWindowGeometry(preferredSize, willOpen);
+        viewWindow.width = geometry.width;
+        viewWindow.height = geometry.height;
+    }
+
+    // Fits the canvas inside the available content area when the window size is fixed (full
+    // screen). The window cannot be resized, so the canvas itself is sized to the file aspect
+    // ratio within the area left of the panel; MainForm centers the content inside centerItem.
+    function applyFullScreenCanvas(preferredSize, panelOpen) {
+        let panelWidth = panelOpen ? Math.max(mainForm.rightItemLoader.width, mainForm.minPanelWidth)
+            + mainForm.splitHandleWidth : 0;
+        mainForm.centerItem.width = viewWindow.width - panelWidth;
     }
 
     function resizeContentView() {
@@ -537,18 +517,79 @@ PAGWindow {
         mainForm.contentViewLoader.item.y = 0;
     }
 
-    // Returns the window height that makes the content canvas of the given height exactly fit.
-    function computeContentWindowHeight(canvasHeight) {
-        return Math.max(viewWindow.minimumHeight,
-                        canvasHeight + windowTitleBarHeight + controlForm.height);
-    }
+    // Computes the window {width, height} that fits a canvas of the file aspect ratio.
+    //
+    // The width direction previously had no upper bound: reverse-deriving the width from the
+    // canvas height for extreme aspect ratios (e.g. 1920x200) produced widths far larger than
+    // any screen. This function keeps both dimensions self-consistent and clamps them to the
+    // available screen size: when the width is capped it reverse-derives the height instead of
+    // blowing up the width, and vice versa, so the canvas always matches the file ratio without
+    // letterboxing.
+    function computeWindowGeometry(preferredSize, panelOpen) {
+        let availW = Screen.desktopAvailableWidth;
+        let availH = Screen.desktopAvailableHeight;
+        let panelWidth = panelOpen ? Math.max(mainForm.rightItemLoader.width, mainForm.minPanelWidth)
+            + mainForm.splitHandleWidth : 0;
 
-    // Returns the window width that fits a canvas of the given height at the file aspect ratio,
-    // plus the side panel width and the split handle.
-    function computePanelWindowWidth(preferredSize, canvasHeight, widthChange) {
-        return Math.max(viewWindow.minimumWidth,
-                        canvasHeight * preferredSize.width / preferredSize.height + widthChange +
-                            mainForm.splitHandleWidth);
+        if (!(preferredSize.width > 0) || !(preferredSize.height > 0)) {
+            // preferredSize can be {0,0} before the file is loaded or the window has no screen
+            // yet; avoid dividing by zero and just fall back to the minimum plus the panel.
+            let fallbackW = Math.max(viewWindow.minimumWidth, viewWindow.minimumWidth + panelWidth);
+            let fallbackH = panelOpen ? Math.max(viewWindow.minimumHeight, minWindowHeightWithEditPanel)
+                : viewWindow.minimumHeight;
+            return {
+                "width": Math.min(fallbackW, availW),
+                "height": Math.min(fallbackH, availH)
+            };
+        }
+
+        let ratio = preferredSize.width / preferredSize.height;
+
+        // Start from the file height (or the panel minimum height) and derive the width.
+        let canvasHeight = preferredSize.height;
+        if (panelOpen) {
+            canvasHeight = Math.max(canvasHeight, minWindowHeightWithEditPanel - chromeHeight);
+        }
+        let canvasWidth = canvasHeight * ratio;
+
+        let winW = canvasWidth + panelWidth + windowPadding;
+        let winH = canvasHeight + chromeHeight + contentHeightPadding;
+
+        // Width capped by the screen: reverse-derive the height so the ratio still holds.
+        if (winW > availW) {
+            canvasWidth = availW - panelWidth - windowPadding;
+            canvasHeight = canvasWidth / ratio;
+            winW = availW;
+            winH = canvasHeight + chromeHeight + contentHeightPadding;
+        }
+        // Height capped by the screen: reverse-derive the width.
+        if (winH > availH) {
+            canvasHeight = availH - chromeHeight - contentHeightPadding;
+            canvasWidth = canvasHeight * ratio;
+            winH = availH;
+            winW = canvasWidth + panelWidth + windowPadding;
+        }
+
+        // Minimum width clamp: keep the ratio by reverse-deriving the height, so the clamp does
+        // not reintroduce top/bottom letterboxing for narrow-tall files.
+        if (winW < viewWindow.minimumWidth) {
+            winW = viewWindow.minimumWidth;
+            canvasWidth = winW - panelWidth - windowPadding;
+            canvasHeight = canvasWidth / ratio;
+            winH = canvasHeight + chromeHeight + contentHeightPadding;
+        }
+        // Minimum height clamp: reverse-derive the width for the same reason.
+        if (winH < viewWindow.minimumHeight) {
+            winH = viewWindow.minimumHeight;
+            canvasHeight = winH - chromeHeight - contentHeightPadding;
+            canvasWidth = canvasHeight * ratio;
+            winW = canvasWidth + panelWidth + windowPadding;
+        }
+
+        return {
+            "width": Math.round(winW),
+            "height": Math.round(winH)
+        };
     }
 
     function updateAvailable(hasNewVersion) {

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -32,9 +32,6 @@ PAGWindow {
     // Minimum window height while the side edit panel is open, so the panel stays usable.
     property int minWindowHeightWithEditPanel: 650
 
-    // Window height before the side panel opened, restored when the panel closes (-1 = none).
-    property int heightBeforePanelOpen: -1
-
     property var contentView: mainForm.contentView
     property var connectedContentView: null
 
@@ -489,12 +486,9 @@ PAGWindow {
             if (viewWindow.visibility === Window.FullScreen) {
                 mainForm.centerItem.width = viewWindow.width - widthChange;
             } else {
-                // Remember the height before the panel resizes the window so closing the panel
-                // can restore it.
-                if (heightBeforePanelOpen < 0) {
-                    heightBeforePanelOpen = viewWindow.height;
-                }
                 // Raise the window to the panel minimum height so the edit panel stays usable.
+                // The height is kept when the panel closes: restoring the pre-panel height would
+                // shrink the window even though the user did not ask for a resize.
                 if (viewWindow.height < minWindowHeightWithEditPanel) {
                     viewWindow.height = minWindowHeightWithEditPanel;
                 }
@@ -522,11 +516,6 @@ PAGWindow {
                 viewWindow.width = viewWindow.minimumWidth;
             } else {
                 viewWindow.width = viewWindow.width + widthChange - mainForm.splitHandleWidth;
-            }
-            // Restore the window height captured before the panel opened.
-            if (heightBeforePanelOpen >= 0) {
-                viewWindow.height = heightBeforePanelOpen;
-                heightBeforePanelOpen = -1;
             }
         }
     }

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -158,7 +158,11 @@ PAGWindow {
         let oldHeight = viewWindow.height;
         let preferredSize = contentView.viewModel.preferredSize;
         let width = Math.max(viewWindow.minimumWidth, preferredSize.width);
-        let height = Math.max(viewWindow.minimumHeight, preferredSize.height + controlForm.height);
+        // The window height must include the title bar and the control bar so that the content
+        // canvas below them exactly matches preferredSize. Otherwise the canvas is shorter than
+        // the file and the aspect-fit rendering leaves blank margins on the left and right.
+        let height = Math.max(viewWindow.minimumHeight,
+                              preferredSize.height + windowTitleBarHeight + controlForm.height);
         if (mainForm.rightItemLoader.status === Loader.Ready) {
             width += mainForm.rightItemLoader.width + mainForm.splitHandleWidth;
         }

--- a/viewer/assets/qml/MainForm.qml
+++ b/viewer/assets/qml/MainForm.qml
@@ -870,7 +870,11 @@ SplitView {
                 PAGRectangle {
                     id: performance
                     color: "#16161D"
-                    height: isSourceEditorActive ? 0 : Math.min(profilerForm.contentHeight, parent.height - tabBar.height - 40)
+                    // Reserve at least 120px for the editing area above, so the profiler never
+                    // squeezes it to an unusable size when the window is short. The profiler
+                    // scrolls internally, so no data is lost.
+                    height: isSourceEditorActive ? 0 : Math.min(profilerForm.contentHeight,
+                                                                Math.max(0, parent.height - tabBar.height - 40 - 120))
                     visible: !isSourceEditorActive
                     clip: true
                     anchors.right: parent.right

--- a/viewer/assets/qml/MainForm.qml
+++ b/viewer/assets/qml/MainForm.qml
@@ -30,6 +30,10 @@ SplitView {
 
     property int controlFormHeight: 76
 
+    // Minimum height reserved for the editing area while the side panel is open, so the
+    // profiler never squeezes it to an unusable size when the window is short.
+    property int minEditAreaHeight: 120
+
     property alias contentViewLoader: contentViewLoader
 
     property alias dropArea: dropArea
@@ -870,11 +874,11 @@ SplitView {
                 PAGRectangle {
                     id: performance
                     color: "#16161D"
-                    // Reserve at least 120px for the editing area above, so the profiler never
+                    // Reserve minEditAreaHeight for the editing area above, so the profiler never
                     // squeezes it to an unusable size when the window is short. The profiler
                     // scrolls internally, so no data is lost.
                     height: isSourceEditorActive ? 0 : Math.min(profilerForm.contentHeight,
-                                                                Math.max(0, parent.height - tabBar.height - 40 - 120))
+                                                                Math.max(0, parent.height - tabBar.height - 40 - minEditAreaHeight))
                     visible: !isSourceEditorActive
                     clip: true
                     anchors.right: parent.right

--- a/viewer/assets/qml/components/PAGMessageBox.qml
+++ b/viewer/assets/qml/components/PAGMessageBox.qml
@@ -15,6 +15,7 @@ PAGWindow {
     minimumHeight: height
     minimumWidth: width
     canResize: false
+    titleBarHeight: isWindows ? 32 : 22
 
     PAGRectangle {
         id: rectangle

--- a/viewer/assets/qml/components/PAGWindow.qml
+++ b/viewer/assets/qml/components/PAGWindow.qml
@@ -337,7 +337,7 @@ Window {
     Item {
         id: placeholder
         anchors.fill: parent
-        anchors.topMargin: window.isWindows ? 32 : 22
+        anchors.topMargin: window.titleBarHeight
         anchors.leftMargin: window.isWindows ? 1 : 0
         anchors.rightMargin: window.isWindows ? 1 : 0
         anchors.bottomMargin: window.isWindows ? 1 : 0

--- a/viewer/assets/translation/Chinese.ts
+++ b/viewer/assets/translation/Chinese.ts
@@ -65,56 +65,56 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../qml/Main.qml" line="205"/>
+        <location filename="../qml/Main.qml" line="215"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="234"/>
+        <location filename="../qml/Main.qml" line="244"/>
         <source>About PAGViewer</source>
         <translation>关于PAGViewer</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="265"/>
+        <location filename="../qml/Main.qml" line="275"/>
         <source>Select Save Path</source>
         <translation>选择保存路径</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="363"/>
+        <location filename="../qml/Main.qml" line="373"/>
         <source>Performance Benchmark Test</source>
         <translation>性能基准测试</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="364"/>
+        <location filename="../qml/Main.qml" line="374"/>
         <source>Performance Benchmark Test Complete</source>
         <translation>性能基准测试已完成</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="386"/>
+        <location filename="../qml/Main.qml" line="396"/>
         <source>Export failed, error code: </source>
         <translation>导出错误，错误码：</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="528"/>
+        <location filename="../qml/Main.qml" line="569"/>
         <source>Open PAG File</source>
         <translation>打开PAG文件</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="615"/>
-        <location filename="../qml/Main.qml" line="640"/>
-        <location filename="../qml/Main.qml" line="663"/>
+        <location filename="../qml/Main.qml" line="656"/>
+        <location filename="../qml/Main.qml" line="681"/>
+        <location filename="../qml/Main.qml" line="704"/>
         <source>Select save path</source>
         <translation>选择保存路径</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="626"/>
-        <location filename="../qml/Main.qml" line="647"/>
-        <location filename="../qml/Main.qml" line="672"/>
+        <location filename="../qml/Main.qml" line="667"/>
+        <location filename="../qml/Main.qml" line="688"/>
+        <location filename="../qml/Main.qml" line="713"/>
         <source>Exporting</source>
         <translation>正在导出</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="690"/>
+        <location filename="../qml/Main.qml" line="731"/>
         <source>Profiling</source>
         <translation>分析</translation>
     </message>
@@ -122,77 +122,77 @@
 <context>
     <name>MainForm</name>
     <message>
-        <location filename="../qml/MainForm.qml" line="317"/>
+        <location filename="../qml/MainForm.qml" line="321"/>
         <source>Click the menu or drag-drop here to open a PAG file</source>
         <translation>点击菜单，或拖放到这里打开一个PAG文件</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="377"/>
+        <location filename="../qml/MainForm.qml" line="381"/>
         <source>Edit Layer</source>
         <translation>图层编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="382"/>
+        <location filename="../qml/MainForm.qml" line="386"/>
         <source>File Structure</source>
         <translation>文件结构</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="382"/>
+        <location filename="../qml/MainForm.qml" line="386"/>
         <source>Source Editor</source>
         <translation>源码编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="450"/>
+        <location filename="../qml/MainForm.qml" line="454"/>
         <source>No layer was editable</source>
         <translation>没有可以编辑的图层</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="450"/>
+        <location filename="../qml/MainForm.qml" line="454"/>
         <source>PAGX files do not support layer editing</source>
         <translation>PAGX 文件不支持图层编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="458"/>
+        <location filename="../qml/MainForm.qml" line="462"/>
         <source>Go to Source Editor →</source>
         <translation>前往源码编辑 →</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="532"/>
+        <location filename="../qml/MainForm.qml" line="536"/>
         <source>Edit Text</source>
         <translation>文本编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="614"/>
+        <location filename="../qml/MainForm.qml" line="618"/>
         <source>Edit Image</source>
         <translation>图片编辑</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="742"/>
+        <location filename="../qml/MainForm.qml" line="746"/>
         <source>Discard</source>
         <translation>放弃</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="776"/>
+        <location filename="../qml/MainForm.qml" line="780"/>
         <source>Apply</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="816"/>
+        <location filename="../qml/MainForm.qml" line="820"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="770"/>
+        <location filename="../qml/MainForm.qml" line="774"/>
         <source>Changes discarded</source>
         <translation>修改已放弃</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="300"/>
+        <location filename="../qml/MainForm.qml" line="304"/>
         <source>Reset Zoom</source>
         <translation>重置缩放</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="807"/>
+        <location filename="../qml/MainForm.qml" line="811"/>
         <source>Changes applied</source>
         <translation>修改已应用</translation>
     </message>
@@ -201,7 +201,7 @@
         <translation type="vanished">应用修改失败</translation>
     </message>
     <message>
-        <location filename="../qml/MainForm.qml" line="849"/>
+        <location filename="../qml/MainForm.qml" line="853"/>
         <source>File saved</source>
         <translation>文件已保存</translation>
     </message>

--- a/viewer/src/PAGViewer.cpp
+++ b/viewer/src/PAGViewer.cpp
@@ -48,10 +48,11 @@ void PAGViewer::openFile(QString path) {
       window = win;
       break;
     }
-    // PAGX files always open in a new window because they require a different QML view
-    // component (PAGXView vs PAGView), and reusing an empty PAG window would need a Loader
-    // switch that is simpler handled by creating a fresh window.
-    if (!isPagx && fileInWindow.isEmpty()) {
+    // Reuse an empty window for any file type. The QML layer switches the view component
+    // (PAGView vs PAGXView) automatically in MainForm.loadFile(), so a PAGX file can reuse
+    // a fresh PAG window instead of forcing a new one. This also prevents duplicate windows
+    // when macOS delivers the same file via both the launch arguments and a FileOpen event.
+    if (fileInWindow.isEmpty()) {
       window = win;
       break;
     }

--- a/viewer/src/PAGViewer.cpp
+++ b/viewer/src/PAGViewer.cpp
@@ -50,11 +50,11 @@ void PAGViewer::openFile(QString path) {
     }
     // Reuse an empty window for any file type. The QML layer switches the view component
     // (PAGView vs PAGXView) automatically in MainForm.loadFile(), so a PAGX file can reuse
-    // a fresh PAG window instead of forcing a new one. This also prevents duplicate windows
-    // when macOS delivers the same file via both the launch arguments and a FileOpen event.
-    // Skip windows whose QML is not ready yet, otherwise PAGWindow::openFile() would silently
+    // a fresh PAG window instead of forcing a new one. A window reports hasContent() == false
+    // when it never loaded a file or its last load failed, so both cases are reusable.
+    // isReady() ensures the QML window exists; otherwise PAGWindow::openFile() would silently
     // drop the request.
-    if (fileInWindow.isEmpty() && win->getEngine() != nullptr) {
+    if (!win->hasContent() && win->isReady()) {
       window = win;
       break;
     }

--- a/viewer/src/PAGViewer.cpp
+++ b/viewer/src/PAGViewer.cpp
@@ -52,7 +52,9 @@ void PAGViewer::openFile(QString path) {
     // (PAGView vs PAGXView) automatically in MainForm.loadFile(), so a PAGX file can reuse
     // a fresh PAG window instead of forcing a new one. This also prevents duplicate windows
     // when macOS delivers the same file via both the launch arguments and a FileOpen event.
-    if (fileInWindow.isEmpty()) {
+    // Skip windows whose QML is not ready yet, otherwise PAGWindow::openFile() would silently
+    // drop the request.
+    if (fileInWindow.isEmpty() && win->getEngine() != nullptr) {
       window = win;
       break;
     }

--- a/viewer/src/rendering/PAGWindow.cpp
+++ b/viewer/src/rendering/PAGWindow.cpp
@@ -39,8 +39,9 @@ void PAGWindow::openFile(QString path) {
   }
   // Set filePath immediately so PAGViewer::openFile() can detect this window already
   // owns the file, preventing duplicate windows when the same file is opened rapidly.
-  // On successful load the ViewModel emits filePathChanged which calls updateFilePath()
-  // to keep filePath in sync; on failure it emits filePathChanged("") to clear it.
+  // On successful load the ViewModel emits filePathChanged with the real path, which
+  // updateFilePath() uses to mark the window as holding content; on failure it emits
+  // filePathChanged("") which clears both filePath and the content flag.
   filePath = path;
   Q_EMIT requestOpenFile(path);
   window->raise();
@@ -216,10 +217,19 @@ QString PAGWindow::getFilePath() {
 
 void PAGWindow::updateFilePath(const QString& path) {
   filePath = path;
+  contentLoaded = !path.isEmpty();
 }
 
 QQmlApplicationEngine* PAGWindow::getEngine() {
   return engine.get();
+}
+
+bool PAGWindow::isReady() const {
+  return window != nullptr;
+}
+
+bool PAGWindow::hasContent() const {
+  return contentLoaded;
 }
 
 }  // namespace pag

--- a/viewer/src/rendering/PAGWindow.h
+++ b/viewer/src/rendering/PAGWindow.h
@@ -51,6 +51,14 @@ class PAGWindow : public QObject {
   QQmlApplicationEngine* getEngine();
   bool isUseEnglish();
 
+  // Returns true once the QML window is created, i.e. openFile() will be accepted rather than
+  // silently dropped. This mirrors the early-return guard in openFile() (window == nullptr).
+  bool isReady() const;
+
+  // Returns true when the window currently holds a successfully loaded file. A window that was
+  // never loaded or whose last load failed reports false and may be reused for a new file.
+  bool hasContent() const;
+
   static QList<PAGWindow*> AllWindows;
 
  private:
@@ -59,6 +67,7 @@ class PAGWindow : public QObject {
   void updateFilePath(const QString& path);
 
   QString filePath = "";
+  bool contentLoaded = false;
   QQuickWindow* window = nullptr;
   ContentView* contentView = nullptr;
   std::unique_ptr<QTranslator> translator = nullptr;


### PR DESCRIPTION
### 背景
修复 PAGViewer 在 macOS 文件打开及窗口尺寸处理上的几个问题。

### 修改内容
1. **修复双击 PAGX 文件打开两个窗口**：macOS 双击文件时，文件路径会同时通过启动参数和 FileOpen 事件到达，导致创建两个窗口（一个空白、一个正常加载）。现允许空窗口被 PAGX 文件复用，由 QML 层自动切换 PAGView/PAGXView 视图组件。
2. **修复画布与文件宽高比不匹配导致的留白**：窗口高度计算遗漏了标题栏高度，导致画布被压缩、内容按适应模式渲染后左右留白。现窗口高度补齐标题栏与控制条高度，画布尺寸恰好匹配文件比例。
3. **打开/关闭数据面板时的窗口尺寸适配**：打开面板时窗口高度不低于 650（保证面板可用），画布宽度按文件宽高比重新计算，画布恰好铺满内容区、无留白；关闭面板时保持窗口高度，仅恢复宽度。
4. **健壮性与维护性改进**：
   - 空窗口复用增加 QML 就绪检查，避免请求被静默丢弃；
   - 提取公共尺寸计算函数，消除窗口高度计算重复；
   - 标题栏高度统一数据源，消除多文件硬编码耦合；
   - 性能面板不再挤压编辑区域，保证小窗口下编辑区可用。

### 验证
- `PAGViewer` 目标编译通过，无 lint 错误。
- 覆盖场景：macOS 双击打开 PAG/PAGX、默认加载、手动调整窗口、开关数据面板、全屏。