### PR TITLE
Fix PAGImageView main-thread block on iOS by keeping composition resident on decoder rebuild

### DIFF
--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -176,9 +176,12 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
   if (pagComposition == newComposition) {
     return;
   }
-  if (!filePath) {
-    pagComposition = newComposition;
-  }
+  // Keep the composition resident even for path-loaded views. Nulling it out (the old
+  // `if (!filePath)` guard) forced updatePAGDecoder to reload from filePath on every decoder
+  // rebuild, and those rebuilds run on the main thread (setBounds/setFrame -> handleSizeChanged,
+  // setContentScaleFactor, setRenderScale), so a network path blocked the main thread on a
+  // synchronous download. The composition is loaded once here and reused on every rebuild.
+  pagComposition = newComposition;
   if (newComposition) {
     self.fileWidth = newComposition->width();
     self.fileHeight = newComposition->height();
@@ -247,14 +250,10 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
     }
     if (pagComposition) {
       pagDecoder = pag::PAGDecoder::MakeFrom(pagComposition, self.maxFrameRate, scaleFactor);
-    } else if (filePath) {
-      PAGFile* pagFile = [PAGFile Load:filePath];
-      if (pagFile != nil) {
-        auto layer = [[pagFile impl] pagLayer];
-        auto composition = std::static_pointer_cast<pag::PAGComposition>(layer);
-        pagDecoder = pag::PAGDecoder::MakeFrom(composition, self.maxFrameRate, scaleFactor);
-      }
     }
+    // Reuse the resident composition; never reload from filePath here. Reloading would reissue
+    // [PAGFile Load:] on the caller thread, and decoder rebuilds are driven by the view lifecycle
+    // on the main thread, so a network path would block the main thread on a synchronous download.
     if (pagDecoder) {
       width = pagDecoder->width();
       height = pagDecoder->height();

--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -458,8 +458,8 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
   CGFloat oldScaleFactor = self.contentScaleFactor;
   [super setContentScaleFactor:scaleFactor];
   if (oldScaleFactor != scaleFactor) {
+    std::lock_guard<std::mutex> autoLock(imageViewLock);
     if (pagComposition || filePath) {
-      std::lock_guard<std::mutex> autoLock(imageViewLock);
       [self reset];
       [self updatePAGDecoder];
       self.viewSize = CGSizeMake(self.frame.size.width, self.frame.size.height);

--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -268,6 +268,7 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
 
 - (void)didMoveToWindow {
   [super didMoveToWindow];
+  std::lock_guard<std::mutex> autoLock(imageViewLock);
   [self checkVisible];
 }
 


### PR DESCRIPTION
## 问题

在 iOS 上，使用**网络 URL** 加载的 `PAGImageView`（`setPath:` / `setPathAsync:`）在 decoder 重建时可能在主线程上发起**同步网络下载**，导致主线程被阻塞。这是 Android 侧 #3647 所修崩溃的 iOS 对应版本：Android 有 `StrictMode` 守卫，会将主线程网络调用变成 `NetworkOnMainThreadException` 崩溃；而 iOS 没有该机制，因此同一根因在 iOS 上表现为**主线程冻结 / 掉帧**（弱网下甚至可能触发 watchdog 杀进程），而非崩溃。

## 根因

与 Android bug 结构完全相同：

1. `setCompositionInternal:` 仅在 `filePath == nil` 时保留 composition，因此 path-loaded 视图从不持有 `pagComposition`（始终为 `nullptr`）。
2. `updatePAGDecoder` 因此在每次 decoder 重建时回退到 `[PAGFile Load:filePath]` 重新加载。
3. decoder 重建由**主线程上的视图生命周期**驱动：`setBounds` / `setFrame` -> `handleSizeChanged`、`setContentScaleFactor`、`setRenderScale`。
4. 网络路径且磁盘缓存未命中时，`PAGFileImpl.Load` 会同步调用 `dataWithContentsOfURL:`，阻塞主线程。

## 修复

对齐 Android 修复（#3647）：保持 composition 常驻，重建时绝不从路径重载。

- `setCompositionInternal:` 始终执行 `pagComposition = newComposition`（移除 `if (!filePath)` 守卫）。
- `updatePAGDecoder` 复用常驻的 `pagComposition`，删除 `else if (filePath) { [PAGFile Load:filePath] ... }` 重载分支。

`getComposition` 对 path-loaded 视图仍返回 `nil`，公开 API 语义不变。

## 验证（iOS 模拟器，iPhone 16）

使用 app 内嵌 HTTP server 提供网络 `.pag`（人为延迟 1.5s），随后在主线程改变视图尺寸强制 decoder 重建：

| | 修复前 | 修复后 |
|---|---|---|
| HTTP 请求次数 | 2 次（首次加载 + 重建重载） | 1 次（仅首次加载） |
| 主线程 size-change 耗时 | **1527 ms**（被网络阻塞） | **4 ms** |
| 结果 | 主线程冻结 | 复用常驻 composition |

## 说明

- 权衡（与 Android 相同）：path-loaded 的 composition 现在常驻内存，为换取正确性放弃原「置空省内存」行为；真正占内存的解码帧 / 像素缓冲不受影响。
- Android 侧对应修复见 #3647。
