### PR TITLE
Fix Windows viewer build failure by enabling /EHsc for rttr.

### DIFF
--- a/vendor.json
+++ b/vendor.json
@@ -48,8 +48,27 @@
         ],
         "platforms": [
           "mac",
-          "win",
           "linux"
+        ]
+      }
+    },
+    {
+      "name": "rttr",
+      "cmake": {
+        "targets": [
+          "rttr_core_lib"
+        ],
+        "arguments": [
+          "-DBUILD_STATIC=TRUE",
+          "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+          "-DCMAKE_CXX_FLAGS=\"-w /EHsc\""
+        ],
+        "includes": [
+          "${SOURCE_DIR}/src/rttr",
+          "${BUILD_DIR}/src/rttr"
+        ],
+        "platforms": [
+          "win"
         ]
       }
     },

--- a/viewer/CMakeLists.txt
+++ b/viewer/CMakeLists.txt
@@ -282,7 +282,7 @@ elseif (WIN32)
             # Copy ffmovie.dll
             COMMAND ${CMAKE_COMMAND} -E copy_if_different "${VIEWER_FFMOVIE_DLL}" "${VIEWER_OUTPUT_DIR}/"
             # Deploy Qt (skip if already deployed)
-            COMMAND cmd /c "if not exist \"${VIEWER_OUTPUT_DIR}\\Qt6Core.dll\" \"${DEPLOYQT_EXECUTABLE}\" \"$<TARGET_FILE:PAGViewer>\" --qmldir=\"${CMAKE_SOURCE_DIR}/assets/qml\""
+            COMMAND "${DEPLOYQT_EXECUTABLE}" "$<TARGET_FILE:PAGViewer>" --qmldir="${CMAKE_SOURCE_DIR}/assets/qml"
             COMMENT "Deploying runtime dependencies for PAGViewer"
             VERBATIM
     )

--- a/viewer/package/build_windows.ps1
+++ b/viewer/package/build_windows.ps1
@@ -258,7 +258,7 @@ $ISCCPath = Join-Path $InnoSetupDir "ISCC.exe"
 if (-not (Test-Path $ISCCPath)) {
     Log-Info "InnoSetup not found, installing..."
     $Installer = "$env:TEMP\innosetup.exe"
-    Invoke-WebRequest -Uri "https://www.jrsoftware.org/download.php/is.exe" -OutFile $Installer
+    Invoke-WebRequest -Uri "https://github.com/jrsoftware/issrc/releases/download/is-6_7_3/innosetup-6.7.3.exe" -OutFile $Installer
     $InstallProcess = Start-Process -PassThru -Wait -FilePath $Installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=$InnoSetupDir"
     Remove-Item -Path $Installer -Force -ErrorAction SilentlyContinue
     if ($InstallProcess.ExitCode -ne 0) { Exit-WithError "Install InnoSetup failed" }


### PR DESCRIPTION
修复 PAGViewer 在 Windows 上的编译错误。

## 问题根因
- rttr 依赖 C++ 异常处理（std_conversion_functions.cpp 中大量 try/catch），但 vendor.json 通过 -DCMAKE_CXX_FLAGS="-w" 覆盖了 MSVC 默认的 /EHsc，触发 warning C4530；
- rttr 自身强制 /WX /W4（警告视为错误），将 C4530 升级为 error C2220，导致 Windows 构建失败。

## 变更内容
1. vendor.json：rttr 按平台拆分（沿用 tgfx 的平台区分写法）：
   - Windows：-DCMAKE_CXX_FLAGS="-w /EHsc"，启用 C++ 异常展开语义，消除 C4530/C2220；
   - mac/linux：保持 -DCMAKE_CXX_FLAGS="-w" 不变，不受影响。
2. viewer/CMakeLists.txt：windeployqt 改为每次构建全量部署 Qt 运行时依赖，避免条件跳过导致 Qt 依赖不完整。
3. viewer/package/build_windows.ps1：Inno Setup 下载源改为 GitHub 固定版本 6.7.3，保证构建可复现。

## 验证
- rttr 在 Windows 下单独构建通过，无 C4530/C2220 错误。
