### PR TITLE
Add alphaInverted, luminanceInverted and contourInverted mask types to PAGX layers.

### DIFF
--- a/.codebuddy/skills/pagx/references/attributes.md
+++ b/.codebuddy/skills/pagx/references/attributes.md
@@ -66,7 +66,7 @@ Basic container for content, child layers, styles, and filters.
 | `composition` | idref | — | Composition reference "@id" for content reuse |
 | `import` | string | — | Path to external file to import (relative to the PAGX file); format inferred from extension |
 | `importFormat` | string | — | Force import format (e.g., `svg`); inferred from file extension when omitted |
-| `maskType` | MaskType | alpha | Mask type (alpha, luminance, or contour) |
+| `maskType` | MaskType | alpha | Mask type (alpha, luminance, contour, alphaInverted, luminanceInverted, or contourInverted) |
 
 Layer also supports all constraint attributes. See §Constraint Attributes below.
 
@@ -574,7 +574,7 @@ Path `data` uses SVG `<path d="...">` syntax exactly. Uppercase = absolute, lowe
 | Enum | Values |
 |------|--------|
 | **BlendMode** | `normal`, `multiply`, `screen`, `overlay`, `darken`, `lighten`, `colorDodge`, `colorBurn`, `hardLight`, `softLight`, `difference`, `exclusion`, `hue`, `saturation`, `color`, `luminosity`, `plusLighter`, `plusDarker` |
-| **MaskType** | `alpha`, `luminance`, `contour` |
+| **MaskType** | `alpha`, `luminance`, `contour`, `alphaInverted`, `luminanceInverted`, `contourInverted` |
 | **TileMode** | `clamp`, `repeat`, `mirror`, `decal` |
 | **FilterMode** | `nearest`, `linear` |
 | **MipmapMode** | `none`, `nearest`, `linear` |

--- a/.codebuddy/skills/pagx/references/guide.md
+++ b/.codebuddy/skills/pagx/references/guide.md
@@ -339,7 +339,7 @@ Write in this order: VectorElements → child Layers → LayerStyles → LayerFi
 | `blendMode` | normal | CSS `mix-blend-mode` names, camelCase |
 | `visible` | true | Whether rendered |
 | `mask` | — | `@id` reference to mask layer |
-| `maskType` | alpha | `alpha` / `luminance` / `contour` |
+| `maskType` | alpha | `alpha` / `luminance` / `contour` / `alphaInverted` / `luminanceInverted` / `contourInverted` |
 | `clipToBounds` | false | Clip content to layer bounds |
 | `composition` | — | `@id` reference to Composition |
 
@@ -366,7 +366,8 @@ Filters are the final rendering stage. They chain in document order.
 ## Masking and Clipping
 
 - **Mask**: `mask="@id"` references a mask Layer. `maskType`: alpha (soft-edge),
-  luminance (brightness-based), contour (hard-edge clipping). Mask layer is not rendered.
+  luminance (brightness-based), contour (hard-edge clipping), plus the inverted
+  variants alphaInverted / luminanceInverted / contourInverted. Mask layer is not rendered.
 - **clipToBounds**: Clips to layer bounds (GPU-accelerated). Prefer over rectangular masks.
 
 ---

--- a/include/pagx/nodes/Layer.h
+++ b/include/pagx/nodes/Layer.h
@@ -133,8 +133,8 @@ class Layer : public Node, public LayoutNode {
   Layer* mask = nullptr;
 
   /**
-   * The type of masking to apply (Alpha, Luminance, or Contour).
-   * The default value is Alpha.
+   * The type of masking to apply (Alpha, Luminance, Contour, AlphaInverted, LuminanceInverted,
+   * or ContourInverted). The default value is Alpha.
    */
   MaskType maskType = MaskType::Alpha;
 

--- a/include/pagx/types/MaskType.h
+++ b/include/pagx/types/MaskType.h
@@ -35,7 +35,22 @@ enum class MaskType {
   /**
    * Use the contour (outline) of the mask for masking.
    */
-  Contour
+  Contour,
+  /**
+   * Use the inverted alpha channel of the mask to determine visibility. The layer content is
+   * visible where the mask is transparent and hidden where the mask is opaque.
+   */
+  AlphaInverted,
+  /**
+   * Use the inverted luminance of the mask to determine visibility. The layer content is visible
+   * where the mask is dark and hidden where the mask is bright.
+   */
+  LuminanceInverted,
+  /**
+   * Use the inverted contour (outline) of the mask for masking. The layer content is visible
+   * outside the mask's contour and hidden inside it.
+   */
+  ContourInverted
 };
 
 }  // namespace pagx

--- a/spec/pagx.xsd
+++ b/spec/pagx.xsd
@@ -163,6 +163,9 @@
       <xs:enumeration value="alpha"/>
       <xs:enumeration value="luminance"/>
       <xs:enumeration value="contour"/>
+      <xs:enumeration value="alphaInverted"/>
+      <xs:enumeration value="luminanceInverted"/>
+      <xs:enumeration value="contourInverted"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/spec/pagx_spec.md
+++ b/spec/pagx_spec.md
@@ -988,6 +988,9 @@ Layer child elements are automatically categorized into five collections by type
 | `alpha` | Alpha mask: Uses mask's alpha channel |
 | `luminance` | Luminance mask: Uses mask's luminance values |
 | `contour` | Contour mask: Uses mask's contour for clipping |
+| `alphaInverted` | Inverted alpha mask: Content is visible where the mask is transparent |
+| `luminanceInverted` | Inverted luminance mask: Content is visible where the mask is dark |
+| `contourInverted` | Inverted contour mask: Content is visible outside the mask's contour |
 
 **BlendMode**: See §2.9 for the complete blend mode table.
 
@@ -2888,7 +2891,7 @@ Additionally, `Layer` (but not `Group`) may contain `<svg>` as an import directi
 | Enum | Values |
 |------|--------|
 | **BlendMode** | `normal`, `multiply`, `screen`, `overlay`, `darken`, `lighten`, `colorDodge`, `colorBurn`, `hardLight`, `softLight`, `difference`, `exclusion`, `hue`, `saturation`, `color`, `luminosity`, `plusLighter`, `plusDarker` |
-| **MaskType** | `alpha`, `luminance`, `contour` |
+| **MaskType** | `alpha`, `luminance`, `contour`, `alphaInverted`, `luminanceInverted`, `contourInverted` |
 | **TileMode** | `clamp`, `repeat`, `mirror`, `decal` |
 | **FilterMode** | `nearest`, `linear` |
 | **MipmapMode** | `none`, `nearest`, `linear` |

--- a/spec/pagx_spec.zh_CN.md
+++ b/spec/pagx_spec.zh_CN.md
@@ -988,6 +988,9 @@ Layer 的子元素按类型自动归类为五个集合：
 | `alpha` | Alpha 遮罩：使用遮罩的 alpha 通道 |
 | `luminance` | 亮度遮罩：使用遮罩的亮度值 |
 | `contour` | 轮廓遮罩：使用遮罩的轮廓进行裁剪 |
+| `alphaInverted` | 反转 Alpha 遮罩：遮罩透明处显示内容 |
+| `luminanceInverted` | 反转亮度遮罩：遮罩暗处显示内容 |
+| `contourInverted` | 反转轮廓遮罩：遮罩轮廓外显示内容 |
 
 **BlendMode**：见 2.9 节混合模式完整表格。
 
@@ -2880,7 +2883,7 @@ Layer / Group
 | 枚举 | 值 |
 |------|------|
 | **BlendMode** | `normal`, `multiply`, `screen`, `overlay`, `darken`, `lighten`, `colorDodge`, `colorBurn`, `hardLight`, `softLight`, `difference`, `exclusion`, `hue`, `saturation`, `color`, `luminosity`, `plusLighter`, `plusDarker` |
-| **MaskType** | `alpha`, `luminance`, `contour` |
+| **MaskType** | `alpha`, `luminance`, `contour`, `alphaInverted`, `luminanceInverted`, `contourInverted` |
 | **TileMode** | `clamp`, `repeat`, `mirror`, `decal` |
 | **FilterMode** | `nearest`, `linear` |
 | **MipmapMode** | `none`, `nearest`, `linear` |

--- a/src/pagx/html/HTMLWriterFilter.cpp
+++ b/src/pagx/html/HTMLWriterFilter.cpp
@@ -443,7 +443,10 @@ std::string HTMLWriter::writeMaskCSS(const Layer* mask, MaskType type, Point mas
     }
   }
 
-  bool useFillColor = (type == MaskType::Luminance && maskFill != nullptr && maskFill->color);
+  bool isLuminance = (type == MaskType::Luminance || type == MaskType::LuminanceInverted);
+  bool inverted = (type == MaskType::AlphaInverted || type == MaskType::LuminanceInverted ||
+                   type == MaskType::ContourInverted);
+  bool useFillColor = (isLuminance && maskFill != nullptr && maskFill->color);
   std::string fillAttr = "white";
   float fillOpacity = 1.0f;
 
@@ -672,30 +675,45 @@ std::string HTMLWriter::writeMaskCSS(const Layer* mask, MaskType type, Point mas
     }
   }
   std::string dataURI = "url('data:image/svg+xml," + encoded + "')";
-  std::string css = ";-webkit-mask-image:" + dataURI;
-  css += ";mask-image:" + dataURI;
-  if (type == MaskType::Luminance) {
+  // CSS masks have no inversion operator. Composite the mask layer with a fully opaque cover
+  // layer (white works for both alpha and luminance modes): exclude/destination-out computes
+  // cover minus shape, i.e. the inverted mask.
+  std::string coverLayer = inverted ? ",linear-gradient(#fff,#fff)" : "";
+  std::string css = ";-webkit-mask-image:" + dataURI + coverLayer;
+  css += ";mask-image:" + dataURI + coverLayer;
+  if (inverted) {
+    css += ";-webkit-mask-composite:destination-out;mask-composite:exclude";
+  }
+  if (isLuminance) {
     css += ";-webkit-mask-mode:luminance;mask-mode:luminance";
   } else {
     css += ";-webkit-mask-mode:alpha;mask-mode:alpha";
   }
   // The mask SVG uses document-absolute coordinates (the maskLayer sits at the document
-  // origin), but CSS mask-image starts at the masked element's own (0,0). Shift the mask
-  // back by the masked layer's render position so the two coordinate systems align.
-  if (!FloatNearlyZero(maskedLayerPos.x) || !FloatNearlyZero(maskedLayerPos.y)) {
-    std::string px = CssFloatToString(-maskedLayerPos.x) + "px";
-    std::string py = CssFloatToString(-maskedLayerPos.y) + "px";
-    css += ";-webkit-mask-position:" + px + " " + py;
-    css += ";mask-position:" + px + " " + py;
+  // origin), but CSS mask-image starts at the masked element's own (0,0). The SVG's viewBox
+  // begins at (minX, minY), so the mask image's top-left already sits at that offset in mask
+  // space: the shift is (min - maskedLayerPos), not just -maskedLayerPos. The cover layer needs
+  // no shift, it fills the element.
+  std::string coverPos = inverted ? ",0px 0px" : "";
+  float shiftX = minX - maskedLayerPos.x;
+  float shiftY = minY - maskedLayerPos.y;
+  if (!FloatNearlyZero(shiftX) || !FloatNearlyZero(shiftY) || inverted) {
+    std::string px = CssFloatToString(shiftX) + "px";
+    std::string py = CssFloatToString(shiftY) + "px";
+    css += ";-webkit-mask-position:" + px + " " + py + coverPos;
+    css += ";mask-position:" + px + " " + py + coverPos;
   }
   // mask-size and mask-repeat must always be pinned, not just when mask-position is used.
   // CSS defaults to `mask-size:auto` which resolves to `cover` in some browsers and to the
   // SVG's intrinsic size in others, and `mask-repeat:repeat` which would tile the mask SVG
   // across the masked element. Without explicit values a 100×100 mask on a 200×200 element
   // either stretches to fill (mask loses its clipping geometry, D1 section of
-  // optimizer_all_rules) or tiles into a checkerboard.
-  css += ";-webkit-mask-size:" + CssFloatToString(maxX) + "px " + CssFloatToString(maxY) + "px";
-  css += ";mask-size:" + CssFloatToString(maxX) + "px " + CssFloatToString(maxY) + "px";
+  // optimizer_all_rules) or tiles into a checkerboard. The size must match the SVG's intrinsic
+  // size (svgW × svgH), which spans min..max rather than 0..max.
+  std::string coverSize = inverted ? ",100% 100%" : "";
+  css += ";-webkit-mask-size:" + CssFloatToString(svgW) + "px " + CssFloatToString(svgH) + "px" +
+         coverSize;
+  css += ";mask-size:" + CssFloatToString(svgW) + "px " + CssFloatToString(svgH) + "px" + coverSize;
   css += ";-webkit-mask-repeat:no-repeat;mask-repeat:no-repeat";
   return css;
 }

--- a/src/pagx/html/importer/HTMLBoxAttributes.h
+++ b/src/pagx/html/importer/HTMLBoxAttributes.h
@@ -283,14 +283,16 @@ struct HTMLBoxAttributes {
   std::string filter = {};
   std::string backdropFilter = {};
 
-  // CSS `mask-image` / `mask-mode` / `mask-size` / `mask-position` for alpha and luminance masks.
-  // `maskImage` is the raw `url(data:image/svg+xml,...)` the HTML exporter emitted; the importer
-  // decodes the embedded SVG and rebuilds a PAGX mask layer from it (the inverse of
-  // `HTMLWriter::writeMaskCSS`). `maskMode` is the lower-cased keyword (`alpha` / `luminance`);
-  // `maskSize` / `maskPosition` are lower-cased and trimmed and drive the mask layer's scale /
-  // offset. All empty means "no mask authored".
+  // CSS `mask-image` / `mask-mode` / `mask-composite` / `mask-size` / `mask-position` for alpha,
+  // luminance and inverted masks. `maskImage` is the raw `url(data:image/svg+xml,...)` the HTML
+  // exporter emitted; the importer decodes the embedded SVG and rebuilds a PAGX mask layer from it
+  // (the inverse of `HTMLWriter::writeMaskCSS`). `maskMode` is the lower-cased keyword (`alpha` /
+  // `luminance`); `maskComposite` is the lower-cased compositing keyword (`exclude` marks the
+  // inverted variants); `maskSize` / `maskPosition` are lower-cased and trimmed and drive the mask
+  // layer's scale / offset. All empty means "no mask authored".
   std::string maskImage = {};
   std::string maskMode = {};
+  std::string maskComposite = {};
   std::string maskSize = {};
   std::string maskPosition = {};
 

--- a/src/pagx/html/importer/HTMLElementEmitter.cpp
+++ b/src/pagx/html/importer/HTMLElementEmitter.cpp
@@ -151,10 +151,20 @@ ScaleMode ResolveImageScaleMode(const std::string& objectFit) {
   return ScaleMode::Stretch;
 }
 
+// Returns the first comma-separated layer of a CSS layer list, trimmed. Mask longhands accept one
+// value per mask layer; the exporter puts the shape layer first and an inverted mask's opaque cover
+// layer second, so callers that model a single mask only ever want the leading layer.
+std::string FirstCssLayer(const std::string& value) {
+  auto layers = SplitTopLevelCommas(value);
+  return Trim(layers.empty() ? value : layers.front());
+}
+
 // Extracts the source string from a CSS `url(...)` token, stripping the wrapper, surrounding
-// whitespace, and matching quotes. Returns empty when `value` is not a `url(...)` form.
+// whitespace, and matching quotes. Returns empty when `value` is not a `url(...)` form. Only the
+// first comma-separated layer is considered, so an inverted mask's `url(...),linear-gradient(...)`
+// list resolves to the shape layer's url instead of running past it.
 std::string ExtractCssUrl(const std::string& value) {
-  std::string trimmed = Trim(value);
+  std::string trimmed = FirstCssLayer(value);
   std::string lower = ToLower(trimmed);
   auto open = lower.find("url(");
   if (open == std::string::npos) return {};
@@ -637,6 +647,12 @@ void HTMLParserContext::applyMaskOrClip(Layer* layer, const HTMLBoxAttributes& b
       return;
     }
     maskType = (box.maskMode == "luminance") ? MaskType::Luminance : MaskType::Alpha;
+    // The exporter marks inverted masks by compositing the shape layer with an opaque cover layer
+    // via mask-composite:exclude, so `exclude` maps back to the inverted variant.
+    if (box.maskComposite == "exclude") {
+      maskType =
+          (maskType == MaskType::Luminance) ? MaskType::LuminanceInverted : MaskType::AlphaInverted;
+    }
   } else {
     // CSS `clip-path`: either a `url(#id)` reference to a hidden <clipPath> def, or a basic shape
     // (`polygon()/path()/circle()/ellipse()/inset()`). Both are rebuilt into a contour mask framed
@@ -815,7 +831,9 @@ void HTMLParserContext::applyMaskSizeAndPosition(Layer* maskLayer, const HTMLBox
   // background/mask sizing model; the exporter's own output is the two-length form.
   float scaleX = 1.0f;
   float scaleY = 1.0f;
-  auto sizeTokens = SplitTopLevelWhitespace(box.maskSize);
+  // Only the first layer applies: an inverted mask pairs the shape layer with a cover layer, and
+  // the shape layer's descriptor leads both lists.
+  auto sizeTokens = SplitTopLevelWhitespace(FirstCssLayer(box.maskSize));
   std::string sizeW = sizeTokens.size() > 0 ? sizeTokens[0] : "";
   std::string sizeH = sizeTokens.size() > 1 ? sizeTokens[1] : "";
   if (sizeW == "contain" || sizeW == "cover") {
@@ -846,7 +864,7 @@ void HTMLParserContext::applyMaskSizeAndPosition(Layer* maskLayer, const HTMLBox
   // The scaled mask box used to resolve percentage / keyword `mask-position` against the element.
   float scaledW = intrinsicW * scaleX;
   float scaledH = intrinsicH * scaleY;
-  auto posTokens = SplitTopLevelWhitespace(box.maskPosition);
+  auto posTokens = SplitTopLevelWhitespace(FirstCssLayer(box.maskPosition));
   std::string posX = posTokens.size() > 0 ? posTokens[0] : "";
   // CSS resolves a single `mask-position` value as the horizontal axis with the vertical defaulting
   // to `center`, not to the leading edge. Two empty tokens keep the `0 0` top-left default below.

--- a/src/pagx/html/importer/HTMLStyleCascade.cpp
+++ b/src/pagx/html/importer/HTMLStyleCascade.cpp
@@ -867,10 +867,12 @@ void HTMLStyleCascade::parseBoxVisuals(HTMLBoxAttributes& box, const PropertyMap
   box.filter = LookupProperty(props, "filter");
   box.backdropFilter = LookupProperty(props, "backdrop-filter");
 
-  // Alpha / luminance mask descriptors. `mask-image` is kept raw (the `url(data:...)` wrapper is
-  // stripped at apply time); the rest are lower-cased so keyword comparisons are case-insensitive.
+  // Alpha / luminance / inverted mask descriptors. `mask-image` is kept raw (the `url(data:...)`
+  // wrapper is stripped at apply time); the rest are lower-cased so keyword comparisons are
+  // case-insensitive.
   box.maskImage = LookupProperty(props, "mask-image");
   box.maskMode = LookupLowerTrimmed(props, "mask-mode");
+  box.maskComposite = LookupLowerTrimmed(props, "mask-composite");
   box.maskSize = LookupLowerTrimmed(props, "mask-size");
   box.maskPosition = LookupLowerTrimmed(props, "mask-position");
   // `clip-path: url(#id)` reference, kept raw so the apply-side can extract the id.

--- a/src/pagx/html/importer/HTMLSubsetPropertyTable.cpp
+++ b/src/pagx/html/importer/HTMLSubsetPropertyTable.cpp
@@ -392,10 +392,13 @@ const PropertyEntry SubsetPropertyEntries[] = {
     {"background-position", PropAction::Keep, nullptr, nullptr},
     // Alpha / luminance masks. `mask-image` carries a `url(data:image/svg+xml,...)` whose SVG the
     // importer turns back into a PAGX mask layer; `mask-mode` selects Alpha vs Luminance and
-    // `mask-size` / `mask-position` drive the mask layer's scale / offset. Kept verbatim and
-    // consumed in HTMLStyleCascade::parseBoxVisuals (the inverse of HTMLWriter::writeMaskCSS).
+    // `mask-size` / `mask-position` drive the mask layer's scale / offset. `mask-composite`
+    // (exclude) marks the inverted variants, which the exporter emits as a two-layer mask.
+    // Kept verbatim and consumed in HTMLStyleCascade::parseBoxVisuals (the inverse of
+    // HTMLWriter::writeMaskCSS).
     {"mask-image", PropAction::Keep, nullptr, nullptr},
     {"mask-mode", PropAction::Keep, nullptr, nullptr},
+    {"mask-composite", PropAction::Keep, nullptr, nullptr},
     {"mask-size", PropAction::Keep, nullptr, nullptr},
     {"mask-position", PropAction::Keep, nullptr, nullptr},
     {"mask-repeat", PropAction::Keep, nullptr, nullptr},

--- a/src/pagx/svg/SVGExporter.cpp
+++ b/src/pagx/svg/SVGExporter.cpp
@@ -1705,6 +1705,22 @@ std::string SVGWriter::writeFilterAndStyleDefs(const std::vector<LayerFilter*>& 
 // SVGWriter – mask / clip-path defs
 //==============================================================================
 
+// Inverted mask types degrade to their base type for best-effort vector output: SVG masks
+// cannot express inversion, so the inversion is dropped here (the feature probe rasterizes
+// the layer instead when baking is enabled).
+static MaskType DegradeInvertedMaskType(MaskType type) {
+  switch (type) {
+    case MaskType::AlphaInverted:
+      return MaskType::Alpha;
+    case MaskType::LuminanceInverted:
+      return MaskType::Luminance;
+    case MaskType::ContourInverted:
+      return MaskType::Contour;
+    default:
+      return type;
+  }
+}
+
 std::string SVGWriter::writeMaskOrClipDef(const Layer* maskLayer, MaskType maskType) {
   // Reuse a previously-emitted def for the same (maskLayer, maskType). Without this cache, a
   // single mask Layer referenced by N owners produces N `<mask>` (or `<clipPath>`) elements
@@ -1712,13 +1728,14 @@ std::string SVGWriter::writeMaskOrClipDef(const Layer* maskLayer, MaskType maskT
   // the first and silently ignore the rest, but a regression that changes emission order would
   // re-wire all owners to a different copy.
   //
-  // MaskType participates in the key because the three values map to materially different SVG
+  // MaskType participates in the key because the values map to materially different SVG
   // output: Alpha and Luminance both emit `<mask>` but differ in `mask-type` (alpha channel vs
   // luminance, the SVG default), while Contour emits `<clipPath>` (geometry-only inside/outside
   // test). Without keying on MaskType, the second reference for a layer used in two roles
   // would silently inherit the first role's def — a luminance owner would render an alpha
   // mask, or a contour owner would receive a path mask — with no warning.
-  bool isClipPath = (maskType == MaskType::Contour);
+  auto baseType = DegradeInvertedMaskType(maskType);
+  bool isClipPath = (baseType == MaskType::Contour);
   const char* tag = isClipPath ? "clipPath" : "mask";
   const char* idPrefix = isClipPath ? "clip" : "mask";
   ContentWriter writer =
@@ -1749,12 +1766,21 @@ std::string SVGWriter::writeMaskOrClipDef(const Layer* maskLayer, MaskType maskT
       case MaskType::Contour:
         defId += "_c";
         break;
+      case MaskType::AlphaInverted:
+        defId += "_ai";
+        break;
+      case MaskType::LuminanceInverted:
+        defId += "_li";
+        break;
+      case MaskType::ContourInverted:
+        defId += "_ci";
+        break;
     }
   }
   SVGBuilder paintDefs(true, _indentSpaces);
   _defs->openElement(tag);
   _defs->addAttribute("id", defId);
-  if (maskType == MaskType::Alpha) {
+  if (baseType == MaskType::Alpha) {
     _defs->addAttribute("style", "mask-type:alpha");
   }
   _defs->closeElementStart();
@@ -3269,8 +3295,8 @@ void SVGWriter::writeLayer(SVGBuilder& out, const Layer* layer) {
     if (features.needsRasterization()) {
       addWarning("layer '" + (layer->id.empty() ? std::string("(unnamed)") : layer->id) +
                  "' uses SVG-unsupported features (TextPath / TextModifier / diamond or conic "
-                 "gradient) and bakeUnsupported is false; emitting as best-effort vector with "
-                 "those features dropped or downgraded to radial.");
+                 "gradient / inverted mask) and bakeUnsupported is false; emitting as best-effort"
+                 " vector with those features dropped or downgraded to radial.");
     }
   }
 
@@ -3435,7 +3461,7 @@ void SVGWriter::writeLayerOuterAttributes(SVGBuilder& out, const Layer* layer) {
   }
 
   if (layer->mask != nullptr) {
-    if (layer->maskType == MaskType::Contour) {
+    if (layer->maskType == MaskType::Contour || layer->maskType == MaskType::ContourInverted) {
       // Contour masking uses <clipPath> which only supports geometry clipping.
       auto clipId = writeClipPathDef(layer->mask, layer);
       out.addAttribute("clip-path", "url(#" + clipId + ")");

--- a/src/pagx/svg/SVGExporter.cpp
+++ b/src/pagx/svg/SVGExporter.cpp
@@ -1721,7 +1721,13 @@ static MaskType DegradeInvertedMaskType(MaskType type) {
   }
 }
 
-std::string SVGWriter::writeMaskOrClipDef(const Layer* maskLayer, MaskType maskType) {
+std::string SVGWriter::writeMaskOrClipDef(const Layer* maskLayer, MaskType requestedType) {
+  // SVG cannot express mask inversion, so inverted types are normalised to their base type up
+  // front: the emitted def, its cache key and its id suffix all key off the base type. Two owners
+  // referencing the same mask layer as Alpha and AlphaInverted therefore share one def instead of
+  // emitting two byte-identical `<mask>` elements.
+  auto maskType = DegradeInvertedMaskType(requestedType);
+
   // Reuse a previously-emitted def for the same (maskLayer, maskType). Without this cache, a
   // single mask Layer referenced by N owners produces N `<mask>` (or `<clipPath>`) elements
   // with the same id in <defs>, which is undefined per the SVG spec — browsers typically use
@@ -1734,8 +1740,7 @@ std::string SVGWriter::writeMaskOrClipDef(const Layer* maskLayer, MaskType maskT
   // test). Without keying on MaskType, the second reference for a layer used in two roles
   // would silently inherit the first role's def — a luminance owner would render an alpha
   // mask, or a contour owner would receive a path mask — with no warning.
-  auto baseType = DegradeInvertedMaskType(maskType);
-  bool isClipPath = (baseType == MaskType::Contour);
+  bool isClipPath = (maskType == MaskType::Contour);
   const char* tag = isClipPath ? "clipPath" : "mask";
   const char* idPrefix = isClipPath ? "clip" : "mask";
   ContentWriter writer =
@@ -1756,6 +1761,7 @@ std::string SVGWriter::writeMaskOrClipDef(const Layer* maskLayer, MaskType maskT
     defId = generateId(idPrefix);
   } else {
     defId = maskLayer->id;
+    // maskType is already normalised to a base type, so the inverted values never reach here.
     switch (maskType) {
       case MaskType::Alpha:
         defId += "_a";
@@ -1764,23 +1770,15 @@ std::string SVGWriter::writeMaskOrClipDef(const Layer* maskLayer, MaskType maskT
         defId += "_l";
         break;
       case MaskType::Contour:
+      default:
         defId += "_c";
-        break;
-      case MaskType::AlphaInverted:
-        defId += "_ai";
-        break;
-      case MaskType::LuminanceInverted:
-        defId += "_li";
-        break;
-      case MaskType::ContourInverted:
-        defId += "_ci";
         break;
     }
   }
   SVGBuilder paintDefs(true, _indentSpaces);
   _defs->openElement(tag);
   _defs->addAttribute("id", defId);
-  if (baseType == MaskType::Alpha) {
+  if (maskType == MaskType::Alpha) {
     _defs->addAttribute("style", "mask-type:alpha");
   }
   _defs->closeElementStart();

--- a/src/pagx/svg/SVGFeatureProbe.cpp
+++ b/src/pagx/svg/SVGFeatureProbe.cpp
@@ -86,6 +86,11 @@ SVGFeatureFlags ProbeLayerFeaturesForSVG(const Layer* layer) {
   if (layer == nullptr || !layer->visible) {
     return out;
   }
+  if (layer->mask != nullptr && (layer->maskType == MaskType::AlphaInverted ||
+                                 layer->maskType == MaskType::LuminanceInverted ||
+                                 layer->maskType == MaskType::ContourInverted)) {
+    out.hasInvertedMask = true;
+  }
   // Aggregating descendant flags here would force the smallest enclosing layer to bake the
   // entire sub-tree into one PNG when any grandchild trips the probe, which both blows up the
   // output size and turns surrounding native content into non-editable raster. Composition

--- a/src/pagx/svg/SVGFeatureProbe.h
+++ b/src/pagx/svg/SVGFeatureProbe.h
@@ -39,12 +39,14 @@ struct SVGFeatureFlags {
   bool hasTextModifier = false;     // TextModifier / RangeSelector (per-glyph animation styling).
   bool hasConicGradient = false;    // No SVG conic/sweep gradient primitive.
   bool hasDiamondGradient = false;  // No SVG diamond gradient primitive.
+  bool hasInvertedMask = false;     // SVG masks cannot express inverted alpha/luminance.
 
   /**
    * Returns true when at least one feature is present.
    */
   bool needsRasterization() const {
-    return hasTextPath || hasTextModifier || hasConicGradient || hasDiamondGradient;
+    return hasTextPath || hasTextModifier || hasConicGradient || hasDiamondGradient ||
+           hasInvertedMask;
   }
 };
 

--- a/src/pagx/utils/StringParser.cpp
+++ b/src/pagx/utils/StringParser.cpp
@@ -187,7 +187,10 @@ DEFINE_ENUM_CONVERSION(ScaleMode, ScaleMode::LetterBox, {ScaleMode::None, "none"
                        {ScaleMode::Zoom, "zoom"})
 
 DEFINE_ENUM_CONVERSION(MaskType, MaskType::Alpha, {MaskType::Alpha, "alpha"},
-                       {MaskType::Luminance, "luminance"}, {MaskType::Contour, "contour"})
+                       {MaskType::Luminance, "luminance"}, {MaskType::Contour, "contour"},
+                       {MaskType::AlphaInverted, "alphaInverted"},
+                       {MaskType::LuminanceInverted, "luminanceInverted"},
+                       {MaskType::ContourInverted, "contourInverted"})
 
 DEFINE_ENUM_CONVERSION(PolystarType, PolystarType::Polygon, {PolystarType::Polygon, "polygon"},
                        {PolystarType::Star, "star"})

--- a/src/renderer/ToTGFX.cpp
+++ b/src/renderer/ToTGFX.cpp
@@ -252,6 +252,12 @@ tgfx::LayerMaskType ToTGFXMaskType(MaskType type) {
       return tgfx::LayerMaskType::Luminance;
     case MaskType::Contour:
       return tgfx::LayerMaskType::Contour;
+    case MaskType::AlphaInverted:
+      return tgfx::LayerMaskType::AlphaInverted;
+    case MaskType::LuminanceInverted:
+      return tgfx::LayerMaskType::LuminanceInverted;
+    case MaskType::ContourInverted:
+      return tgfx::LayerMaskType::ContourInverted;
   }
   return tgfx::LayerMaskType::Alpha;
 }

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -8571,6 +8571,7 @@
     "PAGXTest": {
         "GetRequiredFontsCrossDocument": "8b84d883",
         "LayerBuilderAPIConsistency": "60a88e548",
+        "MaskInverted": "f3076fa68",
         "NoiseFilterAllElements": "60a88e548",
         "NoiseFilterAnimation": {
             "frame_0": "60a88e548",

--- a/test/src/PAGXHTMLImporterTest.cpp
+++ b/test/src/PAGXHTMLImporterTest.cpp
@@ -8222,6 +8222,34 @@ PAG_TEST(PAGXHTMLImporterTest, MaskImageAlphaRebuildsMaskLayer) {
   EXPECT_TRUE(NearlyEqual(ellipse->size.height, 110.0f, 0.01f));
 }
 
+// An inverted mask is exported as a two-layer `mask-image` list (shape plus an opaque cover layer)
+// composited with `mask-composite: exclude`. The importer must read only the first layer's url and
+// map the exclude keyword back to the inverted MaskType, otherwise the round trip either drops the
+// whole mask (url parsing hits the cover layer's bracket) or silently loses the inversion.
+PAG_TEST(PAGXHTMLImporterTest, MaskCompositeExcludeRebuildsInvertedMask) {
+  auto doc = ParseFromString(R"HTML(
+    <html><body style="width:110px;height:110px">
+      <div style="width:110px;height:110px;mask-image:url('data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%22110%22 height=%22110%22 viewBox=%220 0 110 110%22%3E%3Cellipse cx=%2255%22 cy=%2255%22 rx=%2255%22 ry=%2255%22 fill=%22white%22/%3E%3C/svg%3E'),linear-gradient(#fff,#fff);mask-composite:exclude;mask-mode:alpha;mask-size:110px 110px,100% 100%;mask-repeat:no-repeat">
+        <div style="width:110px;height:110px;background-color:#10B981"></div>
+      </div>
+    </body></html>
+  )HTML");
+  ASSERT_NE(doc, nullptr);
+  auto* masked = doc->layers.front()->children.front();
+  ASSERT_NE(masked->mask, nullptr) << "the two-layer mask list must still yield a mask layer";
+  EXPECT_EQ(masked->maskType, pagx::MaskType::AlphaInverted)
+      << "mask-composite:exclude must map back to the inverted mask type";
+  auto* ellipse = FindElementOfType<pagx::Ellipse>(masked->mask);
+  ASSERT_NE(ellipse, nullptr) << "the shape layer's SVG must still be decoded";
+  // mask-size / mask-position are per-layer lists too. Only the shape layer's descriptor applies:
+  // reading the cover layer's `100% 100%` as the height token would scale the mask geometry.
+  EXPECT_TRUE(NearlyEqual(ellipse->size.width, 110.0f, 0.01f));
+  EXPECT_TRUE(NearlyEqual(ellipse->size.height, 110.0f, 0.01f));
+  EXPECT_TRUE(NearlyEqual(masked->mask->matrix.a, 1.0f, 0.01f))
+      << "the shape layer's own mask-size must not be mixed with the cover layer's";
+  EXPECT_TRUE(NearlyEqual(masked->mask->matrix.d, 1.0f, 0.01f));
+}
+
 // A `mask-size` larger than the mask SVG's intrinsic size scales the rebuilt mask layer by the
 // per-axis ratio so the mask geometry covers the element CSS rendered it across, rather than
 // staying pinned at the smaller intrinsic size in the top-left corner. The ratios differ per axis

--- a/test/src/PAGXHtmlTest.cpp
+++ b/test/src/PAGXHtmlTest.cpp
@@ -791,6 +791,105 @@ CLI_TEST(PAGXHtmlTest, MaskAsChildNotEmittedAsContent) {
       << "the mask layer must not appear as visible content";
 }
 
+// Inverted mask types have no CSS inversion operator, so the exporter emits a two-layer mask:
+// the shape layer composited with a fully opaque cover layer via mask-composite:exclude
+// (webkit: destination-out), which computes cover minus shape — the inverted mask.
+CLI_TEST(PAGXHtmlTest, InvertedMaskUsesMaskComposite) {
+  std::string xml =
+      "<pagx width=\"200\" height=\"200\">"
+      "  <Layer mask=\"@mask\" maskType=\"alphaInverted\">"
+      "    <Rectangle width=\"180\" height=\"180\"/>"
+      "    <Fill color=\"#3399EE\"/>"
+      "  </Layer>"
+      "  <Layer id=\"mask\" left=\"10\" top=\"10\" width=\"50\" height=\"50\">"
+      "    <Rectangle width=\"50\" height=\"50\"/>"
+      "    <Fill color=\"#FFFFFF\"/>"
+      "  </Layer>"
+      "</pagx>";
+  auto html = LoadXMLAndConvert(xml);
+  ASSERT_FALSE(html.empty());
+  EXPECT_NE(html.find("mask-composite:exclude"), std::string::npos)
+      << "inverted mask must use mask-composite:exclude";
+  EXPECT_NE(html.find("-webkit-mask-composite:destination-out"), std::string::npos)
+      << "inverted mask must carry the webkit destination-out fallback";
+  EXPECT_NE(html.find("linear-gradient(#fff,#fff)"), std::string::npos)
+      << "inverted mask must add a fully opaque cover layer";
+  EXPECT_NE(html.find(",100% 100%"), std::string::npos)
+      << "the cover layer must be sized to fill the element";
+  // mask-position and mask-size must both carry two comma-separated values, otherwise the shape
+  // and cover layers stop lining up.
+  EXPECT_NE(html.find("mask-position:"), std::string::npos)
+      << "inverted mask must pin mask-position for both layers";
+  auto posStart = html.find("mask-position:");
+  auto posEnd = html.find(';', posStart);
+  ASSERT_NE(posEnd, std::string::npos);
+  auto posValue = html.substr(posStart, posEnd - posStart);
+  EXPECT_NE(posValue.find(','), std::string::npos)
+      << "mask-position must pair the shape and cover layers: " << posValue;
+}
+
+// luminanceInverted and contourInverted must also emit the two-layer composite. Luminance keeps
+// mask-mode:luminance; contour has no CSS clip-path inversion so it goes through the alpha path
+// with a solid opaque shape, which is geometry-equivalent for contour semantics.
+CLI_TEST(PAGXHtmlTest, InvertedMaskCoversLuminanceAndContour) {
+  auto build = [](const char* maskType) {
+    return std::string(
+               "<pagx width=\"200\" height=\"200\">"
+               "  <Layer mask=\"@mask\" maskType=\"") +
+           maskType +
+           "\">"
+           "    <Rectangle width=\"180\" height=\"180\"/>"
+           "    <Fill color=\"#3399EE\"/>"
+           "  </Layer>"
+           "  <Layer id=\"mask\" left=\"10\" top=\"10\" width=\"50\" height=\"50\">"
+           "    <Rectangle width=\"50\" height=\"50\"/>"
+           "    <Fill color=\"#FFFFFF\"/>"
+           "  </Layer>"
+           "</pagx>";
+  };
+
+  auto luma = LoadXMLAndConvert(build("luminanceInverted"));
+  ASSERT_FALSE(luma.empty());
+  EXPECT_NE(luma.find("mask-composite:exclude"), std::string::npos)
+      << "luminanceInverted must composite via exclude";
+  EXPECT_NE(luma.find("mask-mode:luminance"), std::string::npos)
+      << "luminanceInverted must stay in luminance mode";
+
+  auto contour = LoadXMLAndConvert(build("contourInverted"));
+  ASSERT_FALSE(contour.empty());
+  EXPECT_NE(contour.find("mask-composite:exclude"), std::string::npos)
+      << "contourInverted must composite via exclude";
+  EXPECT_NE(contour.find("mask-mode:alpha"), std::string::npos)
+      << "contourInverted has no CSS clip-path inversion, so it uses the alpha path";
+  EXPECT_EQ(contour.find("clip-path:url("), std::string::npos)
+      << "contourInverted must not fall back to a non-inverted clip-path";
+}
+
+// The mask SVG's intrinsic size spans the mask geometry's bounds (min..max) and its viewBox starts
+// at (minX, minY), so mask-size must be that span and mask-position must offset by min. Masks whose
+// geometry starts at the document origin make min=0, where the wrong formulas (max as the size, no
+// min compensation) happen to be identical — this case keeps a non-zero min so they stay apart.
+CLI_TEST(PAGXHtmlTest, MaskSizeAndPositionFollowMaskBounds) {
+  std::string xml =
+      "<pagx width=\"200\" height=\"120\">"
+      "  <Layer id=\"offMask\" visible=\"false\">"
+      "    <Ellipse position=\"120,60\" size=\"60,60\"/>"
+      "    <Fill color=\"#FFFFFF\"/>"
+      "  </Layer>"
+      "  <Layer mask=\"@offMask\" maskType=\"alpha\">"
+      "    <Rectangle position=\"100,60\" size=\"200,120\"/>"
+      "    <Fill color=\"#E11D48\"/>"
+      "  </Layer>"
+      "</pagx>";
+  auto html = LoadXMLAndConvert(xml);
+  ASSERT_FALSE(html.empty());
+  // The ellipse spans x 90..150 and y 30..90, so the mask SVG is 60x60 at (90, 30).
+  EXPECT_NE(html.find("mask-size:60px 60px"), std::string::npos)
+      << "mask-size must match the mask SVG's intrinsic size, not its max extent";
+  EXPECT_NE(html.find("mask-position:90px 30px"), std::string::npos)
+      << "mask-position must offset by the mask bounds' min corner";
+}
+
 CLI_TEST(PAGXHtmlTest, ScrollRectLayoutKeepsChildrenInFlexFlow) {
   pagx::HTMLExportOptions options;
   options.extractStyleSheet = false;

--- a/test/src/PAGXSVGTest.cpp
+++ b/test/src/PAGXSVGTest.cpp
@@ -4132,6 +4132,86 @@ PAGX_TEST(PAGXSVGTest, SVGExport_SharedMaskLayerDifferentMaskTypesEmitDistinctDe
 }
 
 /**
+ * SVG has no mask inversion operator. With bakeUnsupported=true (the default) an inverted mask
+ * trips the feature probe and the whole layer is rasterized to an <image>, preserving the visual
+ * result.
+ */
+PAGX_TEST(PAGXSVGTest, SVGExport_BakeUnsupportedRastersInvertedMask) {
+  auto doc = pagx::PAGXDocument::Make(200, 200);
+
+  auto* maskLayer = doc->makeNode<pagx::Layer>();
+  maskLayer->id = "invMask";
+  auto* maskRect = doc->makeNode<pagx::Rectangle>();
+  maskRect->position = {50, 100};
+  maskRect->size = {100, 200};
+  maskLayer->contents.push_back(maskRect);
+  maskLayer->contents.push_back(MakeSolidFillSVG(doc.get(), 1, 1, 1));
+
+  auto* owner = doc->makeNode<pagx::Layer>();
+  owner->id = "invOwner";
+  owner->mask = maskLayer;
+  owner->maskType = pagx::MaskType::AlphaInverted;
+  auto* rect = doc->makeNode<pagx::Rectangle>();
+  rect->position = {100, 100};
+  rect->size = {180, 180};
+  owner->contents.push_back(rect);
+  owner->contents.push_back(MakeSolidFillSVG(doc.get(), 0.2f, 0.6f, 0.9f));
+  doc->layers.push_back(owner);
+
+  auto svg = pagx::SVGExporter::ToSVG(*doc);
+  EXPECT_NE(svg.find("<image"), std::string::npos);
+  EXPECT_NE(svg.find("data:image/png;base64,"), std::string::npos);
+}
+
+/**
+ * With bakeUnsupported=false the inverted mask degrades to its base type: AlphaInverted emits an
+ * alpha <mask> (not a luminance one) and ContourInverted emits a <clipPath>. The inversion itself
+ * is dropped — that is the documented best-effort vector behaviour.
+ */
+PAGX_TEST(PAGXSVGTest, SVGExport_InvertedMaskDegradesToBaseType) {
+  auto makeDoc = [](pagx::MaskType maskType) {
+    auto doc = pagx::PAGXDocument::Make(200, 200);
+    auto* maskLayer = doc->makeNode<pagx::Layer>();
+    maskLayer->id = "invMask";
+    auto* maskRect = doc->makeNode<pagx::Rectangle>();
+    maskRect->position = {50, 100};
+    maskRect->size = {100, 200};
+    maskLayer->contents.push_back(maskRect);
+    maskLayer->contents.push_back(MakeSolidFillSVG(doc.get(), 1, 1, 1));
+
+    auto* owner = doc->makeNode<pagx::Layer>();
+    owner->mask = maskLayer;
+    owner->maskType = maskType;
+    auto* rect = doc->makeNode<pagx::Rectangle>();
+    rect->position = {100, 100};
+    rect->size = {180, 180};
+    owner->contents.push_back(rect);
+    owner->contents.push_back(MakeSolidFillSVG(doc.get(), 0.2f, 0.6f, 0.9f));
+    doc->layers.push_back(owner);
+    return doc;
+  };
+
+  pagx::SVGExporter::Options opts;
+  opts.bakeUnsupported = false;
+
+  // AlphaInverted degrades to an alpha <mask>, keyed and suffixed by the base type.
+  auto alphaDoc = makeDoc(pagx::MaskType::AlphaInverted);
+  auto alphaSvg = pagx::SVGExporter::ToSVG(*alphaDoc, opts);
+  EXPECT_NE(alphaSvg.find("id=\"invMask_a\""), std::string::npos)
+      << "AlphaInverted must reuse the alpha def id";
+  EXPECT_NE(alphaSvg.find("mask-type:alpha"), std::string::npos)
+      << "AlphaInverted must stay an alpha mask, not degrade to luminance";
+
+  // ContourInverted degrades to a <clipPath>, not a <mask>.
+  auto contourDoc = makeDoc(pagx::MaskType::ContourInverted);
+  auto contourSvg = pagx::SVGExporter::ToSVG(*contourDoc, opts);
+  EXPECT_NE(contourSvg.find("<clipPath"), std::string::npos)
+      << "ContourInverted must degrade to a clipPath";
+  EXPECT_EQ(contourSvg.find("<mask "), std::string::npos)
+      << "ContourInverted must not degrade to a mask";
+}
+
+/**
  * A mask Layer referenced by multiple owners under the same MaskType must produce exactly one
  * <mask> def. The cache reuses the existing def id rather than re-emitting a duplicate-id
  * element into <defs>.

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -90,6 +90,7 @@
 #include "pagx/types/Arrangement.h"
 #include "pagx/types/LayoutMode.h"
 #include "pagx/types/Padding.h"
+#include "pagx/types/Size.h"
 #include "pagx/utils/StringParser.h"
 #include "renderer/FontEmbedder.h"
 #include "renderer/LayerBuilder.h"
@@ -169,6 +170,21 @@ static pagx::Layer* MakeTextLayer(pagx::PAGXDocument* doc, const std::string& co
   group->elements.push_back(text);
   group->elements.push_back(fill);
   layer->contents.push_back(group);
+  return layer;
+}
+
+static pagx::Layer* MakeRectLayer(pagx::PAGXDocument* doc, pagx::Point center, pagx::Size size,
+                                  pagx::Color color) {
+  auto layer = doc->makeNode<pagx::Layer>();
+  auto rect = doc->makeNode<pagx::Rectangle>();
+  rect->position = center;
+  rect->size = size;
+  auto fill = doc->makeNode<pagx::Fill>();
+  auto solid = doc->makeNode<pagx::SolidColor>();
+  solid->color = color;
+  fill->color = solid;
+  layer->contents.push_back(rect);
+  layer->contents.push_back(fill);
   return layer;
 }
 
@@ -623,6 +639,64 @@ PAGX_TEST(PAGXTest, PrecomposedTextRender) {
   displayList.root()->addChild(tgfxLayer);
   displayList.render(surface.get(), false);
   EXPECT_TRUE(Baseline::Compare(surface, "PAGXTest/PrecomposedTextRender"));
+}
+
+/**
+ * Test case: a Layer with an inverted mask type keeps its content visible where the mask is
+ * transparent (AlphaInverted), dark (LuminanceInverted), or outside the mask contour
+ * (ContourInverted). Covers the XML round-trip of the inverted MaskType values and the
+ * LayerBuilder wiring to tgfx::LayerMaskType.
+ */
+PAGX_TEST(PAGXTest, MaskInverted) {
+  auto doc = pagx::PAGXDocument::Make(300, 100);
+
+  // Alpha inverted: the green rect stays visible only in the right half not covered by the mask.
+  auto alphaContent = MakeRectLayer(doc.get(), {50, 50}, {100, 100}, {0, 0.6f, 0, 1});
+  auto alphaMask = MakeRectLayer(doc.get(), {25, 50}, {50, 100}, {1, 0, 0, 1});
+  alphaMask->id = "alphaMask";
+  alphaContent->mask = alphaMask;
+  alphaContent->maskType = pagx::MaskType::AlphaInverted;
+
+  // Luminance inverted: the blue rect stays visible only over the black half of the mask.
+  auto lumaContent = MakeRectLayer(doc.get(), {150, 50}, {100, 100}, {0, 0, 0.8f, 1});
+  auto lumaMask = doc->makeNode<pagx::Layer>();
+  lumaMask->id = "lumaMask";
+  lumaMask->children.push_back(MakeRectLayer(doc.get(), {125, 50}, {50, 100}, {1, 1, 1, 1}));
+  lumaMask->children.push_back(MakeRectLayer(doc.get(), {175, 50}, {50, 100}, {0, 0, 0, 1}));
+  lumaContent->mask = lumaMask;
+  lumaContent->maskType = pagx::MaskType::LuminanceInverted;
+
+  // Contour inverted: the mask fill is half transparent, but contour masking ignores fill alpha,
+  // so the yellow rect stays fully visible only outside the mask geometry.
+  auto contourContent = MakeRectLayer(doc.get(), {250, 50}, {100, 100}, {0.9f, 0.7f, 0, 1});
+  auto contourMask = MakeRectLayer(doc.get(), {225, 50}, {50, 100}, {1, 0, 0, 0.5f});
+  contourMask->id = "contourMask";
+  contourContent->mask = contourMask;
+  contourContent->maskType = pagx::MaskType::ContourInverted;
+
+  doc->layers.push_back(alphaContent);
+  doc->layers.push_back(alphaMask);
+  doc->layers.push_back(lumaContent);
+  doc->layers.push_back(lumaMask);
+  doc->layers.push_back(contourContent);
+  doc->layers.push_back(contourMask);
+
+  doc->applyLayout();
+  auto xml = pagx::PAGXExporter::ToXML(*doc);
+  ASSERT_FALSE(xml.empty());
+  auto pagxPath = SavePAGXFile(xml, "PAGXTest/MaskInverted.pagx");
+
+  auto reloadedDoc = pagx::PAGXImporter::FromFile(pagxPath);
+  ASSERT_TRUE(reloadedDoc != nullptr);
+  reloadedDoc->applyLayout();
+  auto tgfxLayer = pagx::LayerBuilder::Build(reloadedDoc.get());
+  ASSERT_TRUE(tgfxLayer != nullptr);
+
+  auto surface = Surface::Make(context, 300, 100);
+  DisplayList displayList;
+  displayList.root()->addChild(tgfxLayer);
+  displayList.render(surface.get(), false);
+  EXPECT_TRUE(Baseline::Compare(surface, "PAGXTest/MaskInverted"));
 }
 
 /**


### PR DESCRIPTION
本 PR 为 PAGX 的图层蒙版补齐反向（Inverted）能力，使 MaskType 从原来的 3 种（Alpha / Luminance / Contour）扩展到 6 种，新增：

  - AlphaInverted — 按蒙版层的 alpha 通道反向裁剪
  - LuminanceInverted — 按蒙版层的亮度反向裁剪
  - ContourInverted — 按蒙版层轮廓反向裁剪

  补齐了 PAG 蒙版体系中 inverted 语义的缺口