### PR TITLE
Relay PAGAnimator events through a proxy to avoid infinite recursion when a view registers itself as a listener

### DIFF
--- a/src/platform/cocoa/private/PAGAnimatorListenerProxy.h
+++ b/src/platform/cocoa/private/PAGAnimatorListenerProxy.h
@@ -1,0 +1,59 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+#import "PAGAnimator.h"
+
+/**
+ * The object that receives the animator events relayed by a PAGAnimatorListenerProxy. PAGView and
+ * PAGImageView adopt this protocol to dispatch the events to their own public listener list.
+ */
+@protocol PAGViewAnimatorForwarder <NSObject>
+
+/**
+ * Dispatches the animation event identified by the selector to the public listeners.
+ */
+- (void)dispatchListenerEvent:(SEL)selector;
+
+@end
+
+/**
+ * A standalone listener that receives PAGAnimator events and relays them to a forwarder. It
+ * decouples the internal "animator listener" role from the view itself. Without this proxy, the
+ * view has to implement PAGAnimatorListener directly, whose selectors collide with the public
+ * PAGViewListener selectors. A view subclass that also implements the public listener protocol
+ * would then override the internal animator callbacks, and registering the view itself as a
+ * listener would recurse infinitely. Relaying through a dedicated proxy keeps the two roles
+ * separated so the collision can no longer happen.
+ */
+@interface PAGAnimatorListenerProxy : NSObject <PAGAnimatorListener>
+
+/**
+ * Initializes the proxy with the forwarder that receives the relayed events. The proxy holds an
+ * unretained reference to the forwarder, so the forwarder must outlive the proxy or call detach
+ * before it is deallocated.
+ */
+- (instancetype)initWithForwarder:(id<PAGViewAnimatorForwarder>)forwarder;
+
+/**
+ * Drops the reference to the forwarder. Must be called before the forwarder is deallocated so that
+ * no event is relayed to a dangling forwarder.
+ */
+- (void)detach;
+
+@end

--- a/src/platform/cocoa/private/PAGAnimatorListenerProxy.mm
+++ b/src/platform/cocoa/private/PAGAnimatorListenerProxy.mm
@@ -1,0 +1,56 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#import "PAGAnimatorListenerProxy.h"
+
+@implementation PAGAnimatorListenerProxy {
+  __unsafe_unretained id<PAGViewAnimatorForwarder> forwarder;
+}
+
+- (instancetype)initWithForwarder:(id<PAGViewAnimatorForwarder>)value {
+  if (self = [super init]) {
+    forwarder = value;
+  }
+  return self;
+}
+
+- (void)detach {
+  forwarder = nil;
+}
+
+- (void)onAnimationStart:(id<PAGAnimatorUpdater>)updater {
+  [forwarder dispatchListenerEvent:@selector(onAnimationStart:)];
+}
+
+- (void)onAnimationEnd:(id<PAGAnimatorUpdater>)updater {
+  [forwarder dispatchListenerEvent:@selector(onAnimationEnd:)];
+}
+
+- (void)onAnimationCancel:(id<PAGAnimatorUpdater>)updater {
+  [forwarder dispatchListenerEvent:@selector(onAnimationCancel:)];
+}
+
+- (void)onAnimationRepeat:(id<PAGAnimatorUpdater>)updater {
+  [forwarder dispatchListenerEvent:@selector(onAnimationRepeat:)];
+}
+
+- (void)onAnimationUpdate:(id<PAGAnimatorUpdater>)updater {
+  [forwarder dispatchListenerEvent:@selector(onAnimationUpdate:)];
+}
+
+@end

--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -27,6 +27,7 @@
 #import "PAGFile.h"
 #import "platform/cocoa/PAGDiskCache.h"
 #import "platform/cocoa/private/PAGAnimator.h"
+#import "platform/cocoa/private/PAGAnimatorListenerProxy.h"
 #import "platform/cocoa/private/PAGLayer+Internal.h"
 #import "platform/cocoa/private/PAGLayerImpl+Internal.h"
 #import "platform/cocoa/private/PixelBufferUtil.h"
@@ -67,12 +68,13 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
 
 @end
 
-@interface PAGImageView () <PAGAnimatorUpdater, PAGAnimatorListener>
+@interface PAGImageView () <PAGAnimatorUpdater, PAGViewAnimatorForwarder>
 @end
 
 @implementation PAGImageView {
   NSString* filePath;
   PAGAnimator* animator;
+  PAGAnimatorListenerProxy* animatorListenerProxy;
   std::shared_ptr<pag::PAGComposition> pagComposition;
   std::shared_ptr<pag::PAGDecoder> pagDecoder;
   int64_t duration;
@@ -115,7 +117,8 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
   self.backgroundColor = [UIColor clearColor];
   animator = [[PAGAnimator alloc] initWithUpdater:(id<PAGAnimatorUpdater>)self];
   listeners = [[NSHashTable weakObjectsHashTable] retain];
-  [animator addListener:self];
+  animatorListenerProxy = [[PAGAnimatorListenerProxy alloc] initWithForwarder:self];
+  [animator addListener:animatorListenerProxy];
 
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(applicationDidBecomeActive:)
@@ -133,7 +136,9 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
 // against any lingering flush.
 - (void)dealloc {
   [animator cancel];
+  [animatorListenerProxy detach];
   [animator release];
+  [animatorListenerProxy release];
   {
     std::lock_guard<std::mutex> autoLock(imageViewLock);
     [self reset];
@@ -539,27 +544,7 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
   [listeners removeObject:listener];
 }
 
-#pragma mark - PAGAnimatorListener
-
-- (void)onAnimationStart:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationStart:)];
-}
-
-- (void)onAnimationEnd:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationEnd:)];
-}
-
-- (void)onAnimationCancel:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationCancel:)];
-}
-
-- (void)onAnimationRepeat:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationRepeat:)];
-}
-
-- (void)onAnimationUpdate:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationUpdate:)];
-}
+#pragma mark - Listener dispatch
 
 - (void)dispatchListenerEvent:(SEL)selector {
   if ([NSThread isMainThread]) {

--- a/src/platform/ios/PAGView.mm
+++ b/src/platform/ios/PAGView.mm
@@ -20,9 +20,10 @@
 #import "PAGPlayer.h"
 #import "PAGSurface.h"
 #import "platform/cocoa/private/PAGAnimator.h"
+#import "platform/cocoa/private/PAGAnimatorListenerProxy.h"
 #import "platform/ios/private/GPUDrawable.h"
 
-@interface PAGView () <PAGAnimatorUpdater, PAGAnimatorListener>
+@interface PAGView () <PAGAnimatorUpdater, PAGViewAnimatorForwarder>
 @end
 
 @implementation PAGView {
@@ -30,6 +31,7 @@
   PAGSurface* pagSurface;
   NSString* filePath;
   PAGAnimator* animator;
+  PAGAnimatorListenerProxy* animatorListenerProxy;
   BOOL _isVisible;
   std::mutex lock;
   NSHashTable* listeners;
@@ -51,7 +53,8 @@
   pagPlayer = [[PAGPlayer alloc] init];
   animator = [[PAGAnimator alloc] initWithUpdater:(id<PAGAnimatorUpdater>)self];
   listeners = [[NSHashTable weakObjectsHashTable] retain];
-  [animator addListener:self];
+  animatorListenerProxy = [[PAGAnimatorListenerProxy alloc] initWithForwarder:self];
+  [animator addListener:animatorListenerProxy];
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(applicationDidBecomeActive:)
                                                name:UIApplicationDidBecomeActiveNotification
@@ -68,6 +71,7 @@
 
 - (void)dealloc {
   [animator cancel];
+  [animatorListenerProxy detach];
   {
     std::lock_guard<std::mutex> autoLock(lock);
     [pagPlayer release];
@@ -76,6 +80,7 @@
     pagSurface = nil;
   }
   [animator release];
+  [animatorListenerProxy release];
   [filePath release];
   [listeners release];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -172,27 +177,7 @@
   [listeners removeObject:listener];
 }
 
-#pragma mark - PAGAnimatorListener
-
-- (void)onAnimationStart:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationStart:)];
-}
-
-- (void)onAnimationEnd:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationEnd:)];
-}
-
-- (void)onAnimationCancel:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationCancel:)];
-}
-
-- (void)onAnimationRepeat:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationRepeat:)];
-}
-
-- (void)onAnimationUpdate:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationUpdate:)];
-}
+#pragma mark - Listener dispatch
 
 - (void)dispatchListenerEvent:(SEL)selector {
   if ([NSThread isMainThread]) {

--- a/src/platform/mac/PAGView.mm
+++ b/src/platform/mac/PAGView.mm
@@ -19,9 +19,10 @@
 #import "PAGView.h"
 #import "PAGPlayer.h"
 #import "platform/cocoa/private/PAGAnimator.h"
+#import "platform/cocoa/private/PAGAnimatorListenerProxy.h"
 #import "platform/mac/private/GPUDrawable.h"
 
-@interface PAGView () <PAGAnimatorUpdater, PAGAnimatorListener>
+@interface PAGView () <PAGAnimatorUpdater, PAGViewAnimatorForwarder>
 @end
 
 @implementation PAGView {
@@ -30,6 +31,7 @@
   PAGFile* pagFile;
   NSString* filePath;
   PAGAnimator* animator;
+  PAGAnimatorListenerProxy* animatorListenerProxy;
   BOOL _isVisible;
   NSHashTable* listeners;
   NSLock* listenerLock;
@@ -51,7 +53,8 @@
   animator = [[PAGAnimator alloc] initWithUpdater:(id<PAGAnimatorUpdater>)self];
   listeners = [[NSHashTable weakObjectsHashTable] retain];
   listenerLock = [[NSLock alloc] init];
-  [animator addListener:self];
+  animatorListenerProxy = [[PAGAnimatorListenerProxy alloc] initWithForwarder:self];
+  [animator addListener:animatorListenerProxy];
   // The animator must be set to sync mode. Otherwise, the internal surface in the PAGSurface could
   // not be created.
   [animator setSync:YES];
@@ -63,7 +66,9 @@
 
 - (void)dealloc {
   [animator cancel];
+  [animatorListenerProxy detach];
   [animator release];
+  [animatorListenerProxy release];
   [pagPlayer release];
   [pagSurface release];
   [pagFile release];
@@ -153,27 +158,7 @@
   [listenerLock unlock];
 }
 
-#pragma mark - PAGAnimatorListener
-
-- (void)onAnimationStart:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationStart:)];
-}
-
-- (void)onAnimationEnd:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationEnd:)];
-}
-
-- (void)onAnimationCancel:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationCancel:)];
-}
-
-- (void)onAnimationRepeat:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationRepeat:)];
-}
-
-- (void)onAnimationUpdate:(id<PAGAnimatorUpdater>)updater {
-  [self dispatchListenerEvent:@selector(onAnimationUpdate:)];
-}
+#pragma mark - Listener dispatch
 
 - (void)dispatchListenerEvent:(SEL)selector {
   if ([NSThread isMainThread]) {


### PR DESCRIPTION
## 问题

Fix #3664。

`PAGView` / `PAGImageView` 此前直接实现 `PAGAnimatorListener` 协议，而该协议的回调选择器（`onAnimationStart:` 等）与对外公开的 `PAGViewListener` / `PAGImageViewListener` 选择器逐字相同。当业务把 view 自身注册为公开监听器时，view 的 animator 回调会再次派发到自己，从而触发无限递归崩溃。

## 方案

引入独立的 `PAGAnimatorListenerProxy`，专门接收 `PAGAnimator` 事件，并通过新增的内部协议 `PAGViewAnimatorForwarder`（`dispatchListenerEvent:`）中转给 view。这样把「内部 animator 监听」与「对外公开监听」两个角色彻底解耦，选择器不再冲突，递归也不可能再发生。

- 新增 `src/platform/cocoa/private/PAGAnimatorListenerProxy.{h,mm}`。
- iOS `PAGView` / `PAGImageView`、macOS `PAGView` 改为遵循 `PAGViewAnimatorForwarder`，持有并向 animator 注册 proxy，view 不再直接遵循 `PAGAnimatorListener`。
- proxy 以 `__unsafe_unretained` 持有 forwarder；view 在 `dealloc` 中按 `[animator cancel]` → `[proxy detach]` → release 的顺序清理，避免向已释放对象派发事件。

## 影响范围

仅涉及 iOS / macOS 平台层的监听器转发逻辑，不改动任何公开 API，行为对使用方透明。