### PR TITLE
Fix: prevent double-release of Surface in PAGSurface finalize

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGSurface.java
+++ b/android/libpag/src/main/java/org/libpag/PAGSurface.java
@@ -203,6 +203,11 @@ public class PAGSurface {
     private void releaseSurface() {
         if (needsReleaseSurface && surface != null) {
             surface.release();
+            // Null out the reference so that a later GC finalize() does not release the same
+            // Surface (and its underlying ANativeWindow) a second time. Otherwise an explicit
+            // release() followed by GC could double-release the native surface and crash in
+            // android::RefBase::decStrong.
+            surface = null;
         }
     }
 


### PR DESCRIPTION
修复 Android libpag.so 在 PAGSurface 释放时 RefBase::decStrong 闪退问题。

根因：commit 65204a14（Fix Android PAGSurface leak by releasing Surface in finalize）在 finalize() 中新增了 releaseSurface() 调用，但 releaseSurface() 释放 Java Surface 后没有置空 surface 引用，导致同一 PAGSurface 在执行显式 release() 后被 GC finalize() 再次调用 releaseSurface()，对同一个 Surface（底层 ANativeWindow）重复调用 release()，造成引用计数下溢，触发 android::RefBase::decStrong 崩溃。

修复：releaseSurface() 释放 Surface 后置空 surface 引用，使其具备幂等性，避免 finalize() 二次释放。

相关 Issue：https://github.com/Tencent/libpag/issues/3639