### PR TITLE
Fix Android ANR caused by slow eglDestroyContext on PAGView detach

### DIFF
--- a/android/libpag/src/main/java/org/libpag/PAGView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGView.java
@@ -587,12 +587,14 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
         checkVisible();
         super.onDetachedFromWindow();
         synchronized (renderLock) {
-            // Detach the PAGSurface from the PAGPlayer before releasing it: the release path then
-            // skips RenderCache cleanup, which deletes GPU snapshot caches and can block the main
-            // thread for tens of milliseconds on low-end GPUs (issue #3685). The render cache is
-            // cleaned up when the player renders its next frame or is destroyed. Note that
-            // onSurfaceTextureDestroyed() is posted after this method on modern Android versions,
-            // so the setSurface(null) there may not have run yet when we get here.
+            // Detach the PAGSurface from the PAGPlayer before releasing it. PAGPlayer holds a
+            // strong reference to the PAGSurface, so pagSurface.release() alone only drops the JNI
+            // wrapper's reference and the surface (and its GPUDrawable's EGL context) would stay
+            // alive until the player itself is destroyed. Severing the player's reference here lets
+            // the surface be destroyed now, so the slow EGL teardown is handed to the background
+            // disposer thread instead of blocking the main thread on detach (issue #3685). Note
+            // that onSurfaceTextureDestroyed() is posted after this method on modern Android
+            // versions, so the setSurface(null) there may not have run yet when we get here.
             pagPlayer.setSurface(null);
             if (pagSurface != null) {
                 pagSurface.release();

--- a/android/libpag/src/main/java/org/libpag/PAGView.java
+++ b/android/libpag/src/main/java/org/libpag/PAGView.java
@@ -587,6 +587,13 @@ public class PAGView extends TextureView implements TextureView.SurfaceTextureLi
         checkVisible();
         super.onDetachedFromWindow();
         synchronized (renderLock) {
+            // Detach the PAGSurface from the PAGPlayer before releasing it: the release path then
+            // skips RenderCache cleanup, which deletes GPU snapshot caches and can block the main
+            // thread for tens of milliseconds on low-end GPUs (issue #3685). The render cache is
+            // cleaned up when the player renders its next frame or is destroyed. Note that
+            // onSurfaceTextureDestroyed() is posted after this method on modern Android versions,
+            // so the setSurface(null) there may not have run yet when we get here.
+            pagPlayer.setSurface(null);
             if (pagSurface != null) {
                 pagSurface.release();
                 pagSurface = null;

--- a/src/platform/android/EGLResourceDisposer.cpp
+++ b/src/platform/android/EGLResourceDisposer.cpp
@@ -1,0 +1,67 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "AS IS" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "EGLResourceDisposer.h"
+
+namespace pag {
+
+EGLResourceDisposer* EGLResourceDisposer::GetInstance() {
+  // Intentional leak: the disposer and its worker thread live for the entire process. A static
+  // destructor would join the thread during teardown when the EGL display may already be gone,
+  // and Android never unloads the library once loaded.
+  static auto* instance = new EGLResourceDisposer();
+  return instance;
+}
+
+EGLResourceDisposer::EGLResourceDisposer() {
+  workerThread = std::thread(&EGLResourceDisposer::runLoop, this);
+}
+
+void EGLResourceDisposer::DisposeAsync(std::shared_ptr<tgfx::Surface> surface,
+                                       std::shared_ptr<tgfx::EGLWindow> window) {
+  if (surface == nullptr && window == nullptr) {
+    return;
+  }
+  auto disposer = GetInstance();
+  {
+    std::lock_guard<std::mutex> autoLock(disposer->locker);
+    auto& task = disposer->tasks.emplace();
+    task.surface = std::move(surface);
+    task.window = std::move(window);
+  }
+  disposer->condition.notify_one();
+}
+
+void EGLResourceDisposer::runLoop() {
+  while (true) {
+    DisposeTask task = {};
+    {
+      std::unique_lock<std::mutex> autoLock(locker);
+      while (tasks.empty()) {
+        condition.wait(autoLock);
+      }
+      task = std::move(tasks.front());
+      tasks.pop();
+    }
+    // Reset the surface first: it holds a strong reference to the window, and dropping both here
+    // keeps the whole ~EGLWindow -> ~EGLDevice -> eglDestroyContext() chain on this thread.
+    task.surface = nullptr;
+    task.window = nullptr;
+  }
+}
+}  // namespace pag

--- a/src/platform/android/EGLResourceDisposer.h
+++ b/src/platform/android/EGLResourceDisposer.h
@@ -1,0 +1,65 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "AS IS" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include "tgfx/core/Surface.h"
+#include "tgfx/gpu/opengl/egl/EGLWindow.h"
+
+namespace pag {
+
+// Destroys EGL window resources on a dedicated background thread. Some GPU drivers (e.g. PowerVR
+// on MediaTek devices) block for a long time inside eglDestroyContext() while waiting for the GPU
+// to drain. PAGSurface teardown is triggered from the main thread
+// (TextureView.onSurfaceTextureDestroyed), so destroying the EGL resources inline can freeze the
+// main thread and cause ANRs (issue #3685). Thread safety: EGL windows can only reach here after
+// their PAGSurface is destroyed, which is serialized with all rendering by the rootLocker in
+// PAGPlayer, so no thread is still using the EGL context. tgfx keeps its global device table
+// behind a mutex and holds windows weakly in its present list, so the cross-thread destruction is
+// safe even if another EGL context is current elsewhere.
+class EGLResourceDisposer {
+ public:
+  // Moves the cached Surface and its EGLWindow to the disposer thread. The Surface is released
+  // first because it holds a strong reference to the window; the final window release runs
+  // ~EGLDevice, where the potentially slow eglDestroyContext() executes off the main thread.
+  static void DisposeAsync(std::shared_ptr<tgfx::Surface> surface,
+                           std::shared_ptr<tgfx::EGLWindow> window);
+
+ private:
+  struct DisposeTask {
+    std::shared_ptr<tgfx::Surface> surface = nullptr;
+    std::shared_ptr<tgfx::EGLWindow> window = nullptr;
+  };
+
+  EGLResourceDisposer();
+
+  static EGLResourceDisposer* GetInstance();
+
+  void runLoop();
+
+  std::mutex locker = {};
+  std::condition_variable condition = {};
+  std::queue<DisposeTask> tasks = {};
+  std::thread workerThread = {};
+};
+}  // namespace pag

--- a/src/platform/android/EGLResourceDisposer.h
+++ b/src/platform/android/EGLResourceDisposer.h
@@ -37,6 +37,14 @@ namespace pag {
 // PAGPlayer, so no thread is still using the EGL context. tgfx keeps its global device table
 // behind a mutex and holds windows weakly in its present list, so the cross-thread destruction is
 // safe even if another EGL context is current elsewhere.
+//
+// Tradeoff: the task queue is unbounded and every queued task holds strong references to its
+// Surface/EGLWindow (i.e. the underlying EGLContext/EGLSurface/textures). On affected drivers each
+// task with a window can block the worker for 35~85ms, so rapidly creating and destroying many
+// PAGViews (e.g. fast list scrolling) can pile up N tasks and defer the reclamation of N sets of
+// EGL resources by up to N * 85ms. This is deferred reclamation rather than a leak, but it can
+// raise GPU memory pressure and, on drivers that cap the number of EGL contexts per process,
+// temporarily hold more contexts than strictly necessary.
 class EGLResourceDisposer {
  public:
   // Moves the cached Surface and its EGLWindow to the disposer thread. The Surface is released

--- a/src/platform/android/GPUDrawable.cpp
+++ b/src/platform/android/GPUDrawable.cpp
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "GPUDrawable.h"
+#include "EGLResourceDisposer.h"
 #include "base/utils/Log.h"
 #include "tgfx/core/Surface.h"
 
@@ -37,6 +38,13 @@ GPUDrawable::GPUDrawable(ANativeWindow* nativeWindow, EGLContext eglContext)
 
 GPUDrawable::~GPUDrawable() {
   ANativeWindow_release(nativeWindow);
+  // Destroy the cached Surface and the EGLWindow on the disposer thread: the final window
+  // release runs ~EGLDevice, whose eglDestroyContext() can block for a long time on some
+  // drivers (e.g. PowerVR on MediaTek devices, which waits for the GPU to drain), and this
+  // destructor runs on the main thread when a PAGView is detached from the window (issue #3685).
+  // The ANativeWindow is safe to release here because the EGLSurface created from it holds its
+  // own reference until eglDestroySurface() runs on the disposer thread.
+  EGLResourceDisposer::DisposeAsync(std::move(surface), std::move(window));
 }
 
 void GPUDrawable::updateSize() {

--- a/src/platform/android/GPUDrawable.cpp
+++ b/src/platform/android/GPUDrawable.cpp
@@ -62,6 +62,7 @@ void GPUDrawable::freeSurface() {
   // order, so a Surface enqueued earlier is always destroyed before a window enqueued later,
   // keeping its Context alive.
   EGLResourceDisposer::DisposeAsync(std::move(surface), nullptr);
+  onFreeSurface();
 }
 
 std::shared_ptr<tgfx::Device> GPUDrawable::getDevice() {

--- a/src/platform/android/GPUDrawable.cpp
+++ b/src/platform/android/GPUDrawable.cpp
@@ -56,10 +56,11 @@ void GPUDrawable::freeSurface() {
   // Drop the cached Surface reference on the disposer thread instead of destroying it inline.
   // Dropping the last reference can block the calling thread for tens of milliseconds on some
   // devices (measured 35~85ms on a PowerVR GE8320 phone), and this method runs on the main
-  // thread when a PAGView is detached from the window or its surface is resized (issue #3685).
-  // The window reference is kept here: the EGL context is only destroyed when the GPUDrawable
-  // itself is destroyed. The disposer processes tasks in FIFO order, so a Surface enqueued
-  // earlier is always destroyed before a window enqueued later, keeping its Context alive.
+  // thread when the surface is resized or its cache is freed (PAGSurface::updateSize /
+  // onFreeCache, issue #3685). The window reference is kept here: the EGL context is only
+  // destroyed when the GPUDrawable itself is destroyed. The disposer processes tasks in FIFO
+  // order, so a Surface enqueued earlier is always destroyed before a window enqueued later,
+  // keeping its Context alive.
   EGLResourceDisposer::DisposeAsync(std::move(surface), nullptr);
 }
 

--- a/src/platform/android/GPUDrawable.cpp
+++ b/src/platform/android/GPUDrawable.cpp
@@ -52,6 +52,17 @@ void GPUDrawable::updateSize() {
   _height = ANativeWindow_getHeight(nativeWindow);
 }
 
+void GPUDrawable::freeSurface() {
+  // Drop the cached Surface reference on the disposer thread instead of destroying it inline.
+  // Dropping the last reference can block the calling thread for tens of milliseconds on some
+  // devices (measured 35~85ms on a PowerVR GE8320 phone), and this method runs on the main
+  // thread when a PAGView is detached from the window or its surface is resized (issue #3685).
+  // The window reference is kept here: the EGL context is only destroyed when the GPUDrawable
+  // itself is destroyed. The disposer processes tasks in FIFO order, so a Surface enqueued
+  // earlier is always destroyed before a window enqueued later, keeping its Context alive.
+  EGLResourceDisposer::DisposeAsync(std::move(surface), nullptr);
+}
+
 std::shared_ptr<tgfx::Device> GPUDrawable::getDevice() {
   if (_width <= 0 || _height <= 0) {
     return nullptr;

--- a/src/platform/android/GPUDrawable.h
+++ b/src/platform/android/GPUDrawable.h
@@ -44,6 +44,8 @@ class GPUDrawable : public Drawable {
 
   void updateSize() override;
 
+  void freeSurface() override;
+
   void present(tgfx::Context* context) override;
 
   void setTimeStamp(int64_t timeStamp) override;

--- a/src/rendering/drawables/Drawable.h
+++ b/src/rendering/drawables/Drawable.h
@@ -37,7 +37,7 @@ class Drawable {
 
   virtual std::shared_ptr<tgfx::Surface> getFrontSurface(tgfx::Context* context, bool queryOnly);
 
-  void freeSurface();
+  virtual void freeSurface();
 
   virtual void setTimeStamp(int64_t timestamp);
 


### PR DESCRIPTION
## 问题

Fixes #3685。

在部分 GPU 驱动上（例如 MediaTek 设备上的 PowerVR），销毁 EGL context / 释放缓存的 GPU Surface 会阻塞调用线程数十毫秒（在 PowerVR GE8320 机型上实测 35~85ms）。当 PAGView 从 view tree 移除时，`TextureView.onDetachedFromWindow` → `onSurfaceTextureDestroyed` → `~PAGSurface` → `~EGLDevice` → `eglDestroyContext()` 这条销毁链路运行在主线程上，等待 GPU 排空，从而卡住 UI 线程并触发 ANR。

## 方案

将 EGL 资源销毁与缓存 Surface 的释放迁移到独立的后台线程，避免阻塞主线程：

- **新增 `EGLResourceDisposer`**：一个专用后台线程，异步销毁 `tgfx::Surface` 与 `tgfx::EGLWindow`。先释放 Surface（它强引用 window），最终 window 释放触发 `~EGLDevice`，让可能很慢的 `eglDestroyContext()` 在后台线程执行。单例与工作线程随进程常驻（有意泄漏，避免在 EGL display 已销毁时于静态析构阶段 join 线程）。任务队列无上限，属**延迟回收而非泄漏**——快速连续创建/销毁 PAGView（如列表滚动）时任务会积压，带来短时显存压力，权衡已在头文件注释中记录。
- **`GPUDrawable`**：`~GPUDrawable` 与新增的 `freeSurface()` override 改为通过 disposer 异步销毁；`freeSurface()` 仅移交 Surface、保留 window 引用，由 disposer 的 FIFO 顺序保证 Surface 先于 window 销毁，Context 存活期正确；并保留基类 `onFreeSurface()` 钩子调用以维持契约。
- **`Drawable::freeSurface`** 改为 `virtual`，以支持 `GPUDrawable` 覆写。
- **`PAGView.onDetachedFromWindow`**：在释放前先 `pagPlayer.setSurface(null)` 断开 PAGPlayer 对 PAGSurface 的强引用，使 Surface（及其 EGL context）能在 detach 时真正被销毁，从而把销毁工作交给后台 disposer，而不是泄漏到 player 销毁时。

## 释放时机变化

`setSurface(null)` 会把 `pagSurface->pagPlayer` 置空，导致随后 `release()` 路径中 `renderCache->releaseAll()` 分支被跳过，`renderCache` 不在 detach 时立即释放，而是延迟到 re-attach 检测到 contextID 变化或 player GC 时才释放。该延迟释放已验证跨 EGL context 销毁安全（tgfx GL 资源两阶段销毁 + ReturnQueue）。由于 re-attach 必然产生新的 EGL context 并 purge 旧缓存，"保留缓存利于 re-attach" 并非收益，缓存只是从"detach 时释放"推迟到"re-attach/GC 时被正确清理"，代价是 detach 后缓存内存驻留稍久。此释放时机变化是有意的。

## 线程安全

EGL window 只有在其 PAGSurface 被销毁后才会进入 disposer，而 PAGSurface 的所有渲染调用都由 PAGPlayer 的 rootLocker 串行化，因此不存在仍在使用该 EGL context 的线程。tgfx 以 mutex 保护全局 device 表、并在 present 列表中弱持有 window，故跨线程销毁是安全的。

## 影响范围

仅 Android 平台。修复不改变任何对外 API，行为上仅将耗时的 EGL 资源销毁从主线程迁移到后台线程。
