### PR TITLE
Fix WeChat mini program crashes on PAGX parsing and text rendering

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "eccf358181c8ce96c80f5ead931041c25b188352",
+        "commit": "89264e576e69a6a9b80a4dad029e525c8fa8a7c4",
         "dir": "third_party/tgfx"
       },
       {

--- a/pagx/wechat/ts/babel.ts
+++ b/pagx/wechat/ts/babel.ts
@@ -28,6 +28,26 @@ globalThis.isWxWebAssembly = true;
 // eslint-disable-next-line no-global-assign
 window = globalThis;
 
+// WeChat Mini Program has no global crypto, so Expat aborts while requesting entropy during
+// PAGX parsing. Fall back to Math.random(): the hash salt only needs to be unpredictable, not
+// cryptographically secure.
+if (!globalThis.crypto || typeof globalThis.crypto.getRandomValues !== 'function') {
+  const getRandomValues = (array: any) => {
+    if (array && ArrayBuffer.isView(array)) {
+      const bytes = new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
+      for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = Math.floor(Math.random() * 256);
+      }
+    }
+    return array;
+  };
+  if (globalThis.crypto) {
+    globalThis.crypto.getRandomValues = getRandomValues;
+  } else {
+    globalThis.crypto = { getRandomValues };
+  }
+}
+
 // Keep this file a module so the ambient `declare const globalThis` above stays module-scoped;
 // without an import/export it becomes a global script and clashes with the built-in globalThis.
 export {};

--- a/pagx/wechat/tsconfig.type.json
+++ b/pagx/wechat/tsconfig.type.json
@@ -17,5 +17,5 @@
       ]
     }
   },
-  "include": ["ts/pagx.ts"]
+  "include": ["ts/pagx.ts", "ts/pagx-check.ts"]
 }


### PR DESCRIPTION
修复微信小程序端 PAGX 解析与文本渲染崩溃的两个问题。

## 改动

- 在 pagx/wechat/ts/babel.ts 中添加同步的 crypto.getRandomValues 兜底实现（基于 Math.random()）。微信小程序运行时没有全局 crypto，导致 Emscripten 的 getRandomDevice() 在 Expat 解析 PAGX 请求熵值时直接 abort。该兜底只需不可预测、无需密码学强度，足以满足 Expat 哈希盐的要求。
- 将 DEPS 中的 tgfx 升级到 89264e57（[tgfx#1562](https://github.com/Tencent/tgfx/pull/1562)），修复文本渲染时的崩溃 `Aborted(To use dlopen, you need enable dynamic linking, ...)`。根因是 FreeType 2.14 新增的「动态加载 HarfBuzz」模式在 Emscripten 上被默认开启（其启用条件只检查 dlfcn.h 是否声明 dlopen，而 Emscripten 必然通过，且该分支会跳过 find_package 从而架空原有的关闭开关），于是 af_autofitter_init() 会调用 dlsym(RTLD_DEFAULT, "hb_version_atleast")，在 emsdk 3.1.20 上被解析到会 abort 的 JS stub。tgfx 侧通过给 freetype 构建增加 -DFT_DISABLE_HARFBUZZ=TRUE 修复；Web 端因 emsdk 4.x 的 dlsym 是返回 NULL 的原生 stub 而未暴露该问题。
- 将 pagx-check 类型声明发布为独立文件。
