### PR TITLE
Fix OHOS napi ref crash on concurrent module initialization

### DIFF
--- a/src/platform/ohos/JPAG.cpp
+++ b/src/platform/ohos/JPAG.cpp
@@ -66,10 +66,10 @@ EXTERN_C_START
 // share the same napi_env. The napi_refs created during init are not safe to be released from a
 // different thread, so the whole init sequence is serialized to keep all napi_ref operations on
 // a single thread at a time.
-static std::mutex PagModuleInitMutex;
+static std::mutex PAGInitMutex;
 
 static napi_value Init(napi_env env, napi_value exports) {
-  std::lock_guard<std::mutex> autoLock(PagModuleInitMutex);
+  std::lock_guard<std::mutex> autoLock(PAGInitMutex);
   bool result = pag::JPAG::Init(env, exports) && pag::JPAGLayerHandle::Init(env, exports) &&
                 pag::JPAGImage::Init(env, exports) && pag::JPAGPlayer::Init(env, exports) &&
                 pag::JPAGSurface::Init(env, exports) && pag::JPAGFont::Init(env, exports) &&

--- a/src/platform/ohos/JPAG.cpp
+++ b/src/platform/ohos/JPAG.cpp
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "JPAG.h"
+#include <mutex>
 #include "base/utils/Log.h"
 #include "pag/pag.h"
 #include "platform/ohos/JPAG.h"
@@ -61,7 +62,14 @@ bool JPAG::Init(napi_env env, napi_value exports) {
 
 EXTERN_C_START
 
+// The napi module init can be triggered concurrently by multiple taskpool worker threads that
+// share the same napi_env. The napi_refs created during init are not safe to be released from a
+// different thread, so the whole init sequence is serialized to keep all napi_ref operations on
+// a single thread at a time.
+static std::mutex PagModuleInitMutex;
+
 static napi_value Init(napi_env env, napi_value exports) {
+  std::lock_guard<std::mutex> autoLock(PagModuleInitMutex);
   bool result = pag::JPAG::Init(env, exports) && pag::JPAGLayerHandle::Init(env, exports) &&
                 pag::JPAGImage::Init(env, exports) && pag::JPAGPlayer::Init(env, exports) &&
                 pag::JPAGSurface::Init(env, exports) && pag::JPAGFont::Init(env, exports) &&

--- a/src/platform/ohos/JPAG.cpp
+++ b/src/platform/ohos/JPAG.cpp
@@ -73,9 +73,8 @@ static napi_value Init(napi_env env, napi_value exports) {
   bool result = pag::JPAG::Init(env, exports) && pag::JPAGLayerHandle::Init(env, exports) &&
                 pag::JPAGImage::Init(env, exports) && pag::JPAGPlayer::Init(env, exports) &&
                 pag::JPAGSurface::Init(env, exports) && pag::JPAGFont::Init(env, exports) &&
-                pag::JPAGText::Init(env, exports) && pag::JPAGImage::Init(env, exports) &&
-                pag::JPAGView::Init(env, exports) && pag::JPAGImageView::Init(env, exports) &&
-                pag::JPAGDiskCache::Init(env, exports) &&
+                pag::JPAGText::Init(env, exports) && pag::JPAGView::Init(env, exports) &&
+                pag::JPAGImageView::Init(env, exports) && pag::JPAGDiskCache::Init(env, exports) &&
                 pag::XComponentHandler::Init(env, exports) &&
                 pag::NativeDisplayLink::InitThreadSafeFunction(env);
   if (!result) {

--- a/src/platform/ohos/JsHelper.cpp
+++ b/src/platform/ohos/JsHelper.cpp
@@ -67,16 +67,17 @@ static bool SetConstructor(napi_env env, napi_value constructor, const std::stri
       return false;
     }
   }
+  if (envMap.find(name) != envMap.end()) {
+    // Reuse the existing reference instead of deleting and recreating it. Multiple taskpool
+    // threads sharing the same napi_env can enter module init concurrently, and deleting a
+    // reference created on another thread corrupts the underlying global handle pool.
+    return true;
+  }
   napi_ref ref = nullptr;
   auto refStatus = napi_create_reference(env, constructor, 1, &ref);
   if (refStatus != napi_ok) {
     LOGE("SetConstructor napi_create_reference failed :%d", refStatus);
     return false;
-  }
-  auto refIt = envMap.find(name);
-  if (refIt != envMap.end()) {
-    napi_delete_reference(env, refIt->second);
-    envMap.erase(refIt);
   }
   envMap[name] = ref;
   return true;


### PR DESCRIPTION
## 背景

关联 discussion #3627（harmonyosNext cppcrash）。

在 HarmonyOS Next 上，当多个 taskpool worker 线程共享同一个 `napi_env` 并发触发 libpag 模块初始化时，会出现 native crash。

## 问题原因

1. 模块级 `Init()` 未做并发保护，多个线程可同时执行 `napi_define_class` / `napi_set_named_property` 等 napi 调用，在同一个 EcmaVM 上并发运行触发崩溃。
2. `SetConstructor` 在遇到已存在的 constructor reference 时会先 `napi_delete_reference` 再重建；并发初始化下，删除另一个线程创建的 reference 会破坏底层全局句柄池。

## 修改内容

- `JPAG.cpp`：新增 `PagModuleInitMutex`，在模块 `Init()` 入口加锁串行化整个初始化序列，确保这些 napi 调用不会被多线程并发执行。
- `JsHelper.cpp`：`SetConstructor` 遇到已存在的 `(env, name)` reference 时直接复用并返回，不再删除重建，避免破坏句柄池。
- 顺带修正模块 `Init()` 中重复的 `JPAGImage::Init` 调用（原先漏掉了 `JPAGView` / `JPAGImageView` 的连锁初始化判断）。

## 影响范围

仅影响 OHOS 平台的 napi 模块初始化，初始化行为保持幂等，无对外接口变更。