### PR TITLE
Fix PAGViewer file dialog loading and macOS Qt deployment.

### DIFF
--- a/viewer/CMakeLists.txt
+++ b/viewer/CMakeLists.txt
@@ -256,8 +256,8 @@ if (APPLE)
             COMMAND /bin/sh -c "mkdir -p '${VIEWER_RESOURCES_DIR}' && cp -f '${CMAKE_SOURCE_DIR}/assets/images/appIcon.icns' '${VIEWER_RESOURCES_DIR}/' && cp -f '${CMAKE_SOURCE_DIR}/assets/images/pagIcon.icns' '${VIEWER_RESOURCES_DIR}/'"
             # Copy Info.plist
             COMMAND /bin/sh -c "cp -f '${CMAKE_SOURCE_DIR}/package/templates/Info.plist' '${VIEWER_BUNDLE_DIR}/Contents/'"
-            # Deploy Qt (skip if already deployed)
-            COMMAND /bin/sh -c "[ -d '${VIEWER_FRAMEWORKS_DIR}/QtCore.framework' ] || '${DEPLOYQT_EXECUTABLE}' '${VIEWER_BUNDLE_DIR}' -qmldir='${CMAKE_SOURCE_DIR}/assets/qml'"
+            # Deploy Qt
+            COMMAND /bin/sh -c "'${DEPLOYQT_EXECUTABLE}' '${VIEWER_BUNDLE_DIR}' -qmldir='${CMAKE_SOURCE_DIR}/assets/qml' -always-overwrite"
             COMMENT "Deploying runtime dependencies into PAGViewer.app"
             VERBATIM
     )

--- a/viewer/CMakeLists.txt
+++ b/viewer/CMakeLists.txt
@@ -257,7 +257,7 @@ if (APPLE)
             # Copy Info.plist
             COMMAND /bin/sh -c "cp -f '${CMAKE_SOURCE_DIR}/package/templates/Info.plist' '${VIEWER_BUNDLE_DIR}/Contents/'"
             # Deploy Qt
-            COMMAND /bin/sh -c "'${DEPLOYQT_EXECUTABLE}' '${VIEWER_BUNDLE_DIR}' -qmldir='${CMAKE_SOURCE_DIR}/assets/qml' -always-overwrite"
+            COMMAND /bin/sh -c "'${DEPLOYQT_EXECUTABLE}' '${VIEWER_BUNDLE_DIR}' -qmldir='${CMAKE_SOURCE_DIR}/assets/qml'"
             COMMENT "Deploying runtime dependencies into PAGViewer.app"
             VERBATIM
     )

--- a/viewer/assets/qml/Main.qml
+++ b/viewer/assets/qml/Main.qml
@@ -623,7 +623,7 @@ PAGWindow {
             openFileDialog.title = qsTr("Open PAG File");
             openFileDialog.nameFilters = ["PAG files(*.pag *.pagx)"];
             openFileDialog.currentAcceptHandler = function () {
-                let filePath = openFileDialog.selectedFile;
+                let filePath = openFileDialog.selectedFile.toString();
                 mainForm.loadFile(filePath);
             };
             openFileDialog.accepted.connect(openFileDialog.currentAcceptHandler);


### PR DESCRIPTION
## 背景

PAGViewer 存在两个影响本地开发和日常使用的问题：

1. 通过 `File → Open...` 打开 `.pag` 或 `.pagx` 文件时，Qt `FileDialog.selectedFile` 返回的是 `QUrl`，但 `MainForm.loadFile()` 将其当作字符串调用 `toLowerCase()`，导致加载失败：

   ```text
   TypeError: Property 'toLowerCase' of object file:///... is not a function
   ```

2. macOS 下使用 CLion 增量构建 PAGViewer 时，主程序重新链接后会再次指向 Homebrew Qt；但已有 Qt framework 时构建脚本会跳过 `macdeployqt`。最终主程序加载外部 Qt、bundle 内 cocoa 插件加载 app bundle Qt，同一进程出现两套 Qt runtime，导致：

   ```text
   Class ... is implemented in both ...
   QObject::moveToThread ...
   Could not load the Qt platform plugin "cocoa"
   ```

## 修改内容

### FileDialog 文件路径归一化

在菜单文件选择完成后，将 `FileDialog.selectedFile` 显式转换为字符串后再传给 `MainForm.loadFile()`。

- 修复 Qt `url/QUrl` 与 JavaScript `string` 的类型不匹配；
- 保留 `file:///` URL 格式，后续 C++ 层继续通过 `QUrl::toLocalFile()` 处理本地路径；
- 恢复菜单打开 `.pag` 和 `.pagx` 文件的功能；
- 不影响命令行、Finder/Dock 关联打开和拖拽打开路径。

### macOS Qt runtime 增量部署

调整 PAGViewer macOS 的 `POST_BUILD` 部署逻辑：

- 不再因 bundle 内已有 `QtCore.framework` 而跳过 `macdeployqt`；
- 每次可执行文件重新链接后均调用 `macdeployqt`，确保 Mach-O Qt 依赖路径会改写到 app bundle 内；
- 不使用 `-always-overwrite`，已存在的 Qt framework、插件和 QML runtime 会跳过复制，避免重复覆盖约 200 MB 的部署内容。

该方案在正确性和增量构建速度之间取折中：

| 方案 | 增量部署行为 |
| --- | --- |
| 原逻辑 | 已部署后完全跳过，可能加载两套 Qt |
| 强制全量覆盖 | 正确但会重复复制全部 Qt runtime |
| 当前逻辑 | 每次修正可执行文件依赖路径，复用已有 runtime 文件 |

本机实测中，增量 `macdeployqt` 约为 22 秒；强制覆盖已有 runtime 约为 163 秒。

## 验证

- 构建 PAGViewer Debug app：

  ```bash
  cmake --build viewer/cmake-build-debug --target PAGViewer -j 8
  ```

- 使用 `otool -L` 验证：
  - PAGViewer 主程序不再依赖 `/opt/homebrew/.../Qt*.framework`；
  - 主程序和 `PlugIns/platforms/libqcocoa.dylib` 均使用 `PAGViewer.app/Contents/Frameworks` 内的 Qt framework。

- 执行完整测试构建与运行：

  ```bash
  ./codeformat.sh 2>/dev/null; true
  cmake -G Ninja -DPAG_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -B cmake-build-debug
  cmake --build cmake-build-debug --target PAGFullTest
  ./cmake-build-debug/PAGFullTest
  ```

## 影响范围

- `viewer/assets/qml/Main.qml`
- `viewer/CMakeLists.txt`

仅影响 PAGViewer 的菜单文件打开流程，以及 macOS 下 PAGViewer 的开发构建 runtime 部署流程。