### PR TITLE
Reset PAGImageView progress when switching compositions

### DIFF
--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -380,6 +380,8 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
   width = 0;
   height = 0;
   numFrames = 0;
+  self.currentFrameIndex = -1;
+  self.currentUIImage = nil;
 }
 
 - (UIImage*)imageForCVPixelBuffer:(CVPixelBufferRef)pixelBuffer {

--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -192,6 +192,11 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
   }
   self.maxFrameRate = maxFrameRate;
 
+  // The animator keeps a progress that is independent of the composition, so it must be reset to
+  // the new composition's progress when the resource is switched. Otherwise a switch triggered
+  // during playback keeps the previous progress and the new animation starts from the middle.
+  // This matches the behavior of the Android PAGImageView.
+  [animator setProgress:newComposition ? newComposition->getProgress() : 0.0];
   [self reset];
   [self updatePAGDecoder];
   if (self.isVisible) {

--- a/src/platform/ohos/JPAGImageView.cpp
+++ b/src/platform/ohos/JPAGImageView.cpp
@@ -707,6 +707,11 @@ void JPAGImageView::setComposition(std::shared_ptr<PAGComposition> composition, 
   if (composition != nullptr && visible) {
     duration = composition->duration();
   }
+  // The animator keeps a progress that is independent of the composition, so it must be reset to
+  // the new composition's progress when the resource is switched. Otherwise a switch triggered
+  // during playback keeps the previous progress and the new animation starts from the middle.
+  // This matches the behavior of the Android and iOS PAGImageView.
+  animator->setProgress(composition != nullptr ? composition->getProgress() : 0.0);
   animator->setDuration(duration);
   if (visible) {
     animator->update();


### PR DESCRIPTION
## 问题背景

使用 `PAGImageView` 播放动画时，在播放过程中通过 `setPath` 或 `setComposition` 切换到下一个动画，新动画没有从第 0 帧开始，而是沿用上一个动画的播放进度，从中间位置开始播放。该问题在 iOS 的 `PAGImageView` 中可以复现。

## 根本原因

`PAGImageView` 使用独立的 `PAGAnimator` 保存播放进度。切换 composition 时，iOS 和 OHOS 实现只更新了 decoder 和 duration，没有同步更新 animator 的 progress，因此新 composition 会继续使用旧 composition 的进度。

此外，iOS `reset` 没有清除 `currentFrameIndex` 和 `currentUIImage`。当新旧 composition 的初始帧索引相同时，`flush` 会误判当前帧无需更新，继续复用旧 composition 的图像。

## 修复方案

- iOS 和 OHOS 在切换 composition 时，将 animator progress 同步为新 composition 的 progress；
- 空 composition 的 progress 重置为 `0.0`；
- iOS 切换 composition 时清除旧的 `currentFrameIndex` 和 `currentUIImage`，确保下一次 `flush` 重新解码新 composition 的首帧；
- 不改变公共 API，也不在持有 iOS image view 锁时主动触发 animator update，避免潜在的回调重入和死锁。

## 影响范围

- 修复 iOS `PAGImageView` 使用 `setPath` 或 `setComposition` 切换动画时的进度残留问题；
- 同步修复 OHOS `PAGImageView` 的相同进度问题；
- 不影响 `PAGView` 的现有行为；
- 不改变本地资源加载、播放循环或公共 API 语义。

## 验证

- 已使用用户提供的 iOS Demo 编译并安装到 iPhone 16 模拟器；
- 已验证修复前版本和修复版本的 Demo 启动流程；
- 已执行 `PAGFullTest` 构建和测试；
- iOS 平台最终切换行为建议在真实 iOS Demo 中继续回归验证。