### PR TITLE
Fix off-screen visibility handling overriding caller paused animations on ohos

### DIFF
--- a/ohos/libpag/src/main/cpp/types/libpag/Index.d.ts
+++ b/ohos/libpag/src/main/cpp/types/libpag/Index.d.ts
@@ -376,6 +376,8 @@ export declare class JPAGView {
 
   setUseDiskCache(value: boolean);
 
+  setVisible(visible: boolean): void;
+
   release();
 }
 
@@ -505,6 +507,8 @@ export declare class JPAGImageView {
   currentImage(): image.PixelMap | null;
 
   update(): void;
+
+  setVisible(visible: boolean): void;
 
   release();
 }

--- a/ohos/libpag/src/main/ets/PAGImageView.ets
+++ b/ohos/libpag/src/main/ets/PAGImageView.ets
@@ -29,6 +29,9 @@ export struct PAGImageView {
       libraryname: "pag",
     })
       .backgroundColor(Color.Transparent)
+      .onVisibleAreaChange([0.0, 1.0], (isExpanding: boolean, currentRatio: number) => {
+        this.onVisibleAreaChanged(isExpanding, currentRatio);
+      })
   }
 
   onPageShow(): void {
@@ -41,5 +44,13 @@ export struct PAGImageView {
 
   aboutToDisappear(): void {
     this.controller.detachFromView();
+  }
+
+  private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
+    if (currentRatio <= 0.0) {
+      this.controller.onVisibilityChanged(false);
+    } else if (isExpanding) {
+      this.controller.onVisibilityChanged(true);
+    }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGImageView.ets
+++ b/ohos/libpag/src/main/ets/PAGImageView.ets
@@ -32,6 +32,9 @@ export struct PAGImageView {
       .onVisibleAreaChange([0.0, 1.0], (isExpanding: boolean, currentRatio: number) => {
         this.onVisibleAreaChanged(isExpanding, currentRatio);
       })
+      .onLoad(() => {
+        this.controller.update();
+      })
   }
 
   onPageShow(): void {
@@ -47,10 +50,13 @@ export struct PAGImageView {
   }
 
   private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
-    if (currentRatio <= 0.0) {
-      this.controller.onVisibilityChanged(false);
-    } else if (isExpanding) {
+    // Use currentRatio rather than isExpanding as the visibility source: fast scrolling may merge
+    // threshold-crossing callbacks and drop the expanding flag, and the native setVisible is
+    // idempotent. Note this only reflects visible area, not alpha/hidden states within the layout tree.
+    if (currentRatio > 0.0) {
       this.controller.onVisibilityChanged(true);
+    } else {
+      this.controller.onVisibilityChanged(false);
     }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGImageViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewController.ets
@@ -224,27 +224,23 @@ export class PAGImageViewController {
   }
 
   /**
-   * Pauses the animation without changing the play intention recorded by play() and pause().
-   * It is used by the visible area change handling to stop off-screen animations.
+   * Notifies the controller whether the view is currently visible. When it becomes invisible, a
+   * playing animation is paused to save power; when it becomes visible again, playback is resumed
+   * only if the caller has requested playing via play(). The play intention set by play()/pause()
+   * is preserved across visibility changes.
    */
-  pauseForInvisible() {
-    this.jImageView.pause();
-  }
-
-  /**
-   * Plays the animation without changing the play intention recorded by play() and pause().
-   * It is used by the visible area change handling to resume animations paused for invisibility.
-   */
-  playForVisible() {
-    this.jImageView.play();
-  }
-
-  /**
-   * Indicates whether the caller intends to play the animation, which is not affected by the
-   * temporary pause triggered by the visible area change handling.
-   */
-  isUserWantsPlaying(): boolean {
-    return this.userWantsPlaying;
+  setVisible(visible: boolean) {
+    if (!visible) {
+      if (this.jImageView.isPlaying() && !this.pausedForInvisible) {
+        this.pausedForInvisible = true;
+        this.jImageView.pause();
+      }
+    } else if (this.pausedForInvisible) {
+      this.pausedForInvisible = false;
+      if (this.userWantsPlaying) {
+        this.jImageView.play();
+      }
+    }
   }
 
   /**
@@ -366,6 +362,7 @@ export class PAGImageViewController {
   private view: WeakRef<ESObject> | null = null;
   private jImageView: JPAGImageView = new JPAGImageView();
   private userWantsPlaying: boolean = false;
+  private pausedForInvisible: boolean = false;
   readonly onAnimatorStateChange = (state: number): void => {
     switch (state) {
       case PAGAnimatorState.Start:

--- a/ohos/libpag/src/main/ets/PAGImageViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewController.ets
@@ -221,6 +221,10 @@ export class PAGImageViewController {
     this.jImageView.pause();
   }
 
+  /**
+   * Driven by the view's visible-area changes to stop rendering while off-screen and resume it when
+   * on-screen, saving power without altering the caller's play/pause intention.
+   */
   onVisibilityChanged(visible: boolean) {
     this.jImageView.setVisible(visible);
   }
@@ -327,6 +331,9 @@ export class PAGImageViewController {
   }
 
   detachFromView() {
+    // Reset the visibility state so a reused controller does not carry a stale visible flag into the
+    // next view, which would otherwise skip resuming playback on the new view.
+    this.onVisibilityChanged(false);
     this.view = null;
   }
 

--- a/ohos/libpag/src/main/ets/PAGImageViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewController.ets
@@ -203,10 +203,6 @@ export class PAGImageViewController {
    * the beginning.
    */
   play() {
-    this.userWantsPlaying = true;
-    // A caller-initiated play overrides the off-screen pause latch, so the visibility
-    // handling can pause the animation again if it later goes off-screen.
-    this.pausedForInvisible = false;
     this.jImageView.play();
   }
 
@@ -222,28 +218,11 @@ export class PAGImageViewController {
    * animation from the last paused position.
    */
   pause() {
-    this.userWantsPlaying = false;
     this.jImageView.pause();
   }
 
-  /**
-   * Notifies the controller whether the view is currently visible. When it becomes invisible, a
-   * playing animation is paused to save power; when it becomes visible again, playback is resumed
-   * only if the caller has requested playing via play(). The play intention set by play()/pause()
-   * is preserved across visibility changes.
-   */
-  setVisible(visible: boolean) {
-    if (!visible) {
-      if (this.jImageView.isPlaying() && !this.pausedForInvisible) {
-        this.pausedForInvisible = true;
-        this.jImageView.pause();
-      }
-    } else if (this.pausedForInvisible) {
-      this.pausedForInvisible = false;
-      if (this.userWantsPlaying) {
-        this.jImageView.play();
-      }
-    }
+  onVisibilityChanged(visible: boolean) {
+    this.jImageView.setVisible(visible);
   }
 
   /**
@@ -364,8 +343,6 @@ export class PAGImageViewController {
   private listeners: Array<WeakRef<PAGImageViewListener>> = [];
   private view: WeakRef<ESObject> | null = null;
   private jImageView: JPAGImageView = new JPAGImageView();
-  private userWantsPlaying: boolean = false;
-  private pausedForInvisible: boolean = false;
   readonly onAnimatorStateChange = (state: number): void => {
     switch (state) {
       case PAGAnimatorState.Start:

--- a/ohos/libpag/src/main/ets/PAGImageViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewController.ets
@@ -204,6 +204,9 @@ export class PAGImageViewController {
    */
   play() {
     this.userWantsPlaying = true;
+    // A caller-initiated play overrides the off-screen pause latch, so the visibility
+    // handling can pause the animation again if it later goes off-screen.
+    this.pausedForInvisible = false;
     this.jImageView.play();
   }
 

--- a/ohos/libpag/src/main/ets/PAGImageViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewController.ets
@@ -203,6 +203,7 @@ export class PAGImageViewController {
    * the beginning.
    */
   play() {
+    this.userWantsPlaying = true;
     this.jImageView.play();
   }
 
@@ -218,7 +219,32 @@ export class PAGImageViewController {
    * animation from the last paused position.
    */
   pause() {
+    this.userWantsPlaying = false;
     this.jImageView.pause();
+  }
+
+  /**
+   * Pauses the animation without changing the play intention recorded by play() and pause().
+   * It is used by the visible area change handling to stop off-screen animations.
+   */
+  pauseForInvisible() {
+    this.jImageView.pause();
+  }
+
+  /**
+   * Plays the animation without changing the play intention recorded by play() and pause().
+   * It is used by the visible area change handling to resume animations paused for invisibility.
+   */
+  playForVisible() {
+    this.jImageView.play();
+  }
+
+  /**
+   * Indicates whether the caller intends to play the animation, which is not affected by the
+   * temporary pause triggered by the visible area change handling.
+   */
+  isUserWantsPlaying(): boolean {
+    return this.userWantsPlaying;
   }
 
   /**
@@ -339,6 +365,7 @@ export class PAGImageViewController {
   private listeners: Array<WeakRef<PAGImageViewListener>> = [];
   private view: WeakRef<ESObject> | null = null;
   private jImageView: JPAGImageView = new JPAGImageView();
+  private userWantsPlaying: boolean = false;
   readonly onAnimatorStateChange = (state: number): void => {
     switch (state) {
       case PAGAnimatorState.Start:

--- a/ohos/libpag/src/main/ets/PAGImageViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewV2.ets
@@ -21,7 +21,7 @@ import { PAGImageViewController } from './PAGImageViewController'
 @ComponentV2
 export struct PAGImageViewV2 {
   @Require @Param controller!: PAGImageViewController;
-  // 标记动画是否因组件不可见而被组件暂停，重新可见时只恢复组件自己暂停的播放。
+  // Whether playback was paused by this component because it went off-screen; only these pauses are resumed when it becomes visible again.
   private pausedForInvisible: boolean = false;
 
   build() {

--- a/ohos/libpag/src/main/ets/PAGImageViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewV2.ets
@@ -48,9 +48,9 @@ export struct PAGImageViewV2 {
 
   private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
     if (currentRatio <= 0.0) {
-      this.controller.setVisible(false);
+      this.controller.onVisibilityChanged(false);
     } else if (isExpanding) {
-      this.controller.setVisible(true);
+      this.controller.onVisibilityChanged(true);
     }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGImageViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewV2.ets
@@ -21,6 +21,8 @@ import { PAGImageViewController } from './PAGImageViewController'
 @ComponentV2
 export struct PAGImageViewV2 {
   @Require @Param controller!: PAGImageViewController;
+  // 标记动画是否因组件不可见而被组件暂停，重新可见时只恢复组件自己暂停的播放。
+  private pausedForInvisible: boolean = false;
 
   build() {
     XComponent({
@@ -29,6 +31,7 @@ export struct PAGImageViewV2 {
       libraryname: "pag",
     })
       .backgroundColor(Color.Transparent)
+      .onVisibleAreaChange([0.0, 1.0], this.onVisibleAreaChanged)
   }
 
   onPageShow(): void {
@@ -41,5 +44,21 @@ export struct PAGImageViewV2 {
 
   aboutToDisappear(): void {
     this.controller.detachFromView();
+  }
+
+  private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
+    if (currentRatio <= 0.0) {
+      if (this.controller.isPlaying() && !this.pausedForInvisible) {
+        this.pausedForInvisible = true;
+        this.controller.pauseForInvisible();
+      }
+    } else if (isExpanding) {
+      if (this.pausedForInvisible) {
+        this.pausedForInvisible = false;
+        if (this.controller.isUserWantsPlaying()) {
+          this.controller.playForVisible();
+        }
+      }
+    }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGImageViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewV2.ets
@@ -31,7 +31,9 @@ export struct PAGImageViewV2 {
       libraryname: "pag",
     })
       .backgroundColor(Color.Transparent)
-      .onVisibleAreaChange([0.0, 1.0], this.onVisibleAreaChanged)
+      .onVisibleAreaChange([0.0, 1.0], (isExpanding: boolean, currentRatio: number) => {
+        this.onVisibleAreaChanged(isExpanding, currentRatio);
+      })
   }
 
   onPageShow(): void {

--- a/ohos/libpag/src/main/ets/PAGImageViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewV2.ets
@@ -32,6 +32,9 @@ export struct PAGImageViewV2 {
       .onVisibleAreaChange([0.0, 1.0], (isExpanding: boolean, currentRatio: number) => {
         this.onVisibleAreaChanged(isExpanding, currentRatio);
       })
+      .onLoad(() => {
+        this.controller.update();
+      })
   }
 
   onPageShow(): void {
@@ -47,10 +50,13 @@ export struct PAGImageViewV2 {
   }
 
   private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
-    if (currentRatio <= 0.0) {
-      this.controller.onVisibilityChanged(false);
-    } else if (isExpanding) {
+    // Use currentRatio rather than isExpanding as the visibility source: fast scrolling may merge
+    // threshold-crossing callbacks and drop the expanding flag, and the native setVisible is
+    // idempotent. Note this only reflects visible area, not alpha/hidden states within the layout tree.
+    if (currentRatio > 0.0) {
       this.controller.onVisibilityChanged(true);
+    } else {
+      this.controller.onVisibilityChanged(false);
     }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGImageViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGImageViewV2.ets
@@ -21,8 +21,6 @@ import { PAGImageViewController } from './PAGImageViewController'
 @ComponentV2
 export struct PAGImageViewV2 {
   @Require @Param controller!: PAGImageViewController;
-  // Whether playback was paused by this component because it went off-screen; only these pauses are resumed when it becomes visible again.
-  private pausedForInvisible: boolean = false;
 
   build() {
     XComponent({
@@ -50,17 +48,9 @@ export struct PAGImageViewV2 {
 
   private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
     if (currentRatio <= 0.0) {
-      if (this.controller.isPlaying() && !this.pausedForInvisible) {
-        this.pausedForInvisible = true;
-        this.controller.pauseForInvisible();
-      }
+      this.controller.setVisible(false);
     } else if (isExpanding) {
-      if (this.pausedForInvisible) {
-        this.pausedForInvisible = false;
-        if (this.controller.isUserWantsPlaying()) {
-          this.controller.playForVisible();
-        }
-      }
+      this.controller.setVisible(true);
     }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGView.ets
+++ b/ohos/libpag/src/main/ets/PAGView.ets
@@ -50,10 +50,13 @@ export struct PAGView {
   }
 
   private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
-    if (currentRatio <= 0.0) {
-      this.controller.onVisibilityChanged(false);
-    } else if (isExpanding) {
+    // Use currentRatio rather than isExpanding as the visibility source: fast scrolling may merge
+    // threshold-crossing callbacks and drop the expanding flag, and the native setVisible is
+    // idempotent. Note this only reflects visible area, not alpha/hidden states within the layout tree.
+    if (currentRatio > 0.0) {
       this.controller.onVisibilityChanged(true);
+    } else {
+      this.controller.onVisibilityChanged(false);
     }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGView.ets
+++ b/ohos/libpag/src/main/ets/PAGView.ets
@@ -29,6 +29,9 @@ export struct PAGView {
       libraryname: "pag",
     })
       .backgroundColor(Color.Transparent)
+      .onVisibleAreaChange([0.0, 1.0], (isExpanding: boolean, currentRatio: number) => {
+        this.onVisibleAreaChanged(isExpanding, currentRatio);
+      })
       .onLoad(() => {
         this.controller.update();
       })
@@ -44,5 +47,13 @@ export struct PAGView {
 
   aboutToDisappear(): void {
     this.controller.detachFromView();
+  }
+
+  private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
+    if (currentRatio <= 0.0) {
+      this.controller.onVisibilityChanged(false);
+    } else if (isExpanding) {
+      this.controller.onVisibilityChanged(true);
+    }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGViewController.ets
@@ -120,7 +120,7 @@ export class PAGViewController {
    * the beginning.
    */
   play() {
-    this.jView?.play();
+    this.jView.play();
   }
 
   /**
@@ -303,7 +303,7 @@ export class PAGViewController {
    * Sets the progress of play position, the valid value is from 0.0 to 1.0.
    */
   setProgress(progress: number) {
-    this.jView?.setProgress(progress);
+    this.jView.setProgress(progress);
   }
 
   /**

--- a/ohos/libpag/src/main/ets/PAGViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGViewController.ets
@@ -134,27 +134,23 @@ export class PAGViewController {
   }
 
   /**
-   * Pauses the animation without changing the play intention recorded by play() and pause().
-   * It is used by the visible area change handling to stop off-screen animations.
+   * Notifies the controller whether the view is currently visible. When it becomes invisible, a
+   * playing animation is paused to save power; when it becomes visible again, playback is resumed
+   * only if the caller has requested playing via play(). The play intention set by play()/pause()
+   * is preserved across visibility changes.
    */
-  pauseForInvisible() {
-    this.jView.pause();
-  }
-
-  /**
-   * Plays the animation without changing the play intention recorded by play() and pause().
-   * It is used by the visible area change handling to resume animations paused for invisibility.
-   */
-  playForVisible() {
-    this.jView?.play();
-  }
-
-  /**
-   * Indicates whether the caller intends to play the animation, which is not affected by the
-   * temporary pause triggered by the visible area change handling.
-   */
-  isUserWantsPlaying(): boolean {
-    return this.userWantsPlaying;
+  setVisible(visible: boolean) {
+    if (!visible) {
+      if (this.jView.isPlaying() && !this.pausedForInvisible) {
+        this.pausedForInvisible = true;
+        this.jView.pause();
+      }
+    } else if (this.pausedForInvisible) {
+      this.pausedForInvisible = false;
+      if (this.userWantsPlaying) {
+        this.jView?.play();
+      }
+    }
   }
 
   /**
@@ -485,4 +481,5 @@ export class PAGViewController {
   private jView: JPAGView = new JPAGView();
   private view: WeakRef<ESObject> | null = null;
   private userWantsPlaying: boolean = false;
+  private pausedForInvisible: boolean = false;
 }

--- a/ohos/libpag/src/main/ets/PAGViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGViewController.ets
@@ -120,6 +120,7 @@ export class PAGViewController {
    * the beginning.
    */
   play() {
+    this.userWantsPlaying = true;
     this.jView?.play();
   }
 
@@ -128,7 +129,32 @@ export class PAGViewController {
    * animation from the last paused position.
    */
   pause() {
+    this.userWantsPlaying = false;
     this.jView.pause();
+  }
+
+  /**
+   * Pauses the animation without changing the play intention recorded by play() and pause().
+   * It is used by the visible area change handling to stop off-screen animations.
+   */
+  pauseForInvisible() {
+    this.jView.pause();
+  }
+
+  /**
+   * Plays the animation without changing the play intention recorded by play() and pause().
+   * It is used by the visible area change handling to resume animations paused for invisibility.
+   */
+  playForVisible() {
+    this.jView?.play();
+  }
+
+  /**
+   * Indicates whether the caller intends to play the animation, which is not affected by the
+   * temporary pause triggered by the visible area change handling.
+   */
+  isUserWantsPlaying(): boolean {
+    return this.userWantsPlaying;
   }
 
   /**
@@ -458,4 +484,5 @@ export class PAGViewController {
   private listeners: Array<WeakRef<PAGViewListener>> = [];
   private jView: JPAGView = new JPAGView();
   private view: WeakRef<ESObject> | null = null;
+  private userWantsPlaying: boolean = false;
 }

--- a/ohos/libpag/src/main/ets/PAGViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGViewController.ets
@@ -120,10 +120,6 @@ export class PAGViewController {
    * the beginning.
    */
   play() {
-    this.userWantsPlaying = true;
-    // A caller-initiated play overrides the off-screen pause latch, so the visibility
-    // handling can pause the animation again if it later goes off-screen.
-    this.pausedForInvisible = false;
     this.jView?.play();
   }
 
@@ -132,28 +128,11 @@ export class PAGViewController {
    * animation from the last paused position.
    */
   pause() {
-    this.userWantsPlaying = false;
     this.jView.pause();
   }
 
-  /**
-   * Notifies the controller whether the view is currently visible. When it becomes invisible, a
-   * playing animation is paused to save power; when it becomes visible again, playback is resumed
-   * only if the caller has requested playing via play(). The play intention set by play()/pause()
-   * is preserved across visibility changes.
-   */
-  setVisible(visible: boolean) {
-    if (!visible) {
-      if (this.jView.isPlaying() && !this.pausedForInvisible) {
-        this.pausedForInvisible = true;
-        this.jView.pause();
-      }
-    } else if (this.pausedForInvisible) {
-      this.pausedForInvisible = false;
-      if (this.userWantsPlaying) {
-        this.jView?.play();
-      }
-    }
+  onVisibilityChanged(visible: boolean) {
+    this.jView.setVisible(visible);
   }
 
   /**
@@ -483,6 +462,4 @@ export class PAGViewController {
   private listeners: Array<WeakRef<PAGViewListener>> = [];
   private jView: JPAGView = new JPAGView();
   private view: WeakRef<ESObject> | null = null;
-  private userWantsPlaying: boolean = false;
-  private pausedForInvisible: boolean = false;
 }

--- a/ohos/libpag/src/main/ets/PAGViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGViewController.ets
@@ -121,6 +121,9 @@ export class PAGViewController {
    */
   play() {
     this.userWantsPlaying = true;
+    // A caller-initiated play overrides the off-screen pause latch, so the visibility
+    // handling can pause the animation again if it later goes off-screen.
+    this.pausedForInvisible = false;
     this.jView?.play();
   }
 

--- a/ohos/libpag/src/main/ets/PAGViewController.ets
+++ b/ohos/libpag/src/main/ets/PAGViewController.ets
@@ -131,6 +131,10 @@ export class PAGViewController {
     this.jView.pause();
   }
 
+  /**
+   * Driven by the view's visible-area changes to stop rendering while off-screen and resume it when
+   * on-screen, saving power without altering the caller's play/pause intention.
+   */
   onVisibilityChanged(visible: boolean) {
     this.jView.setVisible(visible);
   }
@@ -376,6 +380,9 @@ export class PAGViewController {
   }
 
   detachFromView() {
+    // Reset the visibility state so a reused controller does not carry a stale visible flag into the
+    // next view, which would otherwise skip resuming playback on the new view.
+    this.onVisibilityChanged(false);
     this.view = null;
   }
 

--- a/ohos/libpag/src/main/ets/PAGViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGViewV2.ets
@@ -31,7 +31,9 @@ export struct PAGViewV2 {
       libraryname: "pag",
     })
       .backgroundColor(Color.Transparent)
-      .onVisibleAreaChange([0.0, 1.0], this.onVisibleAreaChanged)
+      .onVisibleAreaChange([0.0, 1.0], (isExpanding: boolean, currentRatio: number) => {
+        this.onVisibleAreaChanged(isExpanding, currentRatio);
+      })
       .onLoad(() => {
         this.controller.update();
       })

--- a/ohos/libpag/src/main/ets/PAGViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGViewV2.ets
@@ -50,10 +50,13 @@ export struct PAGViewV2 {
   }
 
   private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
-    if (currentRatio <= 0.0) {
-      this.controller.onVisibilityChanged(false);
-    } else if (isExpanding) {
+    // Use currentRatio rather than isExpanding as the visibility source: fast scrolling may merge
+    // threshold-crossing callbacks and drop the expanding flag, and the native setVisible is
+    // idempotent. Note this only reflects visible area, not alpha/hidden states within the layout tree.
+    if (currentRatio > 0.0) {
       this.controller.onVisibilityChanged(true);
+    } else {
+      this.controller.onVisibilityChanged(false);
     }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGViewV2.ets
@@ -21,6 +21,8 @@ import { PAGViewController } from './PAGViewController';
 @ComponentV2
 export struct PAGViewV2 {
   @Require @Param controller: PAGViewController;
+  // 标记动画是否因组件不可见而被组件暂停，重新可见时只恢复组件自己暂停的播放。
+  private pausedForInvisible: boolean = false;
 
   build() {
     XComponent({
@@ -29,6 +31,7 @@ export struct PAGViewV2 {
       libraryname: "pag",
     })
       .backgroundColor(Color.Transparent)
+      .onVisibleAreaChange([0.0, 1.0], this.onVisibleAreaChanged)
       .onLoad(() => {
         this.controller.update();
       })
@@ -44,5 +47,21 @@ export struct PAGViewV2 {
 
   aboutToDisappear(): void {
     this.controller.detachFromView();
+  }
+
+  private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
+    if (currentRatio <= 0.0) {
+      if (this.controller.isPlaying() && !this.pausedForInvisible) {
+        this.pausedForInvisible = true;
+        this.controller.pauseForInvisible();
+      }
+    } else if (isExpanding) {
+      if (this.pausedForInvisible) {
+        this.pausedForInvisible = false;
+        if (this.controller.isUserWantsPlaying()) {
+          this.controller.playForVisible();
+        }
+      }
+    }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGViewV2.ets
@@ -21,7 +21,7 @@ import { PAGViewController } from './PAGViewController';
 @ComponentV2
 export struct PAGViewV2 {
   @Require @Param controller: PAGViewController;
-  // 标记动画是否因组件不可见而被组件暂停，重新可见时只恢复组件自己暂停的播放。
+  // Whether playback was paused by this component because it went off-screen; only these pauses are resumed when it becomes visible again.
   private pausedForInvisible: boolean = false;
 
   build() {

--- a/ohos/libpag/src/main/ets/PAGViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGViewV2.ets
@@ -51,9 +51,9 @@ export struct PAGViewV2 {
 
   private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
     if (currentRatio <= 0.0) {
-      this.controller.setVisible(false);
+      this.controller.onVisibilityChanged(false);
     } else if (isExpanding) {
-      this.controller.setVisible(true);
+      this.controller.onVisibilityChanged(true);
     }
   }
 }

--- a/ohos/libpag/src/main/ets/PAGViewV2.ets
+++ b/ohos/libpag/src/main/ets/PAGViewV2.ets
@@ -21,8 +21,6 @@ import { PAGViewController } from './PAGViewController';
 @ComponentV2
 export struct PAGViewV2 {
   @Require @Param controller: PAGViewController;
-  // Whether playback was paused by this component because it went off-screen; only these pauses are resumed when it becomes visible again.
-  private pausedForInvisible: boolean = false;
 
   build() {
     XComponent({
@@ -53,17 +51,9 @@ export struct PAGViewV2 {
 
   private onVisibleAreaChanged(isExpanding: boolean, currentRatio: number): void {
     if (currentRatio <= 0.0) {
-      if (this.controller.isPlaying() && !this.pausedForInvisible) {
-        this.pausedForInvisible = true;
-        this.controller.pauseForInvisible();
-      }
+      this.controller.setVisible(false);
     } else if (isExpanding) {
-      if (this.pausedForInvisible) {
-        this.pausedForInvisible = false;
-        if (this.controller.isUserWantsPlaying()) {
-          this.controller.playForVisible();
-        }
-      }
+      this.controller.setVisible(true);
     }
   }
 }

--- a/src/platform/ohos/JPAGImageView.cpp
+++ b/src/platform/ohos/JPAGImageView.cpp
@@ -690,34 +690,46 @@ Frame JPAGImageView::currentFrame() {
 }
 
 void JPAGImageView::setComposition(std::shared_ptr<PAGComposition> composition, float frameRate) {
-  std::lock_guard lock_guard(locker);
-  if (_animator == nullptr) {
-    return;
+  std::shared_ptr<PAGAnimator> animator = nullptr;
+  bool visible = false;
+  {
+    std::lock_guard lock_guard(locker);
+    animator = _animator;
+    if (animator == nullptr) {
+      return;
+    }
+    _composition = composition;
+    _frameRate = frameRate;
+    invalidDecoder();
+    visible = isVisible;
   }
-  if (composition != nullptr && isVisible) {
-    _animator->setDuration(composition->duration());
-  } else {
-    _animator->setDuration(0);
+  int64_t duration = 0;
+  if (composition != nullptr && visible) {
+    duration = composition->duration();
   }
-  _composition = composition;
-  _frameRate = frameRate;
-  invalidDecoder();
+  animator->setDuration(duration);
 }
 
 void JPAGImageView::setVisible(bool visible) {
-  std::lock_guard lock_guard(locker);
-  if (isVisible == visible) {
+  std::shared_ptr<PAGAnimator> animator = nullptr;
+  std::shared_ptr<PAGComposition> composition = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    if (isVisible == visible) {
+      return;
+    }
+    isVisible = visible;
+    animator = _animator;
+    composition = _composition;
+  }
+  if (animator == nullptr) {
     return;
   }
-  isVisible = visible;
-  if (_animator == nullptr) {
-    return;
+  int64_t duration = 0;
+  if (visible && composition != nullptr) {
+    duration = composition->duration();
   }
-  if (isVisible) {
-    _animator->setDuration(_composition != nullptr ? _composition->duration() : 0);
-  } else {
-    _animator->setDuration(0);
-  }
+  animator->setDuration(visible ? duration : 0);
 }
 
 void JPAGImageView::setScaleMode(PAGScaleMode scaleMode) {

--- a/src/platform/ohos/JPAGImageView.cpp
+++ b/src/platform/ohos/JPAGImageView.cpp
@@ -444,6 +444,24 @@ static napi_value SetCurrentFrame(napi_env env, napi_callback_info info) {
   return nullptr;
 }
 
+static napi_value SetVisible(napi_env env, napi_callback_info info) {
+  napi_value jsView = nullptr;
+  size_t argc = 1;
+  napi_value args[1] = {0};
+  napi_get_cb_info(env, info, &argc, args, &jsView, nullptr);
+  if (argc == 0) {
+    return nullptr;
+  }
+  bool visible = false;
+  napi_get_value_bool(env, args[0], &visible);
+  JPAGImageView* view = nullptr;
+  napi_unwrap(env, jsView, reinterpret_cast<void**>(&view));
+  if (view != nullptr) {
+    view->setVisible(visible);
+  }
+  return nullptr;
+}
+
 static napi_value CurrentImage(napi_env env, napi_callback_info info) {
   napi_value jsView = nullptr;
   size_t argc = 0;
@@ -532,6 +550,7 @@ bool JPAGImageView::Init(napi_env env, napi_value exports) {
       PAG_DEFAULT_METHOD_ENTRY(renderScale, RenderScale),
       PAG_DEFAULT_METHOD_ENTRY(currentFrame, CurrentFrame),
       PAG_DEFAULT_METHOD_ENTRY(setCurrentFrame, SetCurrentFrame),
+      PAG_DEFAULT_METHOD_ENTRY(setVisible, SetVisible),
       PAG_DEFAULT_METHOD_ENTRY(numFrame, NumFrame),
       PAG_DEFAULT_METHOD_ENTRY(setCurrentFrame, SetCurrentFrame),
       PAG_DEFAULT_METHOD_ENTRY(currentImage, CurrentImage),
@@ -675,7 +694,7 @@ void JPAGImageView::setComposition(std::shared_ptr<PAGComposition> composition, 
   if (_animator == nullptr) {
     return;
   }
-  if (composition != nullptr) {
+  if (composition != nullptr && isVisible) {
     _animator->setDuration(composition->duration());
   } else {
     _animator->setDuration(0);
@@ -683,6 +702,22 @@ void JPAGImageView::setComposition(std::shared_ptr<PAGComposition> composition, 
   _composition = composition;
   _frameRate = frameRate;
   invalidDecoder();
+}
+
+void JPAGImageView::setVisible(bool visible) {
+  std::lock_guard lock_guard(locker);
+  if (isVisible == visible) {
+    return;
+  }
+  isVisible = visible;
+  if (_animator == nullptr) {
+    return;
+  }
+  if (isVisible) {
+    _animator->setDuration(_composition != nullptr ? _composition->duration() : 0);
+  } else {
+    _animator->setDuration(0);
+  }
 }
 
 void JPAGImageView::setScaleMode(PAGScaleMode scaleMode) {

--- a/src/platform/ohos/JPAGImageView.cpp
+++ b/src/platform/ohos/JPAGImageView.cpp
@@ -708,6 +708,9 @@ void JPAGImageView::setComposition(std::shared_ptr<PAGComposition> composition, 
     duration = composition->duration();
   }
   animator->setDuration(duration);
+  if (visible) {
+    animator->update();
+  }
 }
 
 void JPAGImageView::setVisible(bool visible) {
@@ -730,6 +733,9 @@ void JPAGImageView::setVisible(bool visible) {
     duration = composition->duration();
   }
   animator->setDuration(visible ? duration : 0);
+  if (visible) {
+    animator->update();
+  }
 }
 
 void JPAGImageView::setScaleMode(PAGScaleMode scaleMode) {
@@ -940,6 +946,7 @@ void JPAGImageView::release() {
     _animator = nullptr;
   }
 
+  isVisible = false;
   invalidDecoder();
 }
 

--- a/src/platform/ohos/JPAGImageView.cpp
+++ b/src/platform/ohos/JPAGImageView.cpp
@@ -615,6 +615,7 @@ void JPAGImageView::onAnimationUpdate(PAGAnimator* animator) {
 }
 
 void JPAGImageView::onSurfaceCreated(NativeWindow* window) {
+  std::shared_ptr<PAGAnimator> animator = nullptr;
   {
     std::lock_guard lock_guard(locker);
     if (_animator == nullptr) {
@@ -623,13 +624,12 @@ void JPAGImageView::onSurfaceCreated(NativeWindow* window) {
     _window = window;
     targetWindow = tgfx::EGLWindow::MakeFrom(reinterpret_cast<EGLNativeWindowType>(_window));
     invalidSize();
+    animator = _animator;
   }
   // animator->update() can synchronously flow back into onAnimationUpdate,
   // which also acquires `locker`. Call it outside the critical section to
   // avoid re-entering the same non-recursive mutex on the caller thread.
-  if (_animator) {
-    _animator->update();
-  }
+  animator->update();
 }
 
 void JPAGImageView::onSurfaceSizeChanged() {

--- a/src/platform/ohos/JPAGImageView.h
+++ b/src/platform/ohos/JPAGImageView.h
@@ -69,6 +69,8 @@ class JPAGImageView : public PAGAnimator::Listener, public XComponentListener {
 
   void setComposition(std::shared_ptr<PAGComposition> composition, float frameRate);
 
+  void setVisible(bool visible);
+
   void setScaleMode(PAGScaleMode scaleMode);
 
   PAGScaleMode scaleMode();
@@ -125,6 +127,7 @@ class JPAGImageView : public PAGAnimator::Listener, public XComponentListener {
   PAGScaleMode _scaleMode = PAGScaleMode::LetterBox;
   tgfx::Matrix _matrix = tgfx::Matrix::I();
   bool _cacheAllFramesInMemory = false;
+  bool isVisible = false;
   std::shared_ptr<PAGComposition> _composition = nullptr;
   std::shared_ptr<PAGAnimator> _animator = nullptr;
   std::shared_ptr<PAGDecoder> _decoder = nullptr;

--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -966,29 +966,34 @@ void JPAGView::setComposition(std::shared_ptr<PAGComposition> composition) {
   }
   player->setComposition(composition);
   animator->setProgress(player->getProgress());
-  std::lock_guard lock_guard(locker);
-  if (composition != nullptr && isVisible) {
-    animator->setDuration(composition->duration());
-  } else {
-    animator->setDuration(0);
+  bool visible = false;
+  {
+    std::lock_guard lock_guard(locker);
+    visible = isVisible;
   }
+  int64_t duration = 0;
+  if (composition != nullptr && visible) {
+    duration = composition->duration();
+  }
+  animator->setDuration(duration);
 }
 
 void JPAGView::setVisible(bool visible) {
   auto player = getPlayer();
   auto animator = getAnimator();
-  std::lock_guard lock_guard(locker);
-  if (isVisible == visible) {
-    return;
+  {
+    std::lock_guard lock_guard(locker);
+    if (isVisible == visible) {
+      return;
+    }
+    isVisible = visible;
   }
-  isVisible = visible;
-  if (animator == nullptr) {
-    return;
+  int64_t duration = 0;
+  if (visible && player != nullptr) {
+    duration = player->duration();
   }
-  if (isVisible && player != nullptr) {
-    animator->setDuration(player->duration());
-  } else {
-    animator->setDuration(0);
+  if (animator != nullptr) {
+    animator->setDuration(visible ? duration : 0);
   }
 }
 

--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -946,6 +946,7 @@ void JPAGView::release() {
     player->setSurface(nullptr);
     player = nullptr;
   }
+  isVisible = false;
 }
 
 std::shared_ptr<PAGAnimator> JPAGView::getAnimator() {
@@ -959,41 +960,45 @@ std::shared_ptr<PAGPlayer> JPAGView::getPlayer() {
 }
 
 void JPAGView::setComposition(std::shared_ptr<PAGComposition> composition) {
-  auto player = getPlayer();
-  auto animator = getAnimator();
+  std::shared_ptr<PAGPlayer> player = nullptr;
+  std::shared_ptr<PAGAnimator> animator = nullptr;
+  bool visible = false;
+  {
+    std::lock_guard lock_guard(locker);
+    player = this->player;
+    animator = this->animator;
+    visible = isVisible;
+  }
   if (player == nullptr || animator == nullptr) {
     return;
   }
   player->setComposition(composition);
   animator->setProgress(player->getProgress());
-  bool visible = false;
-  {
-    std::lock_guard lock_guard(locker);
-    visible = isVisible;
-  }
-  int64_t duration = 0;
-  if (composition != nullptr && visible) {
-    duration = composition->duration();
-  }
+  int64_t duration = (composition != nullptr && visible) ? composition->duration() : 0;
   animator->setDuration(duration);
+  if (visible) {
+    animator->update();
+  }
 }
 
 void JPAGView::setVisible(bool visible) {
-  auto player = getPlayer();
-  auto animator = getAnimator();
+  std::shared_ptr<PAGPlayer> player = nullptr;
+  std::shared_ptr<PAGAnimator> animator = nullptr;
   {
     std::lock_guard lock_guard(locker);
     if (isVisible == visible) {
       return;
     }
     isVisible = visible;
+    player = this->player;
+    animator = this->animator;
   }
-  int64_t duration = 0;
-  if (visible && player != nullptr) {
-    duration = player->duration();
+  if (animator == nullptr) {
+    return;
   }
-  if (animator != nullptr) {
-    animator->setDuration(visible ? duration : 0);
+  animator->setDuration(visible && player != nullptr ? player->duration() : 0);
+  if (visible) {
+    animator->update();
   }
 }
 

--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -123,20 +123,12 @@ static napi_value SetComposition(napi_env env, napi_callback_info info) {
   JPAGView* view = nullptr;
   napi_unwrap(env, jsView, reinterpret_cast<void**>(&view));
   if (view != nullptr) {
-    auto player = view->getPlayer();
-    auto animator = view->getAnimator();
-    if (player == nullptr || animator == nullptr) {
-      return nullptr;
-    }
     if (layer != nullptr) {
       if (layer->layerType() == LayerType::PreCompose) {
-        player->setComposition(std::static_pointer_cast<PAGComposition>(layer));
-        animator->setProgress(player->getProgress());
-        animator->setDuration(layer->duration());
+        view->setComposition(std::static_pointer_cast<PAGComposition>(layer));
       }
     } else {
-      player->setComposition(nullptr);
-      animator->setDuration(0);
+      view->setComposition(nullptr);
     }
   }
   return nullptr;
@@ -763,6 +755,24 @@ static napi_value Release(napi_env env, napi_callback_info info) {
   return nullptr;
 }
 
+static napi_value SetVisible(napi_env env, napi_callback_info info) {
+  napi_value jsView = nullptr;
+  size_t argc = 1;
+  napi_value args[1] = {0};
+  napi_get_cb_info(env, info, &argc, args, &jsView, nullptr);
+  if (argc == 0) {
+    return nullptr;
+  }
+  bool visible = false;
+  napi_get_value_bool(env, args[0], &visible);
+  JPAGView* view = nullptr;
+  napi_unwrap(env, jsView, reinterpret_cast<void**>(&view));
+  if (view != nullptr) {
+    view->setVisible(visible);
+  }
+  return nullptr;
+}
+
 napi_value JPAGView::Constructor(napi_env env, napi_callback_info info) {
   napi_value jsView = nullptr;
   size_t argc = 0;
@@ -820,6 +830,7 @@ bool JPAGView::Init(napi_env env, napi_value exports) {
       PAG_DEFAULT_METHOD_ENTRY(makeSnapshot, MakeSnapshot),
       PAG_DEFAULT_METHOD_ENTRY(useDiskCache, UseDiskCache),
       PAG_DEFAULT_METHOD_ENTRY(setUseDiskCache, SetUseDiskCache),
+      PAG_DEFAULT_METHOD_ENTRY(setVisible, SetVisible),
       PAG_DEFAULT_METHOD_ENTRY(release, Release)};
   auto status = DefineClass(env, exports, ClassName(), sizeof(classProp) / sizeof(classProp[0]),
                             classProp, Constructor, "");
@@ -945,6 +956,40 @@ std::shared_ptr<PAGAnimator> JPAGView::getAnimator() {
 std::shared_ptr<PAGPlayer> JPAGView::getPlayer() {
   std::lock_guard lock_guard(locker);
   return player;
+}
+
+void JPAGView::setComposition(std::shared_ptr<PAGComposition> composition) {
+  auto player = getPlayer();
+  auto animator = getAnimator();
+  if (player == nullptr || animator == nullptr) {
+    return;
+  }
+  player->setComposition(composition);
+  animator->setProgress(player->getProgress());
+  std::lock_guard lock_guard(locker);
+  if (composition != nullptr && isVisible) {
+    animator->setDuration(composition->duration());
+  } else {
+    animator->setDuration(0);
+  }
+}
+
+void JPAGView::setVisible(bool visible) {
+  auto player = getPlayer();
+  auto animator = getAnimator();
+  std::lock_guard lock_guard(locker);
+  if (isVisible == visible) {
+    return;
+  }
+  isVisible = visible;
+  if (animator == nullptr) {
+    return;
+  }
+  if (isVisible && player != nullptr) {
+    animator->setDuration(player->duration());
+  } else {
+    animator->setDuration(0);
+  }
 }
 
 void JPAGView::setProgressCallback(napi_threadsafe_function callback) {

--- a/src/platform/ohos/JPAGView.h
+++ b/src/platform/ohos/JPAGView.h
@@ -57,6 +57,10 @@ class JPAGView : public PAGAnimator::Listener, public XComponentListener {
 
   std::shared_ptr<PAGAnimator> getAnimator();
 
+  void setComposition(std::shared_ptr<PAGComposition> composition);
+
+  void setVisible(bool visible);
+
   void setProgressCallback(napi_threadsafe_function callback);
 
   void setPlayingStateCallback(napi_threadsafe_function callback);
@@ -69,6 +73,7 @@ class JPAGView : public PAGAnimator::Listener, public XComponentListener {
   std::shared_ptr<PAGAnimator> animator = nullptr;
   napi_threadsafe_function progressCallback = nullptr;
   napi_threadsafe_function playingStateCallback = nullptr;
+  bool isVisible = false;
   std::mutex locker;
 };
 }  // namespace pag


### PR DESCRIPTION
## 背景

PR #3652 在鸿蒙端为 PAGViewV2 / PAGImageViewV2 增加了"组件完全不可见时停止播放"的兜底能力（对齐 Android/iOS 的离屏自动停止），但原实现存在两个缺陷：

1. **业务方暂停的动画会被强制播放**：组件重新可见时，可见性回调无条件调用 play()，导致业务方主动暂停的静态帧在列表滚动出屏幕再滑回后被强制播放。
2. **初始挂载存在卡死隐患**：aboutToAppear 中无条件 pause()，恢复播放依赖"首次可见性回调必然触发"，该行为并非 ArkUI 契约保证。

## 方案演进

第一版方案在 ETS 层用 `setVisible(visible)` 状态机 + `pausedForInvisible`/`userWantsPlaying` 门闩实现，经 review 发现存在 Blocker（离屏 play() 空跑、pause() 派发虚假事件）与 Major（门闩跨生命周期残留、V1 未覆盖）问题后，重构为与 Android/iOS 一致的 **native 离屏止刷方案**。

## 最终修复（当前实现）

**离屏止刷下沉到 native，用 `setDuration(0)` 而非 pause()/play()**，对齐 Android/iOS：

- `JPAGView` / `JPAGImageView` 新增 native 持有的 `isVisible` 状态与 `setVisible(visible)` 入口：
  - 不可见时 `animator->setDuration(0)`：`_isRunning` 保持不变、不派发任何事件，`isPlaying()` 语义跨端一致；
  - 重新可见时恢复真实 duration 并 `animator->update()` 刷新一帧。
- 两处 `setComposition` 增加 `isVisible` 守卫（对齐 iOS/Android），保证不可见期间任何路径都不会把 duration 写活。
- Controller 层删除 `pausedForInvisible`/`userWantsPlaying`，`play()`/`pause()` 恢复为纯播放意图；`setVisible` 改名 `onVisibilityChanged` 归入框架胶水（解决与 `PAGLayer.setVisible` 的命名冲突）。
- V1（`PAGView`/`PAGImageView`）与 V2 均接入 `onVisibleAreaChange`，覆盖完整。
- `detachFromView()`/`release()` 重置可见性状态，避免 controller 跨 View 复用时门闩残留。

## 修复的关键问题（含死锁）

- **离屏 `play()` 空跑**：离屏时 `_duration=0`，`startAnimation()` 首行短路，业务方离屏 play() 零刷帧。
- **虚假事件流**：离屏/回屏只调 `setDuration`，不派发 `onAnimationCancel`/`onAnimationStart`。
- **native 持锁死锁**：`setDuration` 移出 view locker（`setDuration(0)` 内部 `extractAndWaitTask` 会等待 flush 异步任务，而 flush 任务回调需同一把锁）。
- **变可见不刷新**：`setVisible(true)`/`setComposition` 可见分支补 `update()`；ImageView 补 `onLoad→update()`。

## 验证

- 模拟器实测：业务方暂停的列表项滚出再滑回保持暂停；正常播放的项滚出再滑回自动恢复；离屏期间调用 play() 后再滚出仍可正确暂停。
- 经三轮多智能体对抗式代码评审（发现并修复死锁、TOCTOU、首帧不刷新等问题，驳回误报）。