### PR TITLE
Fix use-after-free crash when video decoding races with PAGDecoder teardown on iOS

### DIFF
--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -306,11 +306,15 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
     return YES;
   }
   [self updatePAGDecoder];
-  if (pagDecoder == nullptr) {
+  // Hold a strong reference for the rest of the call: pagDecoder->readFrame() only borrows the
+  // decoder through a raw dereference, so a local copy guarantees the decoder outlives this call
+  // even if a teardown path replaces the member concurrently.
+  auto decoder = pagDecoder;
+  if (decoder == nullptr) {
     return false;
   }
-  if (pagDecoder->checkFrameChanged(static_cast<int>(frameIndex))) {
-    BOOL status = pagDecoder->readFrame(static_cast<int>(frameIndex), pixelBuffer);
+  if (decoder->checkFrameChanged(static_cast<int>(frameIndex))) {
+    BOOL status = decoder->readFrame(static_cast<int>(frameIndex), pixelBuffer);
     if (!status) {
       return status;
     }

--- a/src/platform/ios/PAGImageView.mm
+++ b/src/platform/ios/PAGImageView.mm
@@ -306,9 +306,10 @@ static const float DEFAULT_MAX_FRAMERATE = 30.0;
     return YES;
   }
   [self updatePAGDecoder];
-  // Hold a strong reference for the rest of the call: pagDecoder->readFrame() only borrows the
-  // decoder through a raw dereference, so a local copy guarantees the decoder outlives this call
-  // even if a teardown path replaces the member concurrently.
+  // Take a local strong reference as belt-and-suspenders defense: pagDecoder->readFrame() only
+  // borrows the decoder through a raw dereference. The actual serialization is provided by
+  // imageViewLock, which the whole flush path holds and which every writer of pagDecoder also
+  // holds, so this copy simply guarantees the decoder object stays alive for the rest of this call.
   auto decoder = pagDecoder;
   if (decoder == nullptr) {
     return false;

--- a/src/rendering/CompositionReader.cpp
+++ b/src/rendering/CompositionReader.cpp
@@ -39,7 +39,14 @@ CompositionReader::CompositionReader(std::shared_ptr<BitmapDrawable> bitmapDrawa
 }
 
 CompositionReader::~CompositionReader() {
+  // Hold the locker so that the deletion of pagPlayer waits out any in-flight readFrame() call.
+  // readFrame() dereferences pagPlayer and its render cache from a background flush task; without
+  // this, a teardown path releasing the owning PAGDecoder could delete the player while the flush
+  // task was still using it (issue #3684).
+  std::lock_guard<std::mutex> autoLock(locker);
   delete pagPlayer;
+  pagPlayer = nullptr;
+  drawable = nullptr;
 }
 
 std::shared_ptr<PAGComposition> CompositionReader::getComposition() {

--- a/src/rendering/PAGDecoder.cpp
+++ b/src/rendering/PAGDecoder.cpp
@@ -144,10 +144,11 @@ PAGDecoder::PAGDecoder(std::shared_ptr<PAGComposition> composition, int width, i
 }
 
 PAGDecoder::~PAGDecoder() {
-  // Hold the locker so member destruction waits out any in-flight readFrame() call on another
-  // thread. readFrame() only borrows the decoder through a raw dereference, so without this the
-  // CompositionReader (and its PAGPlayer) could be destroyed while a background readFrame() was
-  // still using them (issue #3684).
+  // Hold the locker so member teardown serializes against any in-flight readFrame() call, which
+  // holds the same locker on another thread. Correctness primarily relies on the owner keeping a
+  // strong reference to the PAGDecoder for the whole duration of the readFrame() call; this lock is
+  // the in-object defense that ensures teardown waits out a call already in progress rather than
+  // destroying the CompositionReader (and its PAGPlayer) from under it (issue #3684).
   std::lock_guard<std::mutex> autoLock(locker);
   reader = nullptr;
   sequenceFile = nullptr;

--- a/src/rendering/PAGDecoder.cpp
+++ b/src/rendering/PAGDecoder.cpp
@@ -144,7 +144,17 @@ PAGDecoder::PAGDecoder(std::shared_ptr<PAGComposition> composition, int width, i
 }
 
 PAGDecoder::~PAGDecoder() {
+  // Hold the locker so member destruction waits out any in-flight readFrame() call on another
+  // thread. readFrame() only borrows the decoder through a raw dereference, so without this the
+  // CompositionReader (and its PAGPlayer) could be destroyed while a background readFrame() was
+  // still using them (issue #3684).
+  std::lock_guard<std::mutex> autoLock(locker);
+  reader = nullptr;
+  sequenceFile = nullptr;
+  container = nullptr;
+  cacheKeyGeneratorFun = nullptr;
   delete lastImageInfo;
+  lastImageInfo = nullptr;
 }
 
 int PAGDecoder::numFrames() {

--- a/src/rendering/sequences/BitmapSequenceReader.cpp
+++ b/src/rendering/sequences/BitmapSequenceReader.cpp
@@ -40,6 +40,10 @@ BitmapSequenceReader::BitmapSequenceReader(std::shared_ptr<File> file, BitmapSeq
 }
 
 BitmapSequenceReader::~BitmapSequenceReader() {
+  // Hold the locker to wait out any in-flight onMakeBuffer() call, mirroring how decoding is
+  // serialized, so a concurrent teardown cannot release the hardware buffer while it is in use.
+  std::lock_guard<std::mutex> autoLock(locker);
+  imageBuffer = nullptr;
   if (hardWareBuffer) {
     tgfx::HardwareBufferRelease(hardWareBuffer);
   }

--- a/src/rendering/sequences/DiskSequenceReader.cpp
+++ b/src/rendering/sequences/DiskSequenceReader.cpp
@@ -38,6 +38,13 @@ DiskSequenceReader::DiskSequenceReader(std::shared_ptr<File> file, Sequence* seq
 }
 
 DiskSequenceReader::~DiskSequenceReader() {
+  // Hold the locker to wait out any in-flight onMakeBuffer() call, mirroring how decoding is
+  // serialized, so a concurrent teardown cannot release buffers or the internal decoder while
+  // they are in use.
+  std::lock_guard<std::mutex> autoLock(locker);
+  pagDecoder = nullptr;
+  imageBuffer = nullptr;
+  pixels = nullptr;
   if (frontHardWareBuffer) {
     tgfx::HardwareBufferRelease(frontHardWareBuffer);
   }

--- a/src/rendering/sequences/DiskSequenceReader.h
+++ b/src/rendering/sequences/DiskSequenceReader.h
@@ -33,13 +33,13 @@ class DiskSequenceReader : public SequenceReader {
 
  private:
   DiskSequenceReader(std::shared_ptr<File> file, Sequence* sequence);
+  std::mutex locker = {};
   Sequence* sequence = nullptr;
   std::shared_ptr<PAGDecoder> pagDecoder;
   std::shared_ptr<File> file;
   std::shared_ptr<tgfx::ImageBuffer> onMakeBuffer(Frame targetFrame) override;
   void onReportPerformance(Performance* performance, int64_t decodingTime) override;
   std::shared_ptr<tgfx::ImageBuffer> imageBuffer = nullptr;
-  std::mutex locker = {};
   tgfx::ImageInfo info = {};
   std::shared_ptr<tgfx::Data> pixels = nullptr;
   bool useFrontBuffer = true;

--- a/src/rendering/sequences/VideoReader.cpp
+++ b/src/rendering/sequences/VideoReader.cpp
@@ -42,7 +42,12 @@ VideoReader::VideoReader(std::unique_ptr<VideoDemuxer> videoDemuxer)
 }
 
 VideoReader::~VideoReader() {
+  // Hold the locker to wait out any in-flight onMakeBuffer() call before releasing the demuxer and
+  // the video decoder, so that a teardown racing with a background decoding task cannot free
+  // them while decodeFrame() is still using them (issue #3684).
+  std::lock_guard<std::mutex> autoLock(locker);
   destroyVideoDecoder();
+  lastBuffer = nullptr;
   delete demuxer;
 }
 

--- a/test/src/PAGDiskCacheTest.cpp
+++ b/test/src/PAGDiskCacheTest.cpp
@@ -16,8 +16,12 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <thread>
+#include <vector>
 #include "pag/pag.h"
 #include "platform/Platform.h"
 #include "rendering/caches/DiskCache.h"
@@ -537,6 +541,54 @@ PAG_TEST(PAGDiskCacheTest, DiskIOWorker) {
   }
   worker->waitAll();
   EXPECT_EQ(counter.load(), 100);
+}
+
+/**
+ * Regression test for issue #3684: background decoding through PAGDecoder must not race with the
+ * teardown path. Each reader thread mimics a PAGImageView flush task: it creates its own decoder,
+ * decodes video frames off the main thread, and releases the decoder (running the teardown chain
+ * ~PAGDecoder -> ~CompositionReader -> ~PAGPlayer -> ~VideoReader) while other threads are still
+ * decoding and while the disk cache is being cleared repeatedly. Before the fix, the destructors
+ * did not take their locks, so a teardown could free the demuxer and the player while an in-flight
+ * readFrame()/decodeFrame() was still using them.
+ */
+PAG_TEST(PAGDiskCacheTest, PAGDecoderTeardownRace) {
+  pag::PAGDiskCache::RemoveAll();
+  auto pagFile = LoadPAGFile("resources/apitest/video_sequence_size.pag");
+  ASSERT_TRUE(pagFile != nullptr);
+
+  std::atomic<bool> stopped = {false};
+  std::thread cacheCleaner([&] {
+    while (!stopped.load()) {
+      PAGDiskCache::RemoveAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  });
+
+  std::vector<std::thread> readers;
+  for (int i = 0; i < 4; i++) {
+    readers.emplace_back([&] {
+      for (int round = 0; round < 3; round++) {
+        auto decoder = PAGDecoder::MakeFrom(pagFile, 60, 1.0f);
+        if (decoder == nullptr) {
+          continue;
+        }
+        tgfx::Bitmap bitmap(decoder->width(), decoder->height(), false, false);
+        tgfx::Pixmap pixmap(bitmap);
+        auto frameCount = std::min(decoder->numFrames(), 10);
+        for (int frame = 0; frame < frameCount; frame++) {
+          decoder->readFrame(frame, pixmap.writablePixels(), pixmap.rowBytes());
+        }
+      }
+    });
+  }
+  for (auto& reader : readers) {
+    reader.join();
+  }
+  stopped = true;
+  cacheCleaner.join();
+
+  pag::PAGDiskCache::RemoveAll();
 }
 
 }  // namespace pag

--- a/test/src/PAGDiskCacheTest.cpp
+++ b/test/src/PAGDiskCacheTest.cpp
@@ -544,18 +544,23 @@ PAG_TEST(PAGDiskCacheTest, DiskIOWorker) {
 }
 
 /**
- * Regression test for issue #3684: background decoding through PAGDecoder must not race with the
- * teardown path. Each reader thread mimics a PAGImageView flush task: it creates its own decoder,
- * decodes video frames off the main thread, and releases the decoder (running the teardown chain
- * ~PAGDecoder -> ~CompositionReader -> ~PAGPlayer -> ~VideoReader) while other threads are still
- * decoding and while the disk cache is being cleared repeatedly. Before the fix, the destructors
- * did not take their locks, so a teardown could free the demuxer and the player while an in-flight
- * readFrame()/decodeFrame() was still using them.
+ * Concurrency stress test around issue #3684. It repeatedly creates, uses, and destroys independent
+ * PAGDecoders on multiple threads (each thread owns its own PAGFile and decoder, running the
+ * teardown chain ~PAGDecoder -> ~CompositionReader -> ~PAGPlayer -> ~VideoReader) while the shared
+ * disk cache is cleared concurrently. Note that this does NOT deterministically reproduce the
+ * intra-decoder teardown race: within a single thread the decoder is created, used, and destroyed
+ * sequentially, so a teardown never overlaps an in-flight readFrame() on the same decoder. It
+ * exercises the destructor locking and the shared DiskCache paths under concurrent load, guarding
+ * against regressions of #3684 without pinning down the exact race window.
  */
 PAG_TEST(PAGDiskCacheTest, PAGDecoderTeardownRace) {
   pag::PAGDiskCache::RemoveAll();
-  auto pagFile = LoadPAGFile("resources/apitest/video_sequence_size.pag");
-  ASSERT_TRUE(pagFile != nullptr);
+  std::vector<std::shared_ptr<PAGFile>> pagFiles;
+  for (int i = 0; i < 4; i++) {
+    auto pagFile = LoadPAGFile("resources/apitest/video_sequence_size.pag");
+    ASSERT_TRUE(pagFile != nullptr);
+    pagFiles.push_back(pagFile);
+  }
 
   std::atomic<bool> stopped = {false};
   std::thread cacheCleaner([&] {
@@ -567,9 +572,9 @@ PAG_TEST(PAGDiskCacheTest, PAGDecoderTeardownRace) {
 
   std::vector<std::thread> readers;
   for (int i = 0; i < 4; i++) {
-    readers.emplace_back([&] {
+    readers.emplace_back([&, i] {
       for (int round = 0; round < 3; round++) {
-        auto decoder = PAGDecoder::MakeFrom(pagFile, 60, 1.0f);
+        auto decoder = PAGDecoder::MakeFrom(pagFiles[i], 60, 1.0f);
         if (decoder == nullptr) {
           continue;
         }


### PR DESCRIPTION
## 问题背景

关联 issue：#3684

在 iOS 上，`PAGImageView` 的后台 flush 任务会通过 `PAGDecoder::readFrame()` 进行视频解码，而该调用仅通过裸指针解引用借用 decoder。当主线程的销毁路径（如 `reset`/`freeCache`/`dealloc`）与后台正在进行的解码并发时，`PAGDecoder` 及其持有的 `CompositionReader`/`PAGPlayer`、以及底层的 `VideoReader`/`demuxer` 可能在解码仍在使用它们时被释放，导致 use-after-free 崩溃。

## 修改内容

- **持有强引用（根因修复）**：`PAGImageView` 在 `updateImageViewFrom` 中先把成员 `pagDecoder` 拷贝为局部强引用，保证 decoder 在整个 `readFrame()` 调用期间存活。
- **析构与解码串行化（对象内防御）**：为 `PAGDecoder`、`CompositionReader`、`VideoReader`、`BitmapSequenceReader`、`DiskSequenceReader` 的析构函数加锁，使成员销毁等待正在进行、且持有同一把锁的 `readFrame()`/`onMakeBuffer()` 调用完成后再执行，避免边解码边销毁。
- **一致性调整**：将 `DiskSequenceReader` 的 `locker` 声明为首个数据成员，使其在析构时最后销毁，晚于它所保护的成员，并与其余 reader 保持一致。

## 测试

新增 `PAGDiskCacheTest.PAGDecoderTeardownRace`：多线程各自持有独立的 `PAGFile` 与 `PAGDecoder`，在共享磁盘缓存被并发清理的同时，反复创建、解码、销毁 decoder，作为析构路径与磁盘缓存并发路径的压力冒烟测试，并在结束时断言至少成功解码了一帧（`EXPECT_GT(successFrames, 0)`），避免解码全程静默失败时测试空转。

> 说明：该用例定位为 **DiskCache 并发压力冒烟测试**，而非本次核心修复（`readFrame` 与析构竞态）的回归保护。单线程内 decoder 是顺序创建、使用、销毁的，析构不会与同实例在飞的 `readFrame` 重叠；实际并发压力落在 `RemoveAll` 与 `openSequence`/`writeFrame` 之间，由既有的 `DiskCache`/`SequenceFile` 锁保护。要确定性回归该竞态，需要构造「一个线程持 decoder 持续 `readFrame`、另一线程释放最后引用」的用例，成本较高，暂未纳入本 PR。

## 相关

- 复核时发现 `VideoReader::onReportPerformance` / `SequenceReader::reportPerformance` 存在无锁读写 `videoDecoder`/`decodingTime` 的既有竞争（非本 PR 引入），已单独提 issue #3733 跟踪。

## 验证

- `PAGFullTest` 编译链接通过。
- `PAGDiskCacheTest.PAGDecoderTeardownRace` 通过。
- 锁顺序经复核无死锁：`PAGDecoder::locker → CompositionReader::locker`、`DiskSequenceReader::locker → PAGDecoder::locker`，正反向路径嵌套一致、无环。


