### PR TITLE
Fix iOS dangling GL context pointer crash in PAGDecoder by holding a shared GLDevice

### DIFF
--- a/include/pag/pag.h
+++ b/include/pag/pag.h
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <functional>  // for windows
+#include <memory>
 #include <unordered_map>
 #include "pag/decoder.h"
 #include "pag/gpu.h"
@@ -1661,8 +1662,7 @@ class PAG_API PAGDecoder {
                                                    int numFrames);
 
   PAGDecoder(std::shared_ptr<PAGComposition> composition, int width, int height, int numFrames,
-             float frameRate, float maxFrameRate,
-             std::shared_ptr<tgfx::GLDevice> sharedDevice = nullptr);
+             float frameRate, float maxFrameRate, std::shared_ptr<tgfx::GLDevice> sharedDevice);
 
   bool readFrameInternal(int index, std::shared_ptr<BitmapBuffer> bitmap);
   bool renderFrame(std::shared_ptr<PAGComposition> composition, int index,

--- a/include/pag/pag.h
+++ b/include/pag/pag.h
@@ -30,6 +30,7 @@ struct Rect;
 class Context;
 class Surface;
 class ImageInfo;
+class GLDevice;
 }  // namespace tgfx
 
 namespace pag {
@@ -1642,7 +1643,7 @@ class PAG_API PAGDecoder {
   int _numFrames = 0;
   float _frameRate = 30.0f;
   float maxFrameRate = 30.0f;
-  void* sharedContext = nullptr;
+  std::shared_ptr<tgfx::GLDevice> sharedDevice = nullptr;
   int lastReadIndex = -1;
   tgfx::ImageInfo* lastImageInfo = nullptr;
   uint32_t lastContentVersion = 0;
@@ -1660,7 +1661,8 @@ class PAG_API PAGDecoder {
                                                    int numFrames);
 
   PAGDecoder(std::shared_ptr<PAGComposition> composition, int width, int height, int numFrames,
-             float frameRate, float maxFrameRate, void* sharedContext = nullptr);
+             float frameRate, float maxFrameRate,
+             std::shared_ptr<tgfx::GLDevice> sharedDevice = nullptr);
 
   bool readFrameInternal(int index, std::shared_ptr<BitmapBuffer> bitmap);
   bool renderFrame(std::shared_ptr<PAGComposition> composition, int index,

--- a/src/rendering/CompositionReader.cpp
+++ b/src/rendering/CompositionReader.cpp
@@ -19,12 +19,12 @@
 #include "CompositionReader.h"
 
 namespace pag {
-std::shared_ptr<CompositionReader> CompositionReader::Make(int width, int height,
-                                                           void* sharedContext) {
+std::shared_ptr<CompositionReader> CompositionReader::Make(
+    int width, int height, std::shared_ptr<tgfx::GLDevice> sharedDevice) {
   if (width <= 0 || height <= 0) {
     return nullptr;
   }
-  auto drawable = BitmapDrawable::Make(width, height, sharedContext);
+  auto drawable = BitmapDrawable::Make(width, height, std::move(sharedDevice));
   if (drawable == nullptr) {
     return nullptr;
   }

--- a/src/rendering/CompositionReader.h
+++ b/src/rendering/CompositionReader.h
@@ -25,8 +25,8 @@
 namespace pag {
 class CompositionReader {
  public:
-  static std::shared_ptr<CompositionReader> Make(int width, int height,
-                                                 void* sharedContext = nullptr);
+  static std::shared_ptr<CompositionReader> Make(
+      int width, int height, std::shared_ptr<tgfx::GLDevice> sharedDevice = nullptr);
 
   ~CompositionReader();
 

--- a/src/rendering/PAGDecoder.cpp
+++ b/src/rendering/PAGDecoder.cpp
@@ -120,15 +120,23 @@ std::shared_ptr<PAGDecoder> PAGDecoder::MakeFrom(std::shared_ptr<PAGComposition>
   auto width = roundf(static_cast<float>(composition->width()) * scale);
   auto height = roundf(static_cast<float>(composition->height()) * scale);
   auto result = GetFrameCountAndRate(composition, maxFrameRate);
-  return std::shared_ptr<PAGDecoder>(new PAGDecoder(std::move(composition), static_cast<int>(width),
-                                                    static_cast<int>(height), result.first,
-                                                    result.second, maxFrameRate, sharedContext));
+  // Turn the caller's current GL context into a self-owned shared device right away, while the
+  // context is still guaranteed to be alive. GLDevice::Make() creates a brand-new context that only
+  // shares the sharegroup and reads the caller's context exactly once, so the decoder no longer
+  // depends on the lifetime of that context afterwards. This removes the use-after-free that
+  // happened when the raw context pointer was dereferenced later on a background thread in
+  // readFrame().
+  auto sharedDevice = sharedContext != nullptr ? tgfx::GLDevice::Make(sharedContext) : nullptr;
+  return std::shared_ptr<PAGDecoder>(
+      new PAGDecoder(std::move(composition), static_cast<int>(width), static_cast<int>(height),
+                     result.first, result.second, maxFrameRate, std::move(sharedDevice)));
 }
 
 PAGDecoder::PAGDecoder(std::shared_ptr<PAGComposition> composition, int width, int height,
-                       int numFrames, float frameRate, float maxFrameRate, void* sharedContext)
+                       int numFrames, float frameRate, float maxFrameRate,
+                       std::shared_ptr<tgfx::GLDevice> sharedDevice)
     : _width(width), _height(height), _numFrames(numFrames), _frameRate(frameRate),
-      maxFrameRate(maxFrameRate), sharedContext(sharedContext) {
+      maxFrameRate(maxFrameRate), sharedDevice(std::move(sharedDevice)) {
   container = PAGComposition::Make(width, height);
   container->addLayer(composition);
   staticTimeRanges = GetStaticTimeRange(composition, _numFrames);
@@ -230,7 +238,7 @@ bool PAGDecoder::renderFrame(std::shared_ptr<PAGComposition> composition, int in
     return false;
   }
   if (reader == nullptr) {
-    reader = CompositionReader::Make(_width, _height, sharedContext);
+    reader = CompositionReader::Make(_width, _height, sharedDevice);
     if (reader == nullptr) {
       LOGE("PAGDecoder::renderFrame() Failed to create a CompositionReader!");
       return false;

--- a/src/rendering/drawables/BitmapDrawable.cpp
+++ b/src/rendering/drawables/BitmapDrawable.cpp
@@ -20,11 +20,9 @@
 #include "tgfx/gpu/opengl/GLDevice.h"
 
 namespace pag {
-std::shared_ptr<BitmapDrawable> BitmapDrawable::Make(int width, int height, void* sharedContext) {
-  std::shared_ptr<tgfx::GLDevice> device = nullptr;
-  if (sharedContext != nullptr) {
-    device = tgfx::GLDevice::Make(sharedContext);
-  }
+std::shared_ptr<BitmapDrawable> BitmapDrawable::Make(int width, int height,
+                                                     std::shared_ptr<tgfx::GLDevice> sharedDevice) {
+  std::shared_ptr<tgfx::GLDevice> device = std::move(sharedDevice);
   if (device == nullptr) {
     device = tgfx::GLDevice::MakeWithFallback();
   }

--- a/src/rendering/drawables/BitmapDrawable.h
+++ b/src/rendering/drawables/BitmapDrawable.h
@@ -21,10 +21,15 @@
 #include "Drawable.h"
 #include "rendering/utils/BitmapBuffer.h"
 
+namespace tgfx {
+class GLDevice;
+}  // namespace tgfx
+
 namespace pag {
 class BitmapDrawable : public Drawable {
  public:
-  static std::shared_ptr<BitmapDrawable> Make(int width, int height, void* sharedContext = nullptr);
+  static std::shared_ptr<BitmapDrawable> Make(
+      int width, int height, std::shared_ptr<tgfx::GLDevice> sharedDevice = nullptr);
 
   int width() const override {
     return _width;

--- a/test/src/PAGDiskCacheTest.cpp
+++ b/test/src/PAGDiskCacheTest.cpp
@@ -17,11 +17,13 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include <filesystem>
+#include <thread>
 #include "pag/pag.h"
 #include "platform/Platform.h"
 #include "rendering/caches/DiskCache.h"
 #include "rendering/utils/BitmapBuffer.h"
 #include "rendering/utils/Directory.h"
+#include "tgfx/gpu/opengl/GLDevice.h"
 #include "utils/TestUtils.h"
 
 namespace pag {
@@ -349,6 +351,50 @@ PAG_TEST(PAGDiskCacheTest, PAGDecoder) {
   files = Directory::FindFiles(cacheDir + "/files", ".bin");
   EXPECT_EQ(files.size(), diskFileCount - 3);
 
+  pag::PAGDiskCache::RemoveAll();
+}
+
+/**
+ * Regression test for the iOS dangling GL context crash: after MakeFrom captures the caller's
+ * current GL context, destroying that caller context must not affect subsequent readFrame calls,
+ * even when they happen on another thread. Before the fix, PAGDecoder held a raw pointer to the
+ * caller's context and dereferenced it later in readFrame(), causing a use-after-free once the
+ * caller context was released.
+ */
+static void ReadFirstFrame(PAGDecoder* decoder, bool* success) {
+  tgfx::Bitmap bitmap(decoder->width(), decoder->height(), false, false);
+  tgfx::Pixmap pixmap(bitmap);
+  *success = decoder->readFrame(0, pixmap.writablePixels(), pixmap.rowBytes());
+}
+
+PAG_TEST(PAGDiskCacheTest, PAGDecoderContextDestroyed) {
+  pag::PAGDiskCache::RemoveAll();
+  auto pagFile = LoadPAGFile("resources/apitest/data_bmp.pag");
+  ASSERT_TRUE(pagFile != nullptr);
+
+  // Make a standalone GL context current on this thread so MakeFrom() captures it as the caller
+  // context via GLDevice::CurrentNativeHandle().
+  auto callerDevice = tgfx::GLDevice::Make();
+  ASSERT_TRUE(callerDevice != nullptr);
+  auto callerContext = callerDevice->lockContext();
+  ASSERT_TRUE(callerContext != nullptr);
+  auto decoder = PAGDecoder::MakeFrom(pagFile, 30, 0.5f);
+  ASSERT_TRUE(decoder != nullptr);
+  EXPECT_TRUE(decoder->sharedDevice != nullptr);
+
+  // Destroy the caller's context; a correct decoder no longer depends on its lifetime.
+  callerDevice->unlock();
+  callerDevice = nullptr;
+
+  // Read on another thread with no current GL context: must render through the self-owned
+  // sharedDevice instead of crashing on the freed caller context.
+  bool success = false;
+  std::thread reader(ReadFirstFrame, decoder.get(), &success);
+  reader.join();
+  EXPECT_TRUE(success);
+  EXPECT_TRUE(decoder->reader != nullptr);
+
+  decoder = nullptr;
   pag::PAGDiskCache::RemoveAll();
 }
 


### PR DESCRIPTION
## 背景

Fix #3659：iOS v4.5.x 系列版本因悬空指针引起的崩溃。

`PAGDecoder` 在 `MakeFrom` 时通过 `tgfx::GLDevice::CurrentNativeHandle()` 捕获调用方当前 GL context 的**裸指针**（`void* sharedContext`）并存入成员，直到后台线程调用 `readFrame()` → `renderFrame()` → `CompositionReader::Make` → `BitmapDrawable::Make` → `tgfx::GLDevice::Make(sharedContext)` 时才解引用。若调用方在此期间销毁了自己的 GL context，该裸指针即成为悬空指针，解引用时触发 use-after-free 崩溃。

## 修复方案

在 `MakeFrom` 中（调用方线程、context 仍存活时）**立即**将裸 context 转换为自持有的 `std::shared_ptr<tgfx::GLDevice> sharedDevice` 并存入 decoder。`tgfx::GLDevice::Make()` 会同步读取一次调用方句柄，创建一个仅共享 sharegroup 的全新独立 context，不再持有调用方 context，因此 decoder 后续不再依赖调用方 context 的生命周期，从根本消除悬空指针解引用。

相应地将内部工厂链的参数由 `void* sharedContext` 改为 `std::shared_ptr<tgfx::GLDevice> sharedDevice`：

- `PAGDecoder`：成员与私有构造参数改为 shared_ptr
- `CompositionReader::Make`
- `BitmapDrawable::Make`
- `include/pag/pag.h`：前置声明 `tgfx::GLDevice`

## 影响

- 修复了 iOS 上的 use-after-free 崩溃，且从根源解决而非规避。
- 签名变更完全内聚，仅影响内部渲染路径，公共 API 方法签名不变。