### PR TITLE
Fix HarmonyOS text layers not rendering by registering font fallback synchronously

### DIFF
--- a/ohos/libpag/src/main/ets/PAGInit.ets
+++ b/ohos/libpag/src/main/ets/PAGInit.ets
@@ -38,40 +38,66 @@ export class PAGInit {
     // Synchronously scan the system font directory and register the fallback
     // fonts before Init() returns. This is critical for correctness: PAGFile.Load
     // triggers the first text shaping synchronously right after Init(), while the
-    // text module API (getSystemFontFullNamesByType) can only be consumed
-    // asynchronously. If the fallback list is registered asynchronously, the first
-    // shaping runs against an empty fallback list, produces empty glyphs and caches
-    // them, leaving the text invisible even after the fonts are registered later.
-    if (PAGInit.InitFontFallbackFromSystemDir()) {
-      return;
-    }
+    // system font APIs (text module on API14+, font module below) can only be
+    // consumed asynchronously or may crash. If the fallback list is registered
+    // asynchronously, the first shaping runs against an empty fallback list,
+    // produces empty glyphs and caches them, leaving the text invisible even
+    // after the fonts are registered later.
+    let registeredFromDir = PAGInit.InitFontFallbackFromSystemDir();
 
-    // Fallback path when the system font directory is inaccessible (rare).
+    // The directory scan uses file-system ordering and registers every font file,
+    // losing the language-priority ordering and the curated subset that the system
+    // font config provides. Asynchronously re-register the fallback list from the
+    // system API to restore the correct ordering for subsequent shaping. When the
+    // synchronous scan failed (rare), this is also the only source of fallback fonts.
     if (deviceInfo.sdkApiVersion >= 14) {
       // font.getUIFontConfig() may crash on API14+, so use the text module API.
       PAGInit.InitFontFallbackWithTextModule();
-      return;
+    } else if (!registeredFromDir) {
+      // Below API14 the async text module is unavailable. Only touch the crash-prone
+      // font module when the synchronous scan produced nothing.
+      PAGInit.InitFontFallbackWithFontModule();
     }
-    PAGInit.InitFontFallbackWithFontModule();
+  }
+
+  // Concatenate the two sets (emoji fonts last so they are not matched before text
+  // fonts during shaping) and register them. Returns true when at least one font is
+  // registered. The native call is guarded so a failure cannot escape Init().
+  private static RegisterFallbackPaths(pathSet: Set<string>, emojiPathSet: Set<string>): boolean {
+    let paths = Array.from(pathSet).concat(Array.from(emojiPathSet));
+    if (paths.length === 0) {
+      return false;
+    }
+    try {
+      JPAGFont.SetFallbackFontPaths(paths);
+    } catch (e) {
+      console.warn('[PAGInit] SetFallbackFontPaths failed: ' + e);
+      return false;
+    }
+    return true;
   }
 
   // Synchronously collect fonts from the system font directory and register them.
   // Returns true when at least one font is registered.
   private static InitFontFallbackFromSystemDir(): boolean {
     const systemFontDir = '/system/fonts/';
-    // Use two sets to deduplicate. Emoji fonts are appended at the end so that
-    // they are not matched before text fonts during shaping.
     let pathSet = new Set<string>();
     let emojiPathSet = new Set<string>();
     try {
       let fileNames = fileIo.listFileSync(systemFontDir);
       for (const fileName of fileNames) {
         let lowerCaseName = fileName.toLowerCase();
-        if (!lowerCaseName.endsWith('.ttf') && !lowerCaseName.endsWith('.ttc') &&
-          !lowerCaseName.endsWith('.otf')) {
+        // Skip .ttc: the native SetFallbackFontPaths hardcodes ttcIndex to 0, so only
+        // the first subface of a collection would ever be reachable as a fallback.
+        if (!lowerCaseName.endsWith('.ttf') && !lowerCaseName.endsWith('.otf')) {
           continue;
         }
         let path = systemFontDir + fileName;
+        // listFileSync also returns subdirectory names; skip anything that is not a
+        // regular file so a directory named like a font is not registered as a path.
+        if (fileIo.statSync(path).isDirectory()) {
+          continue;
+        }
         if (lowerCaseName.includes('emoji')) {
           emojiPathSet.add(path);
         } else {
@@ -82,22 +108,22 @@ export class PAGInit {
       console.warn('[PAGInit] scan system font directory failed: ' + e);
       return false;
     }
-    let paths = Array.from(pathSet).concat(Array.from(emojiPathSet));
-    if (paths.length === 0) {
-      return false;
-    }
-    JPAGFont.SetFallbackFontPaths(paths);
-    return true;
+    return PAGInit.RegisterFallbackPaths(pathSet, emojiPathSet);
   }
 
-  // Use the new text module API (API14+). Only used as a fallback when the system
-  // font directory is inaccessible.
+  // Use the new text module API (API14+) to register the curated, ordered fallback list.
   private static InitFontFallbackWithTextModule() {
+    if (!text) {
+      console.warn('[PAGInit] text module is not available, skip font fallback initialization');
+      return;
+    }
     text.getSystemFontFullNamesByType(text.SystemFontType.ALL).then((fontNames: string[]) => {
       if (!fontNames || fontNames.length === 0) {
         return;
       }
-      Promise.all(fontNames.map(fontName =>
+      // Return the inner promise so a rejection propagates to the outer catch instead
+      // of becoming an unhandled promise rejection.
+      return Promise.all(fontNames.map(fontName =>
         text.getFontDescriptorByFullName(fontName, text.SystemFontType.ALL)
       )).then((descriptors) => {
         let pathSet = new Set<string>();
@@ -112,10 +138,7 @@ export class PAGInit {
             pathSet.add(descriptor.path);
           }
         }
-        let paths = Array.from(pathSet).concat(Array.from(emojiPathSet));
-        if (paths.length > 0) {
-          JPAGFont.SetFallbackFontPaths(paths);
-        }
+        PAGInit.RegisterFallbackPaths(pathSet, emojiPathSet);
       });
     }).catch((e: Object) => {
       console.warn('[PAGInit] InitFontFallbackWithTextModule failed: ' + e);
@@ -124,13 +147,16 @@ export class PAGInit {
 
   // Use the legacy font module API (below API14).
   private static InitFontFallbackWithFontModule() {
+    if (!font) {
+      console.warn('[PAGInit] font module is not available, skip font fallback initialization');
+      return;
+    }
     let fontConfig = font.getUIFontConfig();
     if (!fontConfig || !fontConfig.fallbackGroups) {
       console.warn('[PAGInit] fontConfig is not available, skip font fallback initialization');
       return;
     }
 
-    // Use two sets to deduplicate, emoji fonts will be appended at the end
     let pathSet = new Set<string>();
     let emojiPathSet = new Set<string>();
     for (const element of fontConfig.fallbackGroups) {
@@ -151,7 +177,7 @@ export class PAGInit {
         }
       }
     }
-    JPAGFont.SetFallbackFontPaths(Array.from(pathSet).concat(Array.from(emojiPathSet)));
+    PAGInit.RegisterFallbackPaths(pathSet, emojiPathSet);
   }
 
   private static InitCacheDir() {

--- a/ohos/libpag/src/main/ets/PAGInit.ets
+++ b/ohos/libpag/src/main/ets/PAGInit.ets
@@ -121,63 +121,77 @@ export class PAGInit {
 
   // Use the new text module API (API14+) to register the curated, ordered fallback list.
   private static InitFontFallbackWithTextModule() {
-    text.getSystemFontFullNamesByType(text.SystemFontType.ALL).then((fontNames: string[]) => {
-      if (!fontNames || fontNames.length === 0) {
-        return;
-      }
-      // Return the inner promise so a rejection propagates to the outer catch instead
-      // of becoming an unhandled promise rejection.
-      return Promise.all(fontNames.map(fontName =>
-        text.getFontDescriptorByFullName(fontName, text.SystemFontType.ALL)
-      )).then((descriptors) => {
-        let pathSet = new Set<string>();
-        let emojiPathSet = new Set<string>();
-        for (const descriptor of descriptors) {
-          if (!descriptor || !descriptor.path) {
-            continue;
-          }
-          if ((descriptor.fullName || '').toLowerCase().includes('emoji')) {
-            emojiPathSet.add(descriptor.path);
-          } else {
-            pathSet.add(descriptor.path);
-          }
+    try {
+      // Wrap the entry call: the text module object can occasionally be undefined at
+      // runtime, and getSystemFontFullNamesByType then throws a synchronous TypeError
+      // that the promise .catch below cannot intercept and would escape Init().
+      text.getSystemFontFullNamesByType(text.SystemFontType.ALL).then((fontNames: string[]) => {
+        if (!fontNames || fontNames.length === 0) {
+          return;
         }
-        PAGInit.RegisterFallbackPaths(pathSet, emojiPathSet);
+        // Return the inner promise so a rejection propagates to the outer catch instead
+        // of becoming an unhandled promise rejection.
+        return Promise.all(fontNames.map(fontName =>
+          text.getFontDescriptorByFullName(fontName, text.SystemFontType.ALL)
+        )).then((descriptors) => {
+          let pathSet = new Set<string>();
+          let emojiPathSet = new Set<string>();
+          for (const descriptor of descriptors) {
+            if (!descriptor || !descriptor.path) {
+              continue;
+            }
+            if ((descriptor.fullName || '').toLowerCase().includes('emoji')) {
+              emojiPathSet.add(descriptor.path);
+            } else {
+              pathSet.add(descriptor.path);
+            }
+          }
+          PAGInit.RegisterFallbackPaths(pathSet, emojiPathSet);
+        });
+      }).catch((e: Object) => {
+        console.warn('[PAGInit] InitFontFallbackWithTextModule failed: ' + e);
       });
-    }).catch((e: Object) => {
-      console.warn('[PAGInit] InitFontFallbackWithTextModule failed: ' + e);
-    });
+    } catch (e) {
+      console.warn('[PAGInit] text module is not available: ' + e);
+    }
   }
 
   // Use the legacy font module API (below API14).
   private static InitFontFallbackWithFontModule() {
-    let fontConfig = font.getUIFontConfig();
-    if (!fontConfig || !fontConfig.fallbackGroups) {
-      console.warn('[PAGInit] fontConfig is not available, skip font fallback initialization');
-      return;
-    }
-
-    let pathSet = new Set<string>();
-    let emojiPathSet = new Set<string>();
-    for (const element of fontConfig.fallbackGroups) {
-      if (!element || !element.fallback) {
-        continue;
+    try {
+      // font.getUIFontConfig() throws when the font module object is undefined at
+      // runtime (the root cause of the historical #3232 crash), so guard the call
+      // to keep the exception from escaping Init().
+      let fontConfig = font.getUIFontConfig();
+      if (!fontConfig || !fontConfig.fallbackGroups) {
+        console.warn('[PAGInit] fontConfig is not available, skip font fallback initialization');
+        return;
       }
-      for (const fallback of element.fallback) {
-        let fontInfo = font.getFontByName(fallback.family);
-        if (fontInfo == null) {
-          fontInfo = font.getFontByName(fallback.family + " Regular");
+
+      let pathSet = new Set<string>();
+      let emojiPathSet = new Set<string>();
+      for (const element of fontConfig.fallbackGroups) {
+        if (!element || !element.fallback) {
+          continue;
         }
-        if (fontInfo != null) {
-          if (fontInfo.fullName.toLowerCase().includes("emoji")) {
-            emojiPathSet.add(fontInfo.path);
-          } else {
-            pathSet.add(fontInfo.path);
+        for (const fallback of element.fallback) {
+          let fontInfo = font.getFontByName(fallback.family);
+          if (fontInfo == null) {
+            fontInfo = font.getFontByName(fallback.family + " Regular");
+          }
+          if (fontInfo != null) {
+            if (fontInfo.fullName.toLowerCase().includes("emoji")) {
+              emojiPathSet.add(fontInfo.path);
+            } else {
+              pathSet.add(fontInfo.path);
+            }
           }
         }
       }
+      PAGInit.RegisterFallbackPaths(pathSet, emojiPathSet);
+    } catch (e) {
+      console.warn('[PAGInit] font module is not available: ' + e);
     }
-    PAGInit.RegisterFallbackPaths(pathSet, emojiPathSet);
   }
 
   private static InitCacheDir() {

--- a/ohos/libpag/src/main/ets/PAGInit.ets
+++ b/ohos/libpag/src/main/ets/PAGInit.ets
@@ -19,6 +19,7 @@
 import { deviceInfo } from '@kit.BasicServicesKit';
 import { text } from '@kit.ArkGraphics2D';
 import { font } from '@kit.ArkUI';
+import { fileIo } from '@kit.CoreFileKit';
 import { JPAGDiskCache, JPAGFont } from 'libpag.so';
 
 export class PAGInit {
@@ -34,41 +35,94 @@ export class PAGInit {
   private static hasInit: boolean = false;
 
   private static InitFontFallback() {
-    // API14+: prefer the new async API, fallback to the legacy API on failure
-    if (deviceInfo.sdkApiVersion >= 14) {
-      PAGInit.InitFontFallbackWithTextModule().then((success: boolean) => {
-        if (!success) {
-          PAGInit.InitFontFallbackWithFontModule();
-        }
-      });
+    // Synchronously scan the system font directory and register the fallback
+    // fonts before Init() returns. This is critical for correctness: PAGFile.Load
+    // triggers the first text shaping synchronously right after Init(), while the
+    // text module API (getSystemFontFullNamesByType) can only be consumed
+    // asynchronously. If the fallback list is registered asynchronously, the first
+    // shaping runs against an empty fallback list, produces empty glyphs and caches
+    // them, leaving the text invisible even after the fonts are registered later.
+    if (PAGInit.InitFontFallbackFromSystemDir()) {
       return;
     }
 
-    // Below API14: use the legacy API
+    // Fallback path when the system font directory is inaccessible (rare).
+    if (deviceInfo.sdkApiVersion >= 14) {
+      // font.getUIFontConfig() may crash on API14+, so use the text module API.
+      PAGInit.InitFontFallbackWithTextModule();
+      return;
+    }
     PAGInit.InitFontFallbackWithFontModule();
   }
 
-  // Use the new text module API (API14+)
-  private static async InitFontFallbackWithTextModule(): Promise<boolean> {
+  // Synchronously collect fonts from the system font directory and register them.
+  // Returns true when at least one font is registered.
+  private static InitFontFallbackFromSystemDir(): boolean {
+    const systemFontDir = '/system/fonts/';
+    // Use two sets to deduplicate. Emoji fonts are appended at the end so that
+    // they are not matched before text fonts during shaping.
+    let pathSet = new Set<string>();
+    let emojiPathSet = new Set<string>();
     try {
-      let fontNames: string[] = await text.getSystemFontFullNamesByType(text.SystemFontType.ALL);
-      if (fontNames && fontNames.length > 0) {
-        let descriptors = await Promise.all(fontNames.map(fontName =>
-          text.getFontDescriptorByFullName(fontName, text.SystemFontType.ALL)
-        ));
-        let paths = Array.from(new Set(descriptors.filter(d => d && d.path).map(d => d.path)));
-        if (paths.length > 0) {
-          JPAGFont.SetFallbackFontPaths(paths);
-          return true;
+      let fileNames = fileIo.listFileSync(systemFontDir);
+      for (const fileName of fileNames) {
+        let lowerCaseName = fileName.toLowerCase();
+        if (!lowerCaseName.endsWith('.ttf') && !lowerCaseName.endsWith('.ttc') &&
+          !lowerCaseName.endsWith('.otf')) {
+          continue;
+        }
+        let path = systemFontDir + fileName;
+        if (lowerCaseName.includes('emoji')) {
+          emojiPathSet.add(path);
+        } else {
+          pathSet.add(path);
         }
       }
     } catch (e) {
-      console.warn('[PAGInit] text.getSystemFontFullNamesByType failed: ' + e);
+      console.warn('[PAGInit] scan system font directory failed: ' + e);
+      return false;
     }
-    return false;
+    let paths = Array.from(pathSet).concat(Array.from(emojiPathSet));
+    if (paths.length === 0) {
+      return false;
+    }
+    JPAGFont.SetFallbackFontPaths(paths);
+    return true;
   }
 
-  // Use the legacy font module API
+  // Use the new text module API (API14+). Only used as a fallback when the system
+  // font directory is inaccessible.
+  private static InitFontFallbackWithTextModule() {
+    text.getSystemFontFullNamesByType(text.SystemFontType.ALL).then((fontNames: string[]) => {
+      if (!fontNames || fontNames.length === 0) {
+        return;
+      }
+      Promise.all(fontNames.map(fontName =>
+        text.getFontDescriptorByFullName(fontName, text.SystemFontType.ALL)
+      )).then((descriptors) => {
+        let pathSet = new Set<string>();
+        let emojiPathSet = new Set<string>();
+        for (const descriptor of descriptors) {
+          if (!descriptor || !descriptor.path) {
+            continue;
+          }
+          if ((descriptor.fullName || '').toLowerCase().includes('emoji')) {
+            emojiPathSet.add(descriptor.path);
+          } else {
+            pathSet.add(descriptor.path);
+          }
+        }
+        let paths = Array.from(pathSet).concat(Array.from(emojiPathSet));
+        if (paths.length > 0) {
+          JPAGFont.SetFallbackFontPaths(paths);
+        }
+      });
+    }).catch((e: Object) => {
+      console.warn('[PAGInit] InitFontFallbackWithTextModule failed: ' + e);
+    });
+  }
+
+  // Use the legacy font module API (below API14).
   private static InitFontFallbackWithFontModule() {
     let fontConfig = font.getUIFontConfig();
     if (!fontConfig || !fontConfig.fallbackGroups) {

--- a/ohos/libpag/src/main/ets/PAGInit.ets
+++ b/ohos/libpag/src/main/ets/PAGInit.ets
@@ -93,10 +93,18 @@ export class PAGInit {
           continue;
         }
         let path = systemFontDir + fileName;
-        // listFileSync also returns subdirectory names; skip anything that is not a
-        // regular file so a directory named like a font is not registered as a path.
-        if (fileIo.statSync(path).isDirectory()) {
-          continue;
+        // listFileSync also returns subdirectory names. Guard statSync per file:
+        // some protected entries under /system/fonts throw "Permission denied",
+        // which must not abort scanning the whole directory. Only skip confirmed
+        // directories; when stat is unavailable, keep the path since the ArkTS
+        // stat permission differs from the native file read permission, and let
+        // the native loader safely reject anything it cannot open.
+        try {
+          if (fileIo.statSync(path).isDirectory()) {
+            continue;
+          }
+        } catch (e) {
+          // Keep the path; native Typeface loading will skip unreadable files.
         }
         if (lowerCaseName.includes('emoji')) {
           emojiPathSet.add(path);
@@ -113,10 +121,6 @@ export class PAGInit {
 
   // Use the new text module API (API14+) to register the curated, ordered fallback list.
   private static InitFontFallbackWithTextModule() {
-    if (!text) {
-      console.warn('[PAGInit] text module is not available, skip font fallback initialization');
-      return;
-    }
     text.getSystemFontFullNamesByType(text.SystemFontType.ALL).then((fontNames: string[]) => {
       if (!fontNames || fontNames.length === 0) {
         return;
@@ -147,10 +151,6 @@ export class PAGInit {
 
   // Use the legacy font module API (below API14).
   private static InitFontFallbackWithFontModule() {
-    if (!font) {
-      console.warn('[PAGInit] font module is not available, skip font fallback initialization');
-      return;
-    }
     let fontConfig = font.getUIFontConfig();
     if (!fontConfig || !fontConfig.fallbackGroups) {
       console.warn('[PAGInit] fontConfig is not available, skip font fallback initialization');


### PR DESCRIPTION
## 问题

HarmonyOS 上文字图层不渲染（文字不可见）。

根因：字体 fallback 列表是异步注册的（text module API 只能异步消费），但 `PAGFile.Load` 在 `Init()` 之后会同步触发首次文字 shaping。首次 shaping 运行时 fallback 列表为空，生成了空字形并被缓存，导致即使之后字体注册成功，文字依然不可见。

## 修复

改为在 `Init()` 返回前**同步**扫描系统字体目录 `/system/fonts/` 并注册 fallback 字体，确保首次同步 shaping 之前 fallback 列表已就绪：

- 新增 `InitFontFallbackFromSystemDir()`：同步 `fileIo.listFileSync` 扫描 `/system/fonts/`，按扩展名（`.ttf/.ttc/.otf`）过滤，用两个 Set 去重（emoji 字体追加到末尾，避免在 shaping 时先于文本字体被匹配）。
- 仅当系统字体目录不可访问（极罕见）时，才回退到原有的异步 text module API（API14+）或 legacy font module API（API14 以下）。

关联 discussion #3648