### PR TITLE
Upgrade tgfx dependency to latest version with expat 2.8.3 security fix

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "75e1f2959db86f26e4ad67667b3af3ba7a5451cc",
+        "commit": "87b071f62cea4ac52e9a01d612402ed8c88af2e5",
         "dir": "third_party/tgfx"
       },
       {


### PR DESCRIPTION
## 改动说明

将内置 tgfx 依赖从 `75e1f295` 升级到 `87b071f62`（tgfx `main` 当前最新提交）。

`87b071f62` 对应 tgfx PR #1558「Upgrade expat to 2.8.3」，该提交：
- 将 tgfx 内置的 Expat（供 tgfx 的 SVG XML 解析器使用）从 2.6.3 升级到 2.8.3；
- 移除了已弃用的 `XML_SetHashSalt` 弱种子调用，改由 Expat 通过 OS CSPRNG 自行播种强随机盐。

## 背景

本次升级用于修复通过 tgfx 的 SVG 导入器暴露的 CVE-2026-45186。libpag PR #3688 已修复 libpag 自身 `pagx` 导入器使用的 Expat，但 tgfx 仍固定使用 Expat 2.6.3，导致 SVG 解析路径仍处于风险中。升级后，libpag `main` 分支对该 CVE 的修复已完整闭环。

## 影响与后续

- `release/4.5` 仍固定使用较旧版本的 tgfx（含 Expat 2.6.3），需单独升级 tgfx 依赖才能应用此修复；
- `release/4.4` 不受影响：其 tgfx 不依赖 Expat。
