### PR TITLE
添加不可见兜底能力，确保组件完全不可见时停止播放，且预加载在屏幕外时不会播放。

### DIFF
--- a/ohos/libpag/src/main/ets/PAGImageViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewV2.ets
@@ -21,6 +21,7 @@ import { PAGImageViewController } from './PAGImageViewController'
 @ComponentV2
 export struct PAGImageViewV2 {
   @Require @Param controller!: PAGImageViewController;
+  @Param pagBackground: ResourceColor = Color.Transparent;
 
   build() {
     XComponent({
@@ -28,7 +29,19 @@ export struct PAGImageViewV2 {
       type: XComponentType.SURFACE,
       libraryname: "pag",
     })
-      .backgroundColor(Color.Transparent)
+      .backgroundColor(this.pagBackground)
+      .onVisibleAreaChange([0.0, 1.0], (isExpanding: boolean, currentRatio: number) => {
+        if (isExpanding && currentRatio >= 0.0) {
+          if (!this.controller.isPlaying()) {
+            this.controller.play();
+          }
+        }
+        if (!isExpanding && currentRatio <= 0.0) {
+          if (this.controller.isPlaying()) {
+            this.controller.pause();
+          }
+        }
+      })
   }
 
   onPageShow(): void {
@@ -37,6 +50,7 @@ export struct PAGImageViewV2 {
 
   aboutToAppear(): void {
     this.controller.attachToView(new WeakRef(this));
+    this.controller.pause();
   }
 
   aboutToDisappear(): void {

--- a/ohos/libpag/src/main/ets/PAGViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGViewV2.ets
@@ -21,6 +21,12 @@ import { PAGViewController } from './PAGViewController';
 @ComponentV2
 export struct PAGViewV2 {
   @Require @Param controller: PAGViewController;
+  @Param pagBackground: ResourceColor = Color.Transparent;
+
+  aboutToAppear(): void {
+    this.controller.attachToView(new WeakRef(this));
+    this.controller.pause();
+  }
 
   build() {
     XComponent({
@@ -28,7 +34,19 @@ export struct PAGViewV2 {
       type: XComponentType.SURFACE,
       libraryname: "pag",
     })
-      .backgroundColor(Color.Transparent)
+      .backgroundColor(this.pagBackground)
+      .onVisibleAreaChange([0.0, 1.0], (isExpanding: boolean, currentRatio: number) => {
+        if (isExpanding && currentRatio >= 0.0) {
+          if (!this.controller.isPlaying()) {
+            this.controller.play();
+          }
+        }
+        if (!isExpanding && currentRatio <= 0.0) {
+          if (this.controller.isPlaying()) {
+            this.controller.pause();
+          }
+        }
+      })
       .onLoad(() => {
         this.controller.update();
       })
@@ -36,10 +54,6 @@ export struct PAGViewV2 {
 
   onPageShow(): void {
     this.controller.update();
-  }
-
-  aboutToAppear(): void {
-    this.controller.attachToView(new WeakRef(this));
   }
 
   aboutToDisappear(): void {


### PR DESCRIPTION
PagView库目前在功耗的模型里扫出来发现，有非常多的空跑刷新问题，就是说组件并不在屏幕内，但是因为初始状态设置为播放或者组件划出屏幕之后依然没有停止导致。扫了下开源仓的代码发现，在安卓和ios端pagview都自带离屏停止类似的逻辑。建议在鸿蒙端对齐该功能，附件中提供了分析的案例，以及修复后的示例代码。