### PR TITLE
Update bundled Expat to 2.8.3 and drop the manual hash salt call

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -37,7 +37,7 @@
       },
       {
         "url": "https://github.com/libexpat/libexpat.git",
-        "commit": "88b3ed553d8ad335559254863a33360d55b9f1d6",
+        "commit": "70a0d4b01f2b6af4ec3d851ad2b399752f531ff8",
         "dir": "third_party/expat"
       },
       {

--- a/src/pagx/xml/XMLParser.cpp
+++ b/src/pagx/xml/XMLParser.cpp
@@ -108,8 +108,6 @@ bool ParsingContext::endElement(const char* element) {
 
 namespace {
 
-constexpr const void* HASH_SEED = &HASH_SEED;
-
 #define HANDLER_CONTEXT(arg, name) ParsingContext* name = static_cast<ParsingContext*>(arg)
 
 void XMLCALL start_element_handler(void* data, const char* tag, const char** attributes) {
@@ -190,12 +188,6 @@ bool XMLParser::parse(const uint8_t* data, size_t length) {
     return false;
   }
   _expatParser = parsingContext._XMLParser.get();
-
-  // Avoid calls to rand_s if this is not set. This seed helps prevent DOS
-  // with a known hash sequence so an address is sufficient. The provided
-  // seed should not be zero as that results in a call to rand_s.
-  auto seed = static_cast<unsigned long>(reinterpret_cast<size_t>(HASH_SEED) & 0xFFFFFFFF);
-  XML_SetHashSalt(parsingContext._XMLParser, seed ? seed : 1);
 
   XML_SetUserData(parsingContext._XMLParser, &parsingContext);
   XML_SetElementHandler(parsingContext._XMLParser, start_element_handler, end_element_handler);


### PR DESCRIPTION
## 背景

修复 issue #3681。

## 改动

- **`DEPS`**:将内置 Expat 依赖从旧 commit 升级到 **2.8.3** release,涵盖 CVE-2026-45186(O(n²) 哈希碰撞导致的拒绝服务)的修复(该漏洞在 2.8.1 已修复)。
- **`src/pagx/xml/XMLParser.cpp`**:移除 `HASH_SEED` 静态量及 `XML_SetHashSalt()` 调用。

## 为什么移除 `XML_SetHashSalt` 是安全的,且属于安全性提升

- Expat 2.8.x 在从未调用 `XML_SetHashSalt` 时会在首次解析时**自动播种**哈希盐:通过 OS 级 CSPRNG(macOS `arc4random_buf`、Linux `getrandom`/`getentropy`、Windows `rand_s`),生成完整的 128-bit 随机盐。
- 原有代码用静态变量地址的低 32 位(ASLR 派生,熵极低)作为盐,并且因为调用了 `XML_SetHashSalt` 会将盐标记为"已设置",反而**抑制**了 Expat 更强的自播种逻辑。
- 因此删除该调用后,解析器恢复使用 128-bit CSPRNG 默认盐,强度严格优于此前的做法。

## 验证

- 确认 `DEPS` 指向的 commit 为真实的 Expat 2.8.3 release(`XML_MICRO_VERSION 3`)。
- 全仓库无 `HASH_SEED` / `XML_SetHashSalt` 的其它残留引用,无孤立 include 或死代码。

Closes #3681