### PR TITLE
Add WebGPU backend support to GPUContext

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "55e4c4cb274f914f2f539cbb8d17acc9d08be319",
+        "commit": "f0967b2b30d09f6c5026524e3a8ec86156c14f76",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "6662d2b4941b093dbdcceca30adb998de575ad1d",
+        "commit": "55e4c4cb274f914f2f539cbb8d17acc9d08be319",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "75e1f2959db86f26e4ad67667b3af3ba7a5451cc",
+        "commit": "87e63abbd6cf60b62285e97cc7906bc16f371e5b",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "87e63abbd6cf60b62285e97cc7906bc16f371e5b",
+        "commit": "098dd640fc0a38fcb88d72b55d2dac73b293b808",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "098dd640fc0a38fcb88d72b55d2dac73b293b808",
+        "commit": "6662d2b4941b093dbdcceca30adb998de575ad1d",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "f0967b2b30d09f6c5026524e3a8ec86156c14f76",
+        "commit": "87b071f62cea4ac52e9a01d612402ed8c88af2e5",
         "dir": "third_party/tgfx"
       },
       {

--- a/src/pagx/utils/RasterUtils.cpp
+++ b/src/pagx/utils/RasterUtils.cpp
@@ -31,7 +31,11 @@
 #include "tgfx/core/Pixmap.h"
 #include "tgfx/core/Shader.h"
 #include "tgfx/core/Surface.h"
+#if defined(TGFX_USE_WEBGPU)
+#include "tgfx/gpu/webgpu/WebGPUDevice.h"
+#else
 #include "tgfx/gpu/opengl/GLDevice.h"
+#endif
 #include "tgfx/layers/DisplayList.h"
 
 namespace pagx {
@@ -216,7 +220,11 @@ GPUContext::~GPUContext() {
 
 tgfx::Context* GPUContext::lockContext() {
   if (!_device) {
+#if defined(TGFX_USE_WEBGPU)
+    _device = tgfx::WebGPUDevice::Make();
+#else
     _device = tgfx::GLDevice::Make();
+#endif
     if (!_device) {
       return nullptr;
     }


### PR DESCRIPTION
为 GPUContext 添加 WebGPU 后端支持，并同步更新 tgfx 提交。主要改动：

- 在 GPUContext 中接入 WebGPU 后端，支持在 WebGPU 环境下创建 GPUContext 并使用相关能力。
- 通过多次 Update tgfx commit 同步底层渲染引擎改动，以支撑 WebGPU 后端。