### PR TITLE
Add PAGX GlassStyle layer style with full export/import/runtime support.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,12 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@v4
 
+      - name: WeChat Risk Check Test
+        run: |
+          cd pagx/wechat
+          npm install
+          npm run test:pagx-check
+
       - name: Get emsdk Cache
         id: emsdk-cache
         uses: actions/cache/restore@v4

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "eccf358181c8ce96c80f5ead931041c25b188352",
+        "commit": "d8c21b6f84488e71259f4c082f7e8be635023082",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "6887de429c578818aa28706245abc3c4aba46ba3",
+        "commit": "fb88a4308e657a86166a79da1540ab95a0356a26",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "d8c21b6f84488e71259f4c082f7e8be635023082",
+        "commit": "6887de429c578818aa28706245abc3c4aba46ba3",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "ac79e7a3160b7726fa08df886a4899b283862204",
+        "commit": "818d374822c8060516256ade853abeae7720d65d",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -1,8 +1,7 @@
 {
   "version": "1.3.12",
   "vars": {
-    "PAG_GROUP": "https://github.com/libpag",
-    "DESIGN_THIRD_PARTY": "https://cnb.woa.com/tencent-design/third-party"
+    "PAG_GROUP": "https://github.com/libpag"
   },
   "repos": {
     "common": [
@@ -12,8 +11,8 @@
         "dir": "third_party/vendor_tools"
       },
       {
-        "url": "${DESIGN_THIRD_PARTY}/tgfx.git",
-        "commit": "e82f6c1acbe23853eb3a1ae155e3e8cba9b610d8",
+        "url": "${PAG_GROUP}/tgfx.git",
+        "commit": "ac79e7a3160b7726fa08df886a4899b283862204",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@
       },
       {
         "url": "${DESIGN_THIRD_PARTY}/tgfx.git",
-        "commit": "283df9576275ef2eba301975a676ccbfc87fe0b6",
+        "commit": "e82f6c1acbe23853eb3a1ae155e3e8cba9b610d8",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "d33d4e40457906a88bf83825f68c86120a75ed2b",
+        "commit": "a15ecba876fbb65600d4c12f02f017077a799361",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@
       },
       {
         "url": "${DESIGN_THIRD_PARTY}/tgfx.git",
-        "commit": "cfdf2c43690e5ca62531cb0a2887a3aba375ffe9",
+        "commit": "8838e3ee636d3713aaa69731e1a10b469a2adbb4",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@
       },
       {
         "url": "${DESIGN_THIRD_PARTY}/tgfx.git",
-        "commit": "1f7d3f68089e81fb7aa3036df1820d74b531de62",
+        "commit": "cfdf2c43690e5ca62531cb0a2887a3aba375ffe9",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "a15ecba876fbb65600d4c12f02f017077a799361",
+        "commit": "54476f44745cdd790c6ae7a63c884b3e95773f33",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@
       },
       {
         "url": "${DESIGN_THIRD_PARTY}/tgfx.git",
-        "commit": "8838e3ee636d3713aaa69731e1a10b469a2adbb4",
+        "commit": "283df9576275ef2eba301975a676ccbfc87fe0b6",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "fb88a4308e657a86166a79da1540ab95a0356a26",
+        "commit": "d33d4e40457906a88bf83825f68c86120a75ed2b",
         "dir": "third_party/tgfx"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -1,7 +1,8 @@
 {
   "version": "1.3.12",
   "vars": {
-    "PAG_GROUP": "https://github.com/libpag"
+    "PAG_GROUP": "https://github.com/libpag",
+    "DESIGN_THIRD_PARTY": "https://cnb.woa.com/tencent-design/third-party"
   },
   "repos": {
     "common": [
@@ -11,8 +12,8 @@
         "dir": "third_party/vendor_tools"
       },
       {
-        "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "54476f44745cdd790c6ae7a63c884b3e95773f33",
+        "url": "${DESIGN_THIRD_PARTY}/tgfx.git",
+        "commit": "1f7d3f68089e81fb7aa3036df1820d74b531de62",
         "dir": "third_party/tgfx"
       },
       {

--- a/include/pagx/SVGExporter.h
+++ b/include/pagx/SVGExporter.h
@@ -74,8 +74,9 @@ struct SVGExportOptions {
    * baked to an embedded PNG and emitted as an &lt;image&gt; so the visual result is preserved.
    * When false, the exporter falls through to the vector path and those features degrade silently
    * (TextPath / TextModifier drop, diamond/conic gradient fall back to radial). BackgroundBlurStyle
-   * is always kept as vector output with the blur effect silently dropped, since SVG has no
-   * portable backdrop-blur primitive. Naming is aligned with PPTExportOptions::bakeUnsupported.
+   * and GlassStyle are always kept as vector output with the backdrop effect silently dropped,
+   * since SVG has no portable backdrop-blur / glass primitive. Naming is aligned with
+   * PPTExportOptions::bakeUnsupported.
    * The default value is true.
    */
   bool bakeUnsupported = true;
@@ -139,8 +140,7 @@ class SVGExporter {
    * @return true on success.
    */
   static bool ToFile(PAGXDocument& document, const std::string& filePath,
-                     const Options& options = {},
-                     std::vector<std::string>* warnings = nullptr);
+                     const Options& options = {}, std::vector<std::string>* warnings = nullptr);
 };
 
 }  // namespace pagx

--- a/include/pagx/nodes/GlassStyle.h
+++ b/include/pagx/nodes/GlassStyle.h
@@ -1,0 +1,84 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "pagx/nodes/LayerStyle.h"
+
+namespace pagx {
+
+/**
+ * A glass layer style that simulates the physical behavior of light passing through a glass
+ * surface, producing refraction, chromatic dispersion, frosted blur, and specular highlights. It
+ * captures the background content below the layer and renders it with optical distortion shaped by
+ * the layer's content. The background comes implicitly from the full PAGX layer tree below the
+ * layer; no background reference attribute is used. All seven parameters are animatable float
+ * channels with fields matching tgfx::GlassStyle.
+ */
+class GlassStyle : public LayerStyle {
+ public:
+  /**
+   * The amount of optical distortion along curved edges, range [0, 100]. The default value is 80.
+   */
+  float refraction = 80.0f;
+
+  /**
+   * The inward extent of the refraction region from edges, range [1, 100]. The default value is 20.
+   */
+  float depth = 20.0f;
+
+  /**
+   * The amount of background blur (frosted glass), range [0, 100]. The default value is 5.
+   */
+  float frost = 5.0f;
+
+  /**
+   * The intensity of chromatic aberration (rainbow prism effect), range [0, 100]. The default
+   * value is 50.
+   */
+  float dispersion = 50.0f;
+
+  /**
+   * The blend factor for the refraction direction, range [0, 100]. At 0, refraction follows the
+   * curvature of the shape's edges; at 100, it points toward the shape center. The default value
+   * is 0.
+   */
+  float splay = 0.0f;
+
+  /**
+   * The direction of the light source in degrees. 0 means light from directly above, positive
+   * values rotate clockwise. Range [-179, 180]. The default value is 45.
+   */
+  float lightAngle = 45.0f;
+
+  /**
+   * The brightness of edge highlights, range [0, 100]. The default value is 80.
+   */
+  float lightIntensity = 80.0f;
+
+  NodeType nodeType() const override {
+    return NodeType::GlassStyle;
+  }
+
+ private:
+  GlassStyle() = default;
+
+  friend class PAGXDocument;
+};
+
+}  // namespace pagx

--- a/include/pagx/nodes/LayerStyle.h
+++ b/include/pagx/nodes/LayerStyle.h
@@ -24,7 +24,8 @@
 namespace pagx {
 
 /**
- * Base class for layer styles (DropShadowStyle, InnerShadowStyle, BackgroundBlurStyle, NoiseStyle).
+ * Base class for layer styles (DropShadowStyle, InnerShadowStyle, BackgroundBlurStyle, NoiseStyle,
+ * GlassStyle).
  */
 class LayerStyle : public Node {
  public:

--- a/include/pagx/nodes/Node.h
+++ b/include/pagx/nodes/Node.h
@@ -147,6 +147,10 @@ enum class NodeType {
    * A noise layer style.
    */
   NoiseStyle,
+  /**
+   * A glass layer style that simulates light passing through a glass surface.
+   */
+  GlassStyle,
 
   // Layer Filters
   /**

--- a/pagx/wechat/GETTING_STARTED.md
+++ b/pagx/wechat/GETTING_STARTED.md
@@ -976,10 +976,10 @@ SDK 沿"五条独立失效路径"中最高风险路径打分（0-100，越高越
 
 | 路径 | 计算 |
 |------|------|
-| A. BgBlur × 下方不可缓存元素 | `bg_count × (inner + blur + grad/10)` |
+| A. 背景采样样式 × 下方不可缓存元素 | `backdrop_style_count × (inner + blur + grad/10)` |
 | B. Path 几何量 | `path_data_bytes (MB)` |
 | C. 大画布 × 元素密度 | `(pix_M/100) × (imgPat + layer/30 + grad/20)` |
-| D. BgBlur 数量 | `bg_count` |
+| D. 背景采样样式数量 | `backdrop_style_count`（BackgroundBlurStyle + GlassStyle） |
 | E. Layer XML 数量 | 源 XML 中 `<Layer>` 数量 |
 
 ### 设备档位（按 `wx.getDeviceBenchmarkInfo`）

--- a/pagx/wechat/package.json
+++ b/pagx/wechat/package.json
@@ -16,7 +16,8 @@
     "build:js": "rollup -c ./script/rollup.wx.js &&  node script/copy-files.js  &&  tsc -p ./tsconfig.type.json ",
     "build": "node script/cmake.wx.js -a wasm && brotli -f ./lib/pagx-viewer.wasm && npm run build:js",
     "build:release": "node script/cmake.wx.js -a wasm -DNO_LOG=ON && brotli -f ./lib/pagx-viewer.wasm && npm run build:js",
-    "copyFile": "node script/copy-files.js"
+    "copyFile": "node script/copy-files.js",
+    "test:pagx-check": "node test/pagx-check-glass-risk.test.mjs"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "~28.0.3",

--- a/pagx/wechat/test/pagx-check-glass-risk.test.mjs
+++ b/pagx/wechat/test/pagx-check-glass-risk.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { buildSync } from 'esbuild';
+
+globalThis.wx = {
+  getAppBaseInfo: () => ({ SDKVersion: '2.19.0' }),
+  getSystemInfoSync: () => ({
+    SDKVersion: '2.19.0',
+    platform: 'android',
+    benchmarkLevel: 30,
+    brand: 'test',
+    model: 'test',
+  }),
+};
+
+const tempDir = await mkdtemp(join(tmpdir(), 'pagx-check-glass-risk-'));
+try {
+  const bundlePath = join(tempDir, 'pagx-check.mjs');
+  buildSync({
+    bundle: true,
+    entryPoints: ['ts/pagx-check.ts'],
+    format: 'esm',
+    outfile: bundlePath,
+    platform: 'node',
+  });
+
+  const { CheckPagx } = await import(pathToFileURL(bundlePath).href);
+  const encoder = new TextEncoder();
+  const check = (style) => CheckPagx(encoder.encode(`
+    <pagx width="1000" height="1000">
+      <Layer>
+        <Rectangle size="1000,1000"/>
+        <Fill color="#FFFFFF"/>
+        ${style}
+      </Layer>
+    </pagx>
+  `));
+
+  const backgroundBlur = await check('<BackgroundBlurStyle blurX="50" blurY="50"/>');
+  const glassFrost100 = await check('<GlassStyle frost="100"/>');
+  const glassFrost50 = await check('<GlassStyle frost="50"/>');
+  const glassDefaultFrost = await check('<GlassStyle/>');
+  const glassFrost5 = await check('<GlassStyle frost="5"/>');
+
+  assert.equal(glassFrost100.score, backgroundBlur.score);
+  assert.ok(glassFrost50.score > glassFrost100.score);
+  assert.equal(glassDefaultFrost.score, glassFrost5.score);
+} finally {
+  await rm(tempDir, { force: true, recursive: true });
+}

--- a/pagx/wechat/ts/pagx-check.ts
+++ b/pagx/wechat/ts/pagx-check.ts
@@ -204,26 +204,26 @@ interface RiskPathConfig {
 }
 
 const BASE_RISK_PATHS: Record<string, RiskPathConfig> = {
-  A_bg_x_uncacheable: { yellow: 2000, red: 4000 },
+  A_backdrop_x_uncacheable: { yellow: 2000, red: 4000 },
   B_path_data_MB: { yellow: 3, red: 25 },
   C_canvas_x_density: { yellow: 1500, red: 5000 },
-  bg_blur_count: { yellow: 200, red: 400 },
+  backdrop_style_count: { yellow: 200, red: 400 },
   layer_xml: { yellow: 15000, red: 30000 },
 };
 
 const LOCAL_RISK_PATHS = {
-  bgBlurAreaRadius: { yellow: 25, red: 120 },
+  backdropAreaRadius: { yellow: 25, red: 120 },
   imageLoadMP: { yellow: 80, red: 220 },
   imageRuntimeRisk: { yellow: 45, red: 95 },
 };
-const NEUTRAL_SDK_BG_UNCACHEABLE_RISK = BASE_RISK_PATHS.A_bg_x_uncacheable;
+const NEUTRAL_SDK_BG_UNCACHEABLE_RISK = BASE_RISK_PATHS.A_backdrop_x_uncacheable;
 const BARELY_USABLE_SCORE = 50;
 const NEUTRAL_SDK_GREEN_SCORE = 75;
-const SMALL_AREA_BLUR_RISK = 25;
+const SMALL_AREA_BACKDROP_RISK = 25;
 const LARGE_DOWNSCALE_RATIO = 16;
 
 interface LocalRiskRaw {
-  bgBlurAreaRadius: number;
+  backdropAreaRadius: number;
   imageDecodeMP: number;
   imageDownscaleMP: number;
   sdkBgUncacheableRisk: number;
@@ -241,7 +241,7 @@ interface ImageRiskState {
 
 interface LayerScanState {
   maxShapeArea: number;
-  bgBlurRadii: number[];
+  backdropStyleRadii: number[];
 }
 
 /**
@@ -656,7 +656,7 @@ function scanLocalRisk(root: XmlNode): LocalRiskRaw {
   const docWidth = readNumericAttr(root.attribs, 'width');
   const docHeight = readNumericAttr(root.attribs, 'height');
   const raw: LocalRiskRaw = {
-    bgBlurAreaRadius: 0,
+    backdropAreaRadius: 0,
     imageDecodeMP: 0,
     imageDownscaleMP: 0,
     sdkBgUncacheableRisk: 0,
@@ -671,7 +671,7 @@ function scanLocalRisk(root: XmlNode): LocalRiskRaw {
     downscaleOriginalPixels: new Map<string, number>(),
     patternIndex: 0,
   };
-  let bgBlurCount = 0;
+  let backdropStyleCount = 0;
   let innerShadowCount = 0;
   let blurFilterCount = 0;
   let gradientCount = 0;
@@ -680,7 +680,7 @@ function scanLocalRisk(root: XmlNode): LocalRiskRaw {
     let layerState: LayerScanState | null = null;
     if (node.tag === 'Layer') {
       raw.layerCount += 1;
-      layerState = { maxShapeArea: 0, bgBlurRadii: [] };
+      layerState = { maxShapeArea: 0, backdropStyleRadii: [] };
       layerStack.push(layerState);
     }
 
@@ -691,12 +691,21 @@ function scanLocalRisk(root: XmlNode): LocalRiskRaw {
       if (currentLayer && area > currentLayer.maxShapeArea) currentLayer.maxShapeArea = area;
     }
     if (node.tag === 'BackgroundBlurStyle') {
-      bgBlurCount += 1;
+      backdropStyleCount += 1;
       const currentLayer = currentLayerState(layerStack);
       if (currentLayer) {
-        currentLayer.bgBlurRadii.push(
+        currentLayer.backdropStyleRadii.push(
           Math.max(readNumericAttr(node.attribs, 'blurX'), readNumericAttr(node.attribs, 'blurY'), 0),
         );
+      }
+    }
+    // GlassStyle is a backdrop-sampling style with the same background snapshot cost
+    // as BackgroundBlurStyle; frost is the blur-equivalent parameter for radii tracking.
+    if (node.tag === 'GlassStyle') {
+      backdropStyleCount += 1;
+      const currentLayer = currentLayerState(layerStack);
+      if (currentLayer) {
+        currentLayer.backdropStyleRadii.push(readNumericAttr(node.attribs, 'frost'));
       }
     }
     if (node.tag === 'InnerShadowStyle') {
@@ -713,7 +722,7 @@ function scanLocalRisk(root: XmlNode): LocalRiskRaw {
 
     if (node.tag === 'Layer' && layerState) {
       const areaMP = layerState.maxShapeArea / 1_000_000;
-      for (const radius of layerState.bgBlurRadii) raw.bgBlurAreaRadius += areaMP * radius;
+      for (const radius of layerState.backdropStyleRadii) raw.backdropAreaRadius += areaMP * radius;
       layerStack.pop();
       const parentLayer = currentLayerState(layerStack);
       if (parentLayer && layerState.maxShapeArea > parentLayer.maxShapeArea) {
@@ -727,14 +736,14 @@ function scanLocalRisk(root: XmlNode): LocalRiskRaw {
     .reduce((sum, pixels) => sum + pixels, 0) / 1_000_000;
   raw.imageDownscaleMP = Array.from(imageState.downscaleOriginalPixels.values())
     .reduce((sum, pixels) => sum + pixels, 0) / 1_000_000;
-  raw.sdkBgUncacheableRisk = bgBlurCount * (innerShadowCount + blurFilterCount + gradientCount / 10);
+  raw.sdkBgUncacheableRisk = backdropStyleCount * (innerShadowCount + blurFilterCount + gradientCount / 10);
   return raw;
 }
 
-function scoreBgBlurAreaRadius(value: number): number {
+function scoreBackdropAreaRadius(value: number): number {
   if (value <= 0) return 100;
   return Math.max(
-    normalize(value, LOCAL_RISK_PATHS.bgBlurAreaRadius.yellow, LOCAL_RISK_PATHS.bgBlurAreaRadius.red),
+    normalize(value, LOCAL_RISK_PATHS.backdropAreaRadius.yellow, LOCAL_RISK_PATHS.backdropAreaRadius.red),
     BARELY_USABLE_SCORE,
   );
 }
@@ -744,14 +753,14 @@ function getImageRuntimeRisk(raw: LocalRiskRaw): number {
   if (effectiveDownscaleMP <= 0) return 0;
 
   const contentComplexity = raw.layerCount / 1500 + raw.textCount / 400 + raw.innerShadowCount / 10;
-  const bgBlurInteraction = raw.bgBlurAreaRadius > 0
-    && raw.bgBlurAreaRadius <= LOCAL_RISK_PATHS.bgBlurAreaRadius.red
-    ? (raw.bgBlurAreaRadius / 60) * contentComplexity
+  const backdropInteraction = raw.backdropAreaRadius > 0
+    && raw.backdropAreaRadius <= LOCAL_RISK_PATHS.backdropAreaRadius.red
+    ? (raw.backdropAreaRadius / 60) * contentComplexity
     : 0;
   const layoutInteraction = raw.imageDownscaleMP >= LOCAL_RISK_PATHS.imageLoadMP.yellow
     ? raw.layerCount / 6000 + raw.docMP / 100
     : 0;
-  return effectiveDownscaleMP * (bgBlurInteraction + layoutInteraction);
+  return effectiveDownscaleMP * (backdropInteraction + layoutInteraction);
 }
 
 function scoreImageLoadRisk(raw: LocalRiskRaw): number {
@@ -772,7 +781,7 @@ function scoreImageRuntimeRisk(raw: LocalRiskRaw): number {
 
 function scoreLocalRisk(raw: LocalRiskRaw): number {
   return Math.min(
-    scoreBgBlurAreaRadius(raw.bgBlurAreaRadius),
+    scoreBackdropAreaRadius(raw.backdropAreaRadius),
     scoreImageLoadRisk(raw),
     scoreImageRuntimeRisk(raw),
   );
@@ -787,10 +796,10 @@ function scoreNeutralSdkRisk(raw: LocalRiskRaw): number {
 }
 
 function protectDeviceSpread(baseScore: number, localScore: number, neutralScore: number, raw: LocalRiskRaw): number {
-  const isSmallAreaBlur = raw.bgBlurAreaRadius > 0 && raw.bgBlurAreaRadius <= SMALL_AREA_BLUR_RISK;
+  const isSmallAreaBackdrop = raw.backdropAreaRadius > 0 && raw.backdropAreaRadius <= SMALL_AREA_BACKDROP_RISK;
   if (baseScore < BARELY_USABLE_SCORE
       && localScore >= BARELY_USABLE_SCORE
-      && (neutralScore >= NEUTRAL_SDK_GREEN_SCORE || isSmallAreaBlur)) {
+      && (neutralScore >= NEUTRAL_SDK_GREEN_SCORE || isSmallAreaBackdrop)) {
     return BARELY_USABLE_SCORE;
   }
   return baseScore;
@@ -927,7 +936,13 @@ export async function CheckPagx(pagxData: Uint8Array): Promise<PagxCheckResult> 
   const expandedTagCounts = countTagsWithExpansion(root);
 
   // Key metrics (use the expanded counts to reflect the real rendering cost).
-  const bgBlurCount = expandedTagCounts.get('BackgroundBlurStyle') || 0;
+  // Backdrop-sampling styles: BackgroundBlurStyle and GlassStyle both trigger the same
+  // background snapshot mechanism; GlassStyle runs the full glass shader (refraction /
+  // dispersion / frost / edge lighting) on the sampled background, so it is equally or
+  // more expensive per instance and must be counted alongside BackgroundBlurStyle.
+  const backdropStyleCount =
+    (expandedTagCounts.get('BackgroundBlurStyle') || 0) +
+    (expandedTagCounts.get('GlassStyle') || 0);
   const imagePattern = expandedTagCounts.get('ImagePattern') || 0;
   const innerShadowCount = expandedTagCounts.get('InnerShadowStyle') || 0;
   const blurFilterCount = expandedTagCounts.get('BlurFilter') || 0;
@@ -951,15 +966,15 @@ export async function CheckPagx(pagxData: Uint8Array): Promise<PagxCheckResult> 
   // Compute the raw values of the five risk paths.
   const riskRaw: Record<string, number> = {
     // Path A: BgBlur × uncacheable elements (uses the expanded counts).
-    A_bg_x_uncacheable:
-      bgBlurCount * (innerShadowCount + blurFilterCount + gradientCount / 10),
+    A_backdrop_x_uncacheable:
+      backdropStyleCount * (innerShadowCount + blurFilterCount + gradientCount / 10),
     // Path B: Path data volume (uses the expanded counts).
     B_path_data_MB: pathDataBytes / (1024 * 1024),
     // Path C: canvas × element density (uses the expanded Layer count).
     C_canvas_x_density:
       (pixM / 100) * (imagePattern + expandedLayerCount / 30 + gradientCount / 20),
     // Path D: BgBlur count (uses the expanded counts).
-    bg_blur_count: bgBlurCount,
+    backdrop_style_count: backdropStyleCount,
     // Path E: Layer XML count (uses the raw XML count, consistent with the Python version).
     layer_xml: layerXml,
   };
@@ -972,8 +987,8 @@ export async function CheckPagx(pagxData: Uint8Array): Promise<PagxCheckResult> 
   }
 
   // Supplementary calibration from real-device business samples:
-  // - Large-area bgBlur bottoms out at 50 (openable but not recommended).
-  // - Image pressure only counts as a runtime FPS risk when combined with bgBlur / layers / text / canvas complexity.
+  // - Large-area backdrop styles bottoms out at 50 (openable but not recommended).
+  // - Image pressure only counts as a runtime FPS risk when combined with backdrop styles / layers / text / canvas complexity.
   // - Small-area but high-count blur is kept from being wrongly killed by the SDK A path.
   const localRiskRaw = scanLocalRisk(root);
   const localScore = scoreLocalRisk(localRiskRaw);

--- a/pagx/wechat/ts/pagx-check.ts
+++ b/pagx/wechat/ts/pagx-check.ts
@@ -705,7 +705,8 @@ function scanLocalRisk(root: XmlNode): LocalRiskRaw {
       backdropStyleCount += 1;
       const currentLayer = currentLayerState(layerStack);
       if (currentLayer) {
-        currentLayer.backdropStyleRadii.push(readNumericAttr(node.attribs, 'frost'));
+        const frost = node.attribs.frost === undefined ? 5 : readNumericAttr(node.attribs, 'frost');
+        currentLayer.backdropStyleRadii.push(Math.max(0.5, frost * 0.5));
       }
     }
     if (node.tag === 'InnerShadowStyle') {

--- a/pagx/wechat/ts/pagx-check.ts
+++ b/pagx/wechat/ts/pagx-check.ts
@@ -966,7 +966,7 @@ export async function CheckPagx(pagxData: Uint8Array): Promise<PagxCheckResult> 
 
   // Compute the raw values of the five risk paths.
   const riskRaw: Record<string, number> = {
-    // Path A: BgBlur × uncacheable elements (uses the expanded counts).
+    // Path A: backdrop styles × uncacheable elements (uses the expanded counts).
     A_backdrop_x_uncacheable:
       backdropStyleCount * (innerShadowCount + blurFilterCount + gradientCount / 10),
     // Path B: Path data volume (uses the expanded counts).
@@ -974,7 +974,7 @@ export async function CheckPagx(pagxData: Uint8Array): Promise<PagxCheckResult> 
     // Path C: canvas × element density (uses the expanded Layer count).
     C_canvas_x_density:
       (pixM / 100) * (imagePattern + expandedLayerCount / 30 + gradientCount / 20),
-    // Path D: BgBlur count (uses the expanded counts).
+    // Path D: backdrop style count (uses the expanded counts).
     backdrop_style_count: backdropStyleCount,
     // Path E: Layer XML count (uses the raw XML count, consistent with the Python version).
     layer_xml: layerXml,

--- a/pagx/wechat/ts/pagx-check.ts
+++ b/pagx/wechat/ts/pagx-check.ts
@@ -8,10 +8,10 @@ declare const wx: any;
  * Risk model: "max-risk-path" scoring (May 2026 calibration, high-end device as baseline).
  *
  * Five independent failure paths:
- *   A. "BgBlur × uncacheable below"    bg_count × (inner + blur + grad/10)
+ *   A. "Backdrop × uncacheable below"  backdrop_style_count × (inner + blur + grad/10)
  *   B. "Path geometry overload"        path_data_bytes (MB)
  *   C. "Big canvas × element density"  (pix_M/100) × (imgPat + layer/30 + grad/20)
- *   D. "BgBlur count"                  bg_count
+ *   D. "Backdrop style count"          backdrop_style_count (BackgroundBlurStyle + GlassStyle)
  *   E. "Layer XML count"               raw <Layer> count in source XML
  *
  * Rendering recommendation (decided by runtime platform):

--- a/resources/cli/render_layer_backdrop.pagx
+++ b/resources/cli/render_layer_backdrop.pagx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Backdrop-dependent layer styles over a multicolor lower layer tree. -->
+<pagx width="320" height="180">
+  <Layer id="background-left">
+    <Rectangle position="80,90" size="160,180"/>
+    <Fill color="#E53935"/>
+  </Layer>
+  <Layer id="background-right">
+    <Rectangle position="240,90" size="160,180"/>
+    <Fill color="#1565C0"/>
+  </Layer>
+  <Layer id="background-band">
+    <Rectangle position="160,90" size="320,36"/>
+    <Fill color="#FDD835"/>
+  </Layer>
+  <Layer id="background-blur">
+    <Rectangle position="90,90" size="120,110" roundness="20"/>
+    <Fill color="#FFFFFF59"/>
+    <BackgroundBlurStyle blurX="12" blurY="12"/>
+  </Layer>
+  <Layer id="glass">
+    <Rectangle position="230,90" size="120,110" roundness="20"/>
+    <Fill color="#FFFFFF59"/>
+    <GlassStyle refraction="75" depth="25" frost="8" dispersion="45" splay="10"
+                lightAngle="35" lightIntensity="70"/>
+  </Layer>
+</pagx>

--- a/resources/cli/verify_c11_low_opacity_glass.pagx
+++ b/resources/cli/verify_c11_low_opacity_glass.pagx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Test file for C11: Low opacity with a high-cost GlassStyle -->
+<pagx width="200" height="100">
+  <Layer name="LowOpacityGlass" left="10" top="10" alpha="0.03">
+    <Rectangle left="10" width="80" height="50"/>
+    <Fill color="#FF0000"/>
+    <GlassStyle/>
+  </Layer>
+</pagx>

--- a/spec/pagx.xsd
+++ b/spec/pagx.xsd
@@ -775,6 +775,20 @@
     <xs:attribute name="excludeChildEffects" type="BoolType" default="false"/>
   </xs:complexType>
 
+  <!-- GlassStyle -->
+  <xs:complexType name="GlassStyleType">
+    <xs:attributeGroup ref="CommonAttributes"/>
+    <xs:attribute name="refraction" type="xs:decimal" default="80"/>
+    <xs:attribute name="depth" type="xs:decimal" default="20"/>
+    <xs:attribute name="frost" type="xs:decimal" default="5"/>
+    <xs:attribute name="dispersion" type="xs:decimal" default="50"/>
+    <xs:attribute name="splay" type="xs:decimal" default="0"/>
+    <xs:attribute name="lightAngle" type="xs:decimal" default="45"/>
+    <xs:attribute name="lightIntensity" type="xs:decimal" default="80"/>
+    <xs:attribute name="blendMode" type="BlendModeType" default="normal"/>
+    <xs:attribute name="excludeChildEffects" type="BoolType" default="false"/>
+  </xs:complexType>
+
   <!-- ========================= Layer Filters ========================= -->
 
   <!-- BlurFilter -->
@@ -887,6 +901,7 @@
       <xs:element name="DropShadowStyle" type="DropShadowStyleType"/>
       <xs:element name="InnerShadowStyle" type="InnerShadowStyleType"/>
       <xs:element name="BackgroundBlurStyle" type="BackgroundBlurStyleType"/>
+      <xs:element name="GlassStyle" type="GlassStyleType"/>
       <!-- Layer Filters -->
       <xs:element name="BlurFilter" type="BlurFilterType"/>
       <xs:element name="DropShadowFilter" type="DropShadowFilterType"/>

--- a/spec/pagx_spec.md
+++ b/spec/pagx_spec.md
@@ -938,7 +938,7 @@ Layer child elements are automatically categorized into five collections by type
 | Child Element Type | Category | Description |
 |-------------------|----------|-------------|
 | VectorElement | contents | Geometry elements, modifiers, painters (participate in accumulation processing) |
-| LayerStyle | styles | DropShadowStyle, InnerShadowStyle, BackgroundBlurStyle, NoiseStyle |
+| LayerStyle | styles | DropShadowStyle, InnerShadowStyle, BackgroundBlurStyle, NoiseStyle, GlassStyle |
 | LayerFilter | filters | BlurFilter, DropShadowFilter, InnerShadowFilter, BlendFilter, ColorMatrixFilter, NoiseFilter |
 | `<Timelines>` | timelines | Container of `<Animation ref="@id" playing="..."/>` and `<StateMachine ref="@id"/>` entries that drive animations or state machines on the referenced Composition |
 | Layer | children | Nested child layers |
@@ -1082,6 +1082,25 @@ Overlays procedural Perlin noise above the layer content. Three noise modes are 
 | `firstColor` | Color | #000000 | First noise color for Duo mode |
 | `secondColor` | Color | #FFFFFF | Second noise color for Duo mode |
 | `opacity` | float | 0.15 | Overall noise opacity for Multi mode, in [0, 1] |
+
+#### 5.3.5 GlassStyle
+
+Simulates the physical behavior of light passing through a glass surface, producing refraction, chromatic dispersion, frosted blur, and specular highlights. Computes the effect based on **layer background**, using opaque layer content as the shape mask. The background comes implicitly from the complete PAGX layer tree below the layer; no background reference attribute is used. All seven parameters are animatable float channels matching `tgfx::GlassStyle`.
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `refraction` | float | 80 | Optical distortion strength along curved edges, range [0, 100] |
+| `depth` | float | 20 | Inward extent of the refraction region from edges, range [1, 100] |
+| `frost` | float | 5 | Background blur amount (frosted glass), range [0, 100] |
+| `dispersion` | float | 50 | Chromatic aberration intensity (rainbow prism effect), range [0, 100] |
+| `splay` | float | 0 | Refraction direction blend factor, range [0, 100]. At 0, refraction follows the curvature of the shape's edges; at 100, it points toward the shape center |
+| `lightAngle` | float | 45 | Light source direction in degrees. 0 means light from directly above, positive values rotate clockwise. Range [-179, 180] |
+| `lightIntensity` | float | 80 | Edge highlight brightness, range [0, 100] |
+
+**Rendering Steps**:
+1. Get layer background below the layer (implicit backdrop of the full PAGX layer tree)
+2. Apply frosted blur (`frost`), refraction (`refraction`, `depth`, `splay`), and chromatic dispersion (`dispersion`) to the layer background, shaped by the opaque layer content
+3. Add specular edge highlights using `lightAngle` and `lightIntensity`
 
 ### 5.4 Layer Filters
 
@@ -2799,7 +2818,7 @@ This appendix describes node categorization and nesting rules.
 | **State Machine** | `StateMachine`, `Input`, `StateRegion`, `State`, `Transition`, `Condition` | State-driven behavior: input-conditioned transitions between states, each bound to an Animation or empty. Defined in `<Animations>`, driven via `<StateMachine ref="@id"/>` in Layer `<Timelines>`. |
 | **ViewModel** | `ViewModel`, `Property`, `DataBind`, `DataConverter` | ViewModel schema and data binding definitions. |
 | **Color Sources** | `SolidColor`, `LinearGradient`, `RadialGradient`, `ConicGradient`, `DiamondGradient`, `ImagePattern`, `ColorStop` | Color definitions used by painters. |
-| **Layer Styles** | `DropShadowStyle`, `InnerShadowStyle`, `BackgroundBlurStyle`, `NoiseStyle` | Visual effects applied to Layer content. |
+| **Layer Styles** | `DropShadowStyle`, `InnerShadowStyle`, `BackgroundBlurStyle`, `NoiseStyle`, `GlassStyle` | Visual effects applied to Layer content. |
 | **Layer Filters** | `BlurFilter`, `DropShadowFilter`, `InnerShadowFilter`, `BlendFilter`, `ColorMatrixFilter`, `NoiseFilter` | Post-processing effects applied to composited Layer. |
 | **Geometry Elements** | `Rectangle`, `Ellipse`, `Polystar`, `Path`, `Text`, `GlyphRun` | Drawable geometry (shapes and text). Must be inside Layer/Group. |
 | **Modifiers** | `TrimPath`, `RoundCorner`, `MergePath`, `TextModifier`, `RangeSelector`, `TextPath`, `Repeater` | Transform or combine geometry and text. |
@@ -2816,7 +2835,7 @@ pagx (required attributes: width, height)
 │   ├── VectorElement* (see A.3)
 │   ├── <svg>* (import directive, see §7)
 │   ├── Timelines? → Animation* (ref="@id", playing) or StateMachine* (ref="@id")
-│   ├── LayerStyle* (DropShadow / InnerShadow / BackgroundBlur / Noise)
+│   ├── LayerStyle* (DropShadow / InnerShadow / BackgroundBlur / Noise / Glass)
 │   ├── LayerFilter* (Blur / DropShadow / InnerShadow / Blend / ColorMatrix / Noise)
 │   └── Layer* (child layers, recursive)
 │
@@ -3131,6 +3150,18 @@ Group and TextBox share the following transform channels for applying animated t
 | `blurX`, `blurY` | float | Blur radius |
 | `color` | color | Shadow / overlay color |
 | `showBehindLayer` | boolean | Show behind layer (DropShadowStyle) |
+
+**GlassStyle** (all animatable float channels):
+
+| Channel | Value Type | Description |
+|---------|------------|-------------|
+| `refraction` | float | Optical distortion strength along curved edges [0, 100] |
+| `depth` | float | Inward extent of the refraction region from edges [1, 100] |
+| `frost` | float | Background blur amount (frosted glass) [0, 100] |
+| `dispersion` | float | Chromatic aberration intensity [0, 100] |
+| `splay` | float | Refraction direction blend factor [0, 100] |
+| `lightAngle` | float | Light source direction in degrees [-179, 180] |
+| `lightIntensity` | float | Edge highlight brightness [0, 100] |
 
 ### D.9 Filters (Blur / DropShadow / InnerShadow / Blend)
 

--- a/spec/pagx_spec.zh_CN.md
+++ b/spec/pagx_spec.zh_CN.md
@@ -938,7 +938,7 @@ Layer 的子元素按类型自动归类为五个集合：
 | 子元素类型 | 归类 | 说明 |
 |-----------|------|------|
 | VectorElement | contents | 几何元素、修改器、绘制器（参与累积处理） |
-| LayerStyle | styles | DropShadowStyle、InnerShadowStyle、BackgroundBlurStyle、NoiseStyle |
+| LayerStyle | styles | DropShadowStyle、InnerShadowStyle、BackgroundBlurStyle、NoiseStyle、GlassStyle |
 | LayerFilter | filters | BlurFilter、DropShadowFilter、InnerShadowFilter、BlendFilter、ColorMatrixFilter、NoiseFilter |
 | Timeline | timelines | `<Timelines>` 容器内的 `<Animation ref="@id" playing="..."/>` 和 `<StateMachine ref="@id"/>` 条目，用于驱动引用合成上的动画或状态机 |
 | Layer | children | 嵌套子图层 |
@@ -1082,6 +1082,25 @@ Layer 的子元素按类型自动归类为五个集合：
 | `firstColor` | Color | #000000 | Duo 模式下的第一种噪声颜色 |
 | `secondColor` | Color | #FFFFFF | Duo 模式下的第二种噪声颜色 |
 | `opacity` | float | 0.15 | Multi 模式下的整体噪声透明度 [0, 1] |
+
+#### 5.3.5 玻璃样式（GlassStyle）
+
+模拟光穿过玻璃表面的物理行为，产生折射、色散（色差）、磨砂模糊和镜面高光。基于**图层背景**计算效果，并使用不透明图层内容作为形状遮罩。背景来自完整 PAGX 图层树的隐式 backdrop，不使用背景引用属性。七个参数均为可动画的 float 通道，字段与 `tgfx::GlassStyle` 一致。
+
+| 属性 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `refraction` | float | 80 | 沿曲线边缘的光学畸变强度，范围 [0, 100] |
+| `depth` | float | 20 | 折射区域从边缘向内的延伸程度，范围 [1, 100] |
+| `frost` | float | 5 | 背景模糊量（磨砂玻璃），范围 [0, 100] |
+| `dispersion` | float | 50 | 色散（彩虹棱镜效果）强度，范围 [0, 100] |
+| `splay` | float | 0 | 折射方向混合因子，范围 [0, 100]。为 0 时折射沿形状边缘曲率方向；为 100 时指向形状中心 |
+| `lightAngle` | float | 45 | 光源方向（角度）。0 表示光源位于正上方，正值顺时针旋转。范围 [-179, 180] |
+| `lightIntensity` | float | 80 | 边缘高光亮度，范围 [0, 100] |
+
+**渲染步骤**：
+1. 获取图层下方的图层背景（完整 PAGX 图层树的隐式 backdrop）
+2. 以不透明图层内容为形状遮罩，对图层背景应用磨砂模糊（`frost`）、折射（`refraction`、`depth`、`splay`）和色散（`dispersion`）
+3. 使用 `lightAngle` 和 `lightIntensity` 添加镜面边缘高光
 
 ### 5.4 图层滤镜（Layer Filters）
 
@@ -2791,7 +2810,7 @@ ViewModel 是属性的模式定义，包含名称、类型、默认值和可选�
 | **状态机** | `StateMachine`, `Input`, `StateRegion`, `State`, `Transition`, `Condition` | 状态驱动行为：由输入条件触发状态间转换，每个状态可绑定 Animation 或为空。在 `<Animations>` 中定义，通过 `<StateMachine ref="@id"/>` 在 Layer `<Timelines>` 中驱动。 |
 | **ViewModel** | `ViewModel`, `Property`, `DataBind`, `DataConverter` | ViewModel 模式与数据绑定定义。 |
 | **颜色源** | `SolidColor`, `LinearGradient`, `RadialGradient`, `ConicGradient`, `DiamondGradient`, `ImagePattern`, `ColorStop` | 绘制器使用的颜色定义。 |
-| **图层样式** | `DropShadowStyle`, `InnerShadowStyle`, `BackgroundBlurStyle`, `NoiseStyle` | 应用于图层内容的视觉效果。 |
+| **图层样式** | `DropShadowStyle`, `InnerShadowStyle`, `BackgroundBlurStyle`, `NoiseStyle`, `GlassStyle` | 应用于图层内容的视觉效果。 |
 | **图层滤镜** | `BlurFilter`, `DropShadowFilter`, `InnerShadowFilter`, `BlendFilter`, `ColorMatrixFilter`, `NoiseFilter` | 应用于合成图层的后期处理效果。 |
 | **几何元素** | `Rectangle`, `Ellipse`, `Polystar`, `Path`, `Text`, `GlyphRun` | 可绘制的几何（形状和文本）。必须在 Layer/Group 内。 |
 | **修改器** | `TrimPath`, `RoundCorner`, `MergePath`, `TextModifier`, `RangeSelector`, `TextPath`, `Repeater` | 变换或组合几何图形和文本。 |
@@ -2808,7 +2827,7 @@ pagx（必需属性：width、height）
 │   ├── VectorElement*（见 A.3）
 │   ├── <svg>*（导入指令，见 §7）
 │   ├── Timelines? → Animation* (ref="@id", playing) 或 StateMachine* (ref="@id")
-│   ├── LayerStyle*（DropShadow / InnerShadow / BackgroundBlur / Noise）
+│   ├── LayerStyle*（DropShadow / InnerShadow / BackgroundBlur / Noise / Glass）
 │   ├── LayerFilter*（Blur / DropShadow / InnerShadow / Blend / ColorMatrix / Noise）
 │   └── Layer*（子图层，递归）
 │
@@ -3123,6 +3142,18 @@ Group 和 TextBox 共享以下变换通道，可对内部元素整体施加动�
 | `blurX`, `blurY` | float | 模糊半径 |
 | `color` | color | 阴影/覆盖颜色 |
 | `showBehindLayer` | boolean | 是否显示在图层后方（DropShadowStyle） |
+
+**GlassStyle**（全部为可动画 float 通道）：
+
+| 通道 | 值类型 | 说明 |
+|------|--------|------|
+| `refraction` | float | 沿曲线边缘的光学畸变强度 [0, 100] |
+| `depth` | float | 折射区域从边缘向内的延伸程度 [1, 100] |
+| `frost` | float | 背景模糊量（磨砂玻璃）[0, 100] |
+| `dispersion` | float | 色散强度 [0, 100] |
+| `splay` | float | 折射方向混合因子 [0, 100] |
+| `lightAngle` | float | 光源方向（角度）[-179, 180] |
+| `lightIntensity` | float | 边缘高光亮度 [0, 100] |
 
 ### D.9 滤镜（Blur / DropShadow / InnerShadow / Blend）
 

--- a/src/cli/CommandVerify.cpp
+++ b/src/cli/CommandVerify.cpp
@@ -1627,7 +1627,7 @@ static bool HasHighCostChildren(const Layer* layer) {
   for (auto* style : layer->styles) {
     auto type = style->nodeType();
     if (type == NodeType::DropShadowStyle || type == NodeType::InnerShadowStyle ||
-        type == NodeType::BackgroundBlurStyle) {
+        type == NodeType::BackgroundBlurStyle || type == NodeType::GlassStyle) {
       return true;
     }
   }

--- a/src/cli/FormatUtils.cpp
+++ b/src/cli/FormatUtils.cpp
@@ -389,6 +389,8 @@ const char* NodeTypeName(NodeType type) {
       return "InnerShadowStyle";
     case NodeType::BackgroundBlurStyle:
       return "BackgroundBlurStyle";
+    case NodeType::GlassStyle:
+      return "GlassStyle";
     default:
       return "Node";
   }

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -39,6 +39,7 @@
 #include "pagx/nodes/Ellipse.h"
 #include "pagx/nodes/Fill.h"
 #include "pagx/nodes/Font.h"
+#include "pagx/nodes/GlassStyle.h"
 #include "pagx/nodes/GlyphRun.h"
 #include "pagx/nodes/Gradient.h"
 #include "pagx/nodes/Group.h"
@@ -1267,6 +1268,27 @@ static void WriteLayerStyle(XMLBuilder& xml, const LayerStyle* node) {
       if (style->tileMode != Default<BackgroundBlurStyle>().tileMode) {
         xml.addAttribute("tileMode", TileModeToString(style->tileMode));
       }
+      WriteCustomData(xml, node);
+      xml.closeElementSelfClosing();
+      break;
+    }
+    case NodeType::GlassStyle: {
+      auto style = static_cast<const GlassStyle*>(node);
+      xml.openElement("GlassStyle");
+      xml.addAttribute("id", style->id);
+      if (style->blendMode != Default<GlassStyle>().blendMode) {
+        xml.addAttribute("blendMode", BlendModeToString(style->blendMode));
+      }
+      xml.addAttribute("excludeChildEffects", style->excludeChildEffects,
+                       Default<GlassStyle>().excludeChildEffects);
+      xml.addAttribute("refraction", style->refraction, Default<GlassStyle>().refraction);
+      xml.addAttribute("depth", style->depth, Default<GlassStyle>().depth);
+      xml.addAttribute("frost", style->frost, Default<GlassStyle>().frost);
+      xml.addAttribute("dispersion", style->dispersion, Default<GlassStyle>().dispersion);
+      xml.addAttribute("splay", style->splay, Default<GlassStyle>().splay);
+      xml.addAttribute("lightAngle", style->lightAngle, Default<GlassStyle>().lightAngle);
+      xml.addAttribute("lightIntensity", style->lightIntensity,
+                       Default<GlassStyle>().lightIntensity);
       WriteCustomData(xml, node);
       xml.closeElementSelfClosing();
       break;

--- a/src/pagx/PAGXImporter.cpp
+++ b/src/pagx/PAGXImporter.cpp
@@ -45,6 +45,7 @@
 #include "pagx/nodes/Ellipse.h"
 #include "pagx/nodes/Fill.h"
 #include "pagx/nodes/Font.h"
+#include "pagx/nodes/GlassStyle.h"
 #include "pagx/nodes/GlyphRun.h"
 #include "pagx/nodes/Gradient.h"
 #include "pagx/nodes/Group.h"
@@ -190,6 +191,7 @@ static Composition* ParseComposition(const DOMNode* node, PAGXDocument* doc);
 static Font* ParseFont(const DOMNode* node, PAGXDocument* doc);
 static Glyph* ParseGlyph(const DOMNode* node, PAGXDocument* doc);
 static GlyphRun* ParseGlyphRun(const DOMNode* node, PAGXDocument* doc);
+static GlassStyle* ParseGlassStyle(const DOMNode* node, PAGXDocument* doc);
 static DropShadowStyle* ParseDropShadowStyle(const DOMNode* node, PAGXDocument* doc);
 static InnerShadowStyle* ParseInnerShadowStyle(const DOMNode* node, PAGXDocument* doc);
 static BackgroundBlurStyle* ParseBackgroundBlurStyle(const DOMNode* node, PAGXDocument* doc);
@@ -620,6 +622,7 @@ static Layer* ParseLayer(const DOMNode* node, PAGXDocument* doc) {
                     " Path, Text, Fill, Stroke, TrimPath, RoundCorner,"
                     " MergePath, TextModifier, TextPath, TextBox, Repeater,"
                     " DropShadowStyle, InnerShadowStyle, BackgroundBlurStyle, NoiseStyle,"
+                    " GlassStyle,"
                     " BlurFilter, DropShadowFilter, InnerShadowFilter,"
                     " BlendFilter, ColorMatrixFilter, NoiseFilter.");
   }
@@ -665,7 +668,7 @@ static void ParseStyles(const DOMNode* node, Layer* layer, PAGXDocument* doc) {
                   "Element '" + current->name +
                       "' is not allowed in 'styles'."
                       " Expected: DropShadowStyle, InnerShadowStyle,"
-                      " BackgroundBlurStyle, NoiseStyle.");
+                      " BackgroundBlurStyle, NoiseStyle, GlassStyle.");
     }
   }
 }
@@ -813,6 +816,9 @@ static LayerStyle* ParseLayerStyle(const DOMNode* node, PAGXDocument* doc) {
   }
   if (node->name == "NoiseStyle") {
     return ParseNoiseStyle(node, doc);
+  }
+  if (node->name == "GlassStyle") {
+    return ParseGlassStyle(node, doc);
   }
   return nullptr;
 }
@@ -2428,6 +2434,25 @@ static BackgroundBlurStyle* ParseBackgroundBlurStyle(const DOMNode* node, PAGXDo
   style->blurX = GetFloatAttribute(node, "blurX", Default<BackgroundBlurStyle>().blurX, doc);
   style->blurY = GetFloatAttribute(node, "blurY", Default<BackgroundBlurStyle>().blurY, doc);
   style->tileMode = GET_ENUM(node, "tileMode", "mirror", doc, TileMode);
+  return style;
+}
+
+static GlassStyle* ParseGlassStyle(const DOMNode* node, PAGXDocument* doc) {
+  auto style = makeNodeFromXML<GlassStyle>(node, doc);
+  if (!style) {
+    return nullptr;
+  }
+  style->blendMode = GET_ENUM(node, "blendMode", "normal", doc, BlendMode);
+  style->excludeChildEffects =
+      GetBoolAttribute(node, "excludeChildEffects", Default<GlassStyle>().excludeChildEffects, doc);
+  style->refraction = GetFloatAttribute(node, "refraction", Default<GlassStyle>().refraction, doc);
+  style->depth = GetFloatAttribute(node, "depth", Default<GlassStyle>().depth, doc);
+  style->frost = GetFloatAttribute(node, "frost", Default<GlassStyle>().frost, doc);
+  style->dispersion = GetFloatAttribute(node, "dispersion", Default<GlassStyle>().dispersion, doc);
+  style->splay = GetFloatAttribute(node, "splay", Default<GlassStyle>().splay, doc);
+  style->lightAngle = GetFloatAttribute(node, "lightAngle", Default<GlassStyle>().lightAngle, doc);
+  style->lightIntensity =
+      GetFloatAttribute(node, "lightIntensity", Default<GlassStyle>().lightIntensity, doc);
   return style;
 }
 

--- a/src/pagx/PAGXNodeChannel.cpp
+++ b/src/pagx/PAGXNodeChannel.cpp
@@ -33,6 +33,7 @@
 #include "pagx/nodes/DropShadowStyle.h"
 #include "pagx/nodes/Ellipse.h"
 #include "pagx/nodes/Fill.h"
+#include "pagx/nodes/GlassStyle.h"
 #include "pagx/nodes/Gradient.h"
 #include "pagx/nodes/Group.h"
 #include "pagx/nodes/ImagePattern.h"
@@ -745,6 +746,20 @@ static std::vector<ChannelDef> BuildBackgroundBlurStyleFields() {
   };
 }
 
+static std::vector<ChannelDef> BuildGlassStyleFields() {
+  return {
+      FIELD_ENUM(GlassStyle, "blendMode", blendMode, NoFlags, BlendMode),
+      FIELD_BOOL(GlassStyle, "excludeChildEffects", excludeChildEffects, NoFlags),
+      FIELD_FLOAT(GlassStyle, "refraction", refraction, Anim),
+      FIELD_FLOAT(GlassStyle, "depth", depth, Anim),
+      FIELD_FLOAT(GlassStyle, "frost", frost, Anim),
+      FIELD_FLOAT(GlassStyle, "dispersion", dispersion, Anim),
+      FIELD_FLOAT(GlassStyle, "splay", splay, Anim),
+      FIELD_FLOAT(GlassStyle, "lightAngle", lightAngle, Anim),
+      FIELD_FLOAT(GlassStyle, "lightIntensity", lightIntensity, Anim),
+  };
+}
+
 static std::vector<ChannelDef> BuildBlurFilterFields() {
   return {
       FIELD_FLOAT(BlurFilter, "blurX", blurX, Anim),
@@ -893,6 +908,10 @@ const std::vector<ChannelDef>& ChannelsFor(NodeType type) {
     }
     case NodeType::BackgroundBlurStyle: {
       static const std::vector<ChannelDef> table = BuildBackgroundBlurStyleFields();
+      return table;
+    }
+    case NodeType::GlassStyle: {
+      static const std::vector<ChannelDef> table = BuildGlassStyleFields();
       return table;
     }
     case NodeType::BlurFilter: {

--- a/src/pagx/html/HTMLWriterLayer.cpp
+++ b/src/pagx/html/HTMLWriterLayer.cpp
@@ -2270,6 +2270,11 @@ void HTMLWriter::writeLayer(HTMLBuilder& out, const Layer* layer, float parentAl
       if (hasBlendMode) {
         belowStyles.push_back({NodeType::BackgroundBlurStyle, ls});
       }
+    } else if (ls->nodeType() == NodeType::GlassStyle) {
+      // GlassStyle (frost / refraction / chromatic dispersion / edge lighting) is a GPU-shader
+      // backdrop effect that CSS cannot reproduce faithfully — a bare `backdrop-filter: blur()`
+      // would only capture the frost component and misrepresent the rest. Intentionally skipped
+      // so the layer's base content still renders and no wrong approximation is emitted.
     }
   }
   if (!pendingFilterDropShadows.empty()) {

--- a/src/pagx/ppt/PPTExporter.cpp
+++ b/src/pagx/ppt/PPTExporter.cpp
@@ -797,7 +797,7 @@ void PPTWriter::writeLayer(XMLBuilder& out, const Layer* layer,
   // blends, ColorMatrix filters, or wide-gamut colors.
   auto features = ProbeLayerFeatures(layer);
   if (features.needsRasterization(_bakeUnsupported)) {
-    // Backdrop-aware features (non-Normal blend mode, BackgroundBlurStyle)
+    // Backdrop-aware features (non-Normal blend mode, backdrop styles)
     // require rendering the whole scene clipped to the layer's bounds —
     // this turns any editable native content beneath the patch into baked
     // pixels, which is the main reason a caller might disable

--- a/src/pagx/ppt/PPTFeatureProbe.cpp
+++ b/src/pagx/ppt/PPTFeatureProbe.cpp
@@ -93,8 +93,7 @@ static void Merge(PPTFeatureFlags* dst, const PPTFeatureFlags& src) {
   dst->hasDiamondGradient |= src.hasDiamondGradient;
   dst->hasConicGradient |= src.hasConicGradient;
   dst->hasShearTransform |= src.hasShearTransform;
-  dst->hasBackgroundBlur |= src.hasBackgroundBlur;
-  dst->hasGlassStyle |= src.hasGlassStyle;
+  dst->hasBackdropStyle |= src.hasBackdropStyle;
 }
 
 static bool GradientHasWideGamutStop(const std::vector<ColorStop*>& stops) {
@@ -224,14 +223,15 @@ PPTFeatureFlags ProbeLayerFeatures(const Layer* layer) {
     }
     if (style->nodeType() == NodeType::BackgroundBlurStyle) {
       auto* bg = static_cast<const BackgroundBlurStyle*>(style);
+      // Zero-radius BackgroundBlur is a true no-op, so only flag when blur is non-zero.
       if (bg->blurX > 0 || bg->blurY > 0) {
-        out.hasBackgroundBlur = true;
+        out.hasBackdropStyle = true;
       }
     } else if (style->nodeType() == NodeType::GlassStyle) {
-      // Unlike BackgroundBlurStyle (a true no-op at zero radius), a GlassStyle always
-      // composites the backdrop through the layer's shape (frost / refraction / chromatic
-      // dispersion / edge lighting) as soon as it is present, so flag it unconditionally.
-      out.hasGlassStyle = true;
+      // Unlike BackgroundBlurStyle, a GlassStyle always composites the backdrop through the
+      // layer's shape (frost / refraction / chromatic dispersion / edge lighting) as soon as
+      // it is present, so flag it unconditionally.
+      out.hasBackdropStyle = true;
     }
   }
 

--- a/src/pagx/ppt/PPTFeatureProbe.cpp
+++ b/src/pagx/ppt/PPTFeatureProbe.cpp
@@ -94,6 +94,7 @@ static void Merge(PPTFeatureFlags* dst, const PPTFeatureFlags& src) {
   dst->hasConicGradient |= src.hasConicGradient;
   dst->hasShearTransform |= src.hasShearTransform;
   dst->hasBackgroundBlur |= src.hasBackgroundBlur;
+  dst->hasGlassStyle |= src.hasGlassStyle;
 }
 
 static bool GradientHasWideGamutStop(const std::vector<ColorStop*>& stops) {
@@ -226,6 +227,11 @@ PPTFeatureFlags ProbeLayerFeatures(const Layer* layer) {
       if (bg->blurX > 0 || bg->blurY > 0) {
         out.hasBackgroundBlur = true;
       }
+    } else if (style->nodeType() == NodeType::GlassStyle) {
+      // Unlike BackgroundBlurStyle (a true no-op at zero radius), a GlassStyle always
+      // composites the backdrop through the layer's shape (frost / refraction / chromatic
+      // dispersion / edge lighting) as soon as it is present, so flag it unconditionally.
+      out.hasGlassStyle = true;
     }
   }
 

--- a/src/pagx/ppt/PPTFeatureProbe.h
+++ b/src/pagx/ppt/PPTFeatureProbe.h
@@ -57,21 +57,29 @@ struct PPTFeatureFlags {
                                      // rounded corners, so it is not a valid stand-in). On the
                                      // vector path the style is silently dropped; only the
                                      // backdrop-aware raster fallback can reproduce it.
+  bool hasGlassStyle = false;        // GlassStyle is a shader-based glass effect (refraction,
+                                     // chromatic dispersion, frosted blur, edge lighting) that
+                                     // samples and optically distorts the backdrop behind the
+                                     // layer. OOXML has no primitive that can reproduce it and no
+                                     // approximate stand-in is worth emitting, so the layer must
+                                     // be baked via the backdrop-aware raster fallback to stay
+                                     // faithful. On the vector path the style is silently dropped.
 
   /**
    * Returns true when at least one unsupported feature is present and the exporter should fall
    * back to baking the layer to a PNG patch. Features with no meaningful vector fallback
    * (TextPath, TextModifier, ColorMatrix, conic/diamond gradients, shear transforms) always
    * trigger a bake. Features that have a degraded-but-valid vector fallback (unsupported blend
-   * modes fall back to Normal, wide-gamut colors clamp to sRGB, background blur is dropped)
-   * trigger a bake only when the caller opts in via `bakeUnsupported`.
+   * modes fall back to Normal, wide-gamut colors clamp to sRGB, background blur and glass
+   * effects are dropped) trigger a bake only when the caller opts in via `bakeUnsupported`.
    */
   bool needsRasterization(bool bakeUnsupported) const {
     if (hasTextPath || hasTextModifier || hasColorMatrix || hasConicGradient ||
         hasDiamondGradient || hasShearTransform) {
       return true;
     }
-    if (bakeUnsupported && (hasUnsupportedBlend || hasWideGamutColor || hasBackgroundBlur)) {
+    if (bakeUnsupported &&
+        (hasUnsupportedBlend || hasWideGamutColor || hasBackgroundBlur || hasGlassStyle)) {
       return true;
     }
     return false;
@@ -79,11 +87,12 @@ struct PPTFeatureFlags {
 
   /**
    * Returns true when reproducing the unsupported feature requires compositing the layer against
-   * the real backdrop pixels (non-Normal blend mode, BackgroundBlurStyle). Self-contained features
-   * (TextPath, ColorMatrix, wide-gamut color, etc.) render fine against an empty canvas.
+   * the real backdrop pixels (non-Normal blend mode, BackgroundBlurStyle, GlassStyle).
+   * Self-contained features (TextPath, ColorMatrix, wide-gamut color, etc.) render fine against
+   * an empty canvas.
    */
   bool requiresBackdrop(bool bakeUnsupported) const {
-    return bakeUnsupported && (hasUnsupportedBlend || hasBackgroundBlur);
+    return bakeUnsupported && (hasUnsupportedBlend || hasBackgroundBlur || hasGlassStyle);
   }
 };
 

--- a/src/pagx/ppt/PPTFeatureProbe.h
+++ b/src/pagx/ppt/PPTFeatureProbe.h
@@ -51,35 +51,28 @@ struct PPTFeatureFlags {
                                      // translation, rotation, and axis-aligned scale/flip). The
                                      // exporter's matrix decomposition silently drops the shear,
                                      // producing a visibly wrong shape unless the layer is baked.
-  bool hasBackgroundBlur = false;    // BackgroundBlurStyle is a frosted-glass / backdrop-filter
-                                     // effect; OOXML has no native backdrop-blur primitive
-                                     // (a:blur blurs the shape itself, including its strokes and
-                                     // rounded corners, so it is not a valid stand-in). On the
-                                     // vector path the style is silently dropped; only the
+  bool hasBackdropStyle = false;     // A backdrop-sampling layer style (BackgroundBlurStyle or
+                                     // GlassStyle). Both are shader-based effects that sample the
+                                     // pixels behind the layer (frosted blur for BackgroundBlur;
+                                     // refraction / dispersion / edge lighting for Glass). OOXML
+                                     // has no primitive that can reproduce either; on the vector
+                                     // path the style is silently dropped, and only the
                                      // backdrop-aware raster fallback can reproduce it.
-  bool hasGlassStyle = false;        // GlassStyle is a shader-based glass effect (refraction,
-                                     // chromatic dispersion, frosted blur, edge lighting) that
-                                     // samples and optically distorts the backdrop behind the
-                                     // layer. OOXML has no primitive that can reproduce it and no
-                                     // approximate stand-in is worth emitting, so the layer must
-                                     // be baked via the backdrop-aware raster fallback to stay
-                                     // faithful. On the vector path the style is silently dropped.
 
   /**
    * Returns true when at least one unsupported feature is present and the exporter should fall
    * back to baking the layer to a PNG patch. Features with no meaningful vector fallback
    * (TextPath, TextModifier, ColorMatrix, conic/diamond gradients, shear transforms) always
    * trigger a bake. Features that have a degraded-but-valid vector fallback (unsupported blend
-   * modes fall back to Normal, wide-gamut colors clamp to sRGB, background blur and glass
-   * effects are dropped) trigger a bake only when the caller opts in via `bakeUnsupported`.
+   * modes fall back to Normal, wide-gamut colors clamp to sRGB, backdrop styles are dropped)
+   * trigger a bake only when the caller opts in via `bakeUnsupported`.
    */
   bool needsRasterization(bool bakeUnsupported) const {
     if (hasTextPath || hasTextModifier || hasColorMatrix || hasConicGradient ||
         hasDiamondGradient || hasShearTransform) {
       return true;
     }
-    if (bakeUnsupported &&
-        (hasUnsupportedBlend || hasWideGamutColor || hasBackgroundBlur || hasGlassStyle)) {
+    if (bakeUnsupported && (hasUnsupportedBlend || hasWideGamutColor || hasBackdropStyle)) {
       return true;
     }
     return false;
@@ -87,12 +80,11 @@ struct PPTFeatureFlags {
 
   /**
    * Returns true when reproducing the unsupported feature requires compositing the layer against
-   * the real backdrop pixels (non-Normal blend mode, BackgroundBlurStyle, GlassStyle).
-   * Self-contained features (TextPath, ColorMatrix, wide-gamut color, etc.) render fine against
-   * an empty canvas.
+   * the real backdrop pixels (non-Normal blend mode, backdrop styles). Self-contained features
+   * (TextPath, ColorMatrix, wide-gamut color, etc.) render fine against an empty canvas.
    */
   bool requiresBackdrop(bool bakeUnsupported) const {
-    return bakeUnsupported && (hasUnsupportedBlend || hasBackgroundBlur || hasGlassStyle);
+    return bakeUnsupported && (hasUnsupportedBlend || hasBackdropStyle);
   }
 };
 

--- a/src/pagx/ppt/PPTStyleEmitter.cpp
+++ b/src/pagx/ppt/PPTStyleEmitter.cpp
@@ -516,13 +516,14 @@ void PPTWriter::writeEffects(XMLBuilder& out, const std::vector<LayerFilter*>& f
   // shape bounds — required for solid-filled shapes, otherwise PowerPoint clips the
   // blurred edges back to the original bounds and the effect becomes invisible.
   //
-  // BackgroundBlurStyle is intentionally NOT mapped to a:blur. It is a frosted-glass
-  // / backdrop-filter effect that blurs the pixels behind the shape while leaving the
-  // shape's own fill and stroke crisp. OOXML has no native backdrop-blur primitive
-  // and using a:blur as a stand-in produces visibly wrong output: the card's stroke,
-  // rounded corners, and fill all become fuzzy. Authors who need a faithful render of
-  // BackgroundBlurStyle should enable `bakeUnsupported` so the layer is baked with
-  // its real backdrop via rasterizeLayerAsPicture (probed in PPTFeatureProbe).
+  // BackgroundBlurStyle and GlassStyle are intentionally NOT mapped to a:blur. They
+  // are backdrop-sampling effects that operate on the pixels behind the shape while
+  // leaving the shape's own fill and stroke crisp. OOXML has no native backdrop
+  // primitive and using a:blur as a stand-in produces visibly wrong output: the
+  // card's stroke, rounded corners, and fill all become fuzzy. Authors who need a
+  // faithful render of either style should enable `bakeUnsupported` so the layer is
+  // baked with its real backdrop via rasterizeLayerAsPicture (probed in
+  // PPTFeatureProbe).
   if (sources.blur) {
     float avgBlur = (sources.blur->blurX + sources.blur->blurY) / 2.0f;
     if (avgBlur > 0) {

--- a/src/pagx/ppt/PPTWriter.h
+++ b/src/pagx/ppt/PPTWriter.h
@@ -571,10 +571,10 @@ struct EffectSources {
   const DropShadowFilter* dropShadowFilter = nullptr;
   const DropShadowStyle* dropShadowStyle = nullptr;
 
-  // BackgroundBlurStyle is intentionally not tracked: it has no faithful OOXML
-  // primitive (a:blur blurs the shape itself, not the backdrop) and the writer
-  // drops it on the vector path. When `bakeUnsupported` is enabled, the feature
-  // probe bakes the layer (with backdrop) to a PNG patch instead.
+  // BackgroundBlurStyle and GlassStyle are intentionally not tracked: they have no
+  // faithful OOXML primitive (a:blur blurs the shape itself, not the backdrop) and
+  // the writer drops them on the vector path. When `bakeUnsupported` is enabled, the
+  // feature probe bakes the layer (with backdrop) to a PNG patch instead.
   bool empty() const {
     return !blur && !blend && !innerShadowFilter && !innerShadowStyle && !dropShadowFilter &&
            !dropShadowStyle;

--- a/src/pagx/svg/SVGExporter.cpp
+++ b/src/pagx/svg/SVGExporter.cpp
@@ -1492,10 +1492,12 @@ void SVGWriter::writeFilterList(const std::vector<LayerFilter*>& filters, int& s
 }
 
 // LayerStyle emission mirrors the Filter pass so DropShadowStyle / InnerShadowStyle
-// share the feMerge aggregation logic. BackgroundBlurStyle is silently skipped because SVG has
-// no portable backdrop-blur primitive (the deprecated enable-background is not supported by
-// modern renderers). NoiseStyle emits its SVG primitives and adds the result name to
-// agg.aboveResults so it composites above the source in the final feMerge.
+// share the feMerge aggregation logic. BackgroundBlurStyle and GlassStyle are explicitly
+// skipped because SVG has no portable backdrop-blur / glass primitive (the deprecated
+// enable-background is not supported by modern renderers), so the layer keeps its base vector
+// content and only the unsupported backdrop effect is dropped. NoiseStyle emits its SVG
+// primitives and adds the result name to agg.aboveResults so it composites above the source in
+// the final feMerge.
 void SVGWriter::writeStyleList(const std::vector<LayerStyle*>& styles, int& shadowIndex,
                                ShadowAggregate& agg) {
   int noiseStyleIndex = 0;
@@ -1548,6 +1550,12 @@ void SVGWriter::writeStyleList(const std::vector<LayerStyle*>& styles, int& shad
         agg.needSourceGraphic = true;
         break;
       }
+      case NodeType::GlassStyle:
+        // GlassStyle (frost / refraction / chromatic dispersion / edge lighting) samples and
+        // optically distorts the backdrop via GPU shaders; SVG has no portable equivalent.
+        // Skipped explicitly like BackgroundBlurStyle so the layer's base content still
+        // renders and no wrong approximation is emitted.
+        break;
       default:
         break;
     }
@@ -1606,12 +1614,14 @@ std::string SVGWriter::writeFilterAndStyleDefs(const std::vector<LayerFilter*>& 
     return {};
   }
 
-  // BackgroundBlurStyle is silently skipped (SVG has no portable backdrop-blur). Check whether
-  // any style will actually produce SVG filter primitives so we don't emit an empty <filter>
-  // element, which would make the layer invisible.
+  // BackgroundBlurStyle and GlassStyle are explicitly skipped (SVG has no portable
+  // backdrop-blur / glass primitive). Check whether any other style will actually produce SVG
+  // filter primitives so we don't emit an empty <filter> element, which would make the layer
+  // invisible.
   bool hasEffectiveStyle = false;
   for (const auto* style : styles) {
-    if (style->nodeType() != NodeType::BackgroundBlurStyle) {
+    if (style->nodeType() != NodeType::BackgroundBlurStyle &&
+        style->nodeType() != NodeType::GlassStyle) {
       hasEffectiveStyle = true;
       break;
     }
@@ -3255,8 +3265,9 @@ void SVGWriter::writeLayer(SVGBuilder& out, const Layer* layer) {
   // diamond/conic gradient). If any trip AND rasterization is enabled, bake the whole layer to a
   // PNG so the visual result is preserved. The alternative (silently dropping unsupported
   // elements / degrading gradients to radial) is what the vector path below does.
-  // BackgroundBlurStyle is intentionally excluded: SVG has no portable backdrop-blur primitive,
-  // so the layer is kept as vector with the blur effect silently dropped.
+  // BackgroundBlurStyle and GlassStyle are intentionally excluded: SVG has no portable
+  // backdrop-blur / glass primitive, so the layer is kept as vector with the effect explicitly
+  // dropped (only the base content is emitted).
   if (_bakeUnsupported) {
     auto features = ProbeLayerFeaturesForSVG(layer);
     if (features.needsRasterization()) {

--- a/src/pagx/svg/SVGExporter.cpp
+++ b/src/pagx/svg/SVGExporter.cpp
@@ -3265,9 +3265,9 @@ void SVGWriter::writeLayer(SVGBuilder& out, const Layer* layer) {
   // diamond/conic gradient). If any trip AND rasterization is enabled, bake the whole layer to a
   // PNG so the visual result is preserved. The alternative (silently dropping unsupported
   // elements / degrading gradients to radial) is what the vector path below does.
-  // BackgroundBlurStyle and GlassStyle are intentionally excluded: SVG has no portable
-  // backdrop-blur / glass primitive, so the layer is kept as vector with the effect explicitly
-  // dropped (only the base content is emitted).
+  // Note: the SVG feature probe only covers layer->contents; layer styles (including
+  // BackgroundBlurStyle and GlassStyle, which SVG has no portable primitive for) are handled
+  // separately by the explicit skip in writeStyleList / writeFilterAndStyleDefs.
   if (_bakeUnsupported) {
     auto features = ProbeLayerFeaturesForSVG(layer);
     if (features.needsRasterization()) {

--- a/src/pagx/utils/StringParser.cpp
+++ b/src/pagx/utils/StringParser.cpp
@@ -91,6 +91,8 @@ const char* NodeTypeName(NodeType type) {
       return "BackgroundBlurStyle";
     case NodeType::NoiseStyle:
       return "NoiseStyle";
+    case NodeType::GlassStyle:
+      return "GlassStyle";
     case NodeType::BlurFilter:
       return "BlurFilter";
     case NodeType::DropShadowFilter:

--- a/src/renderer/LayerBuilder.cpp
+++ b/src/renderer/LayerBuilder.cpp
@@ -146,10 +146,14 @@ void RuntimeBinding::remove(const Node* node) {
 //
 // PAG_DISABLE_BACKGROUND_BLUR_STYLE: skips BackgroundBlurStyle (offscreen background snapshot
 //   plus blur pass; usually the heaviest single category in dense designs).
+// PAG_DISABLE_GLASS_STYLE:           skips GlassStyle (offscreen background snapshot with
+//   refraction / dispersion / frost / edge-light passes; cost is comparable to or higher than
+//   BackgroundBlurStyle since it runs the full glass shader on the sampled background).
 // PAG_DISABLE_SHADOW_STYLES:         skips DropShadowStyle and InnerShadowStyle.
 // PAG_DISABLE_LAYER_FILTERS:         skips all LayerFilters (BlurFilter, DropShadow/InnerShadow
 //   filters, BlendFilter, ColorMatrixFilter). BlurFilter with very large sigma dominates here.
 #define PAG_DISABLE_BACKGROUND_BLUR_STYLE 0
+#define PAG_DISABLE_GLASS_STYLE 0
 #define PAG_DISABLE_SHADOW_STYLES 0
 #define PAG_DISABLE_LAYER_FILTERS 0
 
@@ -2474,6 +2478,9 @@ class LayerBuilderContext {
 #endif
       }
       case NodeType::GlassStyle: {
+#if PAG_DISABLE_GLASS_STYLE
+        return nullptr;
+#else
         auto style = static_cast<const pagx::GlassStyle*>(node);
         auto tgfxStyle =
             tgfx::GlassStyle::Make(style->refraction, style->depth, style->frost, style->dispersion,
@@ -2484,6 +2491,7 @@ class LayerBuilderContext {
         _result.binding.set(style, tgfxStyle);
         bindGlassStyleChannels(style);
         return tgfxStyle;
+#endif
       }
       case NodeType::NoiseStyle: {
         auto style = static_cast<const pagx::NoiseStyle*>(node);

--- a/src/renderer/LayerBuilder.cpp
+++ b/src/renderer/LayerBuilder.cpp
@@ -36,6 +36,7 @@
 #include "pagx/nodes/Ellipse.h"
 #include "pagx/nodes/Fill.h"
 #include "pagx/nodes/Font.h"
+#include "pagx/nodes/GlassStyle.h"
 #include "pagx/nodes/Gradient.h"
 #include "pagx/nodes/Group.h"
 #include "pagx/nodes/Image.h"
@@ -100,6 +101,7 @@
 #include "tgfx/layers/filters/NoiseFilter.h"
 #include "tgfx/layers/layerstyles/BackgroundBlurStyle.h"
 #include "tgfx/layers/layerstyles/DropShadowStyle.h"
+#include "tgfx/layers/layerstyles/GlassStyle.h"
 #include "tgfx/layers/layerstyles/InnerShadowStyle.h"
 #include "tgfx/layers/layerstyles/NoiseStyle.h"
 #include "tgfx/layers/vectors/Ellipse.h"
@@ -2471,6 +2473,18 @@ class LayerBuilderContext {
         return tgfxStyle;
 #endif
       }
+      case NodeType::GlassStyle: {
+        auto style = static_cast<const pagx::GlassStyle*>(node);
+        auto tgfxStyle =
+            tgfx::GlassStyle::Make(style->refraction, style->depth, style->frost, style->dispersion,
+                                   style->splay, style->lightAngle, style->lightIntensity);
+        if (node->blendMode != BlendMode::Normal) {
+          tgfxStyle->setBlendMode(ToTGFX(node->blendMode));
+        }
+        _result.binding.set(style, tgfxStyle);
+        bindGlassStyleChannels(style);
+        return tgfxStyle;
+      }
       case NodeType::NoiseStyle: {
         auto style = static_cast<const pagx::NoiseStyle*>(node);
         if (style->size <= 0.0f) {
@@ -2666,6 +2680,37 @@ class LayerBuilderContext {
     _result.binding.setAccessor(
         node, "blurY", WriteBackgroundBlurStyleBlurY,
         ReadScalar<tgfx::BackgroundBlurStyle, &tgfx::BackgroundBlurStyle::blurrinessY>);
+  }
+
+  void bindGlassStyleChannels(const pagx::GlassStyle* node) {
+    _result.binding.setAccessor(node, "refraction",
+                                WriteMixedFloat<tgfx::GlassStyle, &tgfx::GlassStyle::refraction,
+                                                &tgfx::GlassStyle::setRefraction>,
+                                ReadScalar<tgfx::GlassStyle, &tgfx::GlassStyle::refraction>);
+    _result.binding.setAccessor(
+        node, "depth",
+        WriteMixedFloat<tgfx::GlassStyle, &tgfx::GlassStyle::depth, &tgfx::GlassStyle::setDepth>,
+        ReadScalar<tgfx::GlassStyle, &tgfx::GlassStyle::depth>);
+    _result.binding.setAccessor(
+        node, "frost",
+        WriteMixedFloat<tgfx::GlassStyle, &tgfx::GlassStyle::frost, &tgfx::GlassStyle::setFrost>,
+        ReadScalar<tgfx::GlassStyle, &tgfx::GlassStyle::frost>);
+    _result.binding.setAccessor(node, "dispersion",
+                                WriteMixedFloat<tgfx::GlassStyle, &tgfx::GlassStyle::dispersion,
+                                                &tgfx::GlassStyle::setDispersion>,
+                                ReadScalar<tgfx::GlassStyle, &tgfx::GlassStyle::dispersion>);
+    _result.binding.setAccessor(
+        node, "splay",
+        WriteMixedFloat<tgfx::GlassStyle, &tgfx::GlassStyle::splay, &tgfx::GlassStyle::setSplay>,
+        ReadScalar<tgfx::GlassStyle, &tgfx::GlassStyle::splay>);
+    _result.binding.setAccessor(node, "lightAngle",
+                                WriteMixedFloat<tgfx::GlassStyle, &tgfx::GlassStyle::lightAngle,
+                                                &tgfx::GlassStyle::setLightAngle>,
+                                ReadScalar<tgfx::GlassStyle, &tgfx::GlassStyle::lightAngle>);
+    _result.binding.setAccessor(node, "lightIntensity",
+                                WriteMixedFloat<tgfx::GlassStyle, &tgfx::GlassStyle::lightIntensity,
+                                                &tgfx::GlassStyle::setLightIntensity>,
+                                ReadScalar<tgfx::GlassStyle, &tgfx::GlassStyle::lightIntensity>);
   }
 
   static void WriteNoiseStyleSize(void* object, const KeyValue& value, float mix) {

--- a/test/src/PAGXCliTest.cpp
+++ b/test/src/PAGXCliTest.cpp
@@ -849,6 +849,19 @@ CLI_TEST(PAGXCliTest, Verify_C11_LowOpacityHighCost) {
   EXPECT_TRUE(output.find("high-cost children") != std::string::npos);
 }
 
+CLI_TEST(PAGXCliTest, Verify_C11_LowOpacityHighCostGlassStyle) {
+  auto inputPath = TestResourcePath("verify_c11_low_opacity_glass.pagx");
+  std::streambuf* old = std::cerr.rdbuf();
+  std::ostringstream oss;
+  std::cerr.rdbuf(oss.rdbuf());
+  auto ret = CallRun(pagx::cli::RunVerify, {"verify", "--skip-render", "--skip-layout", inputPath});
+  std::cerr.rdbuf(old);
+  auto output = oss.str();
+  EXPECT_NE(ret, 0);
+  EXPECT_TRUE(output.find("opacity") != std::string::npos);
+  EXPECT_TRUE(output.find("high-cost children") != std::string::npos);
+}
+
 CLI_TEST(PAGXCliTest, Verify_C13_SimpleRectangleMask) {
   auto inputPath = TestResourcePath("verify_c13_simple_rect_mask.pagx");
   std::streambuf* old = std::cerr.rdbuf();

--- a/test/src/PAGXCliTest.cpp
+++ b/test/src/PAGXCliTest.cpp
@@ -392,6 +392,26 @@ CLI_TEST(PAGXCliTest, Render_Background) {
                                "PAGXCliTest/RenderBackground"));
 }
 
+CLI_TEST(PAGXCliTest, Render_BackdropStyles) {
+  auto inputPath = TestResourcePath("render_layer_backdrop.pagx");
+  std::vector<std::string> args = {"render", inputPath};
+  std::vector<char*> argv;
+  for (auto& arg : args) {
+    argv.push_back(arg.data());
+  }
+  auto bitmap = pagx::cli::RenderToBitmap(static_cast<int>(argv.size()), argv.data());
+  ASSERT_FALSE(bitmap.isEmpty());
+  EXPECT_EQ(bitmap.width(), 320);
+  EXPECT_EQ(bitmap.height(), 180);
+
+  auto blurredRed = bitmap.getColor(90, 55);
+  auto glassBlue = bitmap.getColor(230, 55);
+  EXPECT_GT(blurredRed.red, blurredRed.blue);
+  EXPECT_GT(glassBlue.blue, glassBlue.red);
+  EXPECT_GT(blurredRed.alpha, 0.99f);
+  EXPECT_GT(glassBlue.alpha, 0.99f);
+}
+
 CLI_TEST(PAGXCliTest, Render_WebpFormat) {
   auto inputPath = TestResourcePath("render_basic.pagx");
   auto outputPath = TempDir() + "/RenderWebpFormat.webp";

--- a/test/src/PAGXGlassRenderTest.cpp
+++ b/test/src/PAGXGlassRenderTest.cpp
@@ -1,0 +1,173 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <cmath>
+
+#include "base/PAGTest.h"
+#include "pagx/PAGXDocument.h"
+#include "pagx/nodes/Fill.h"
+#include "pagx/nodes/GlassStyle.h"
+#include "pagx/nodes/Layer.h"
+#include "pagx/nodes/Rectangle.h"
+#include "pagx/nodes/SolidColor.h"
+#include "renderer/LayerBuilder.h"
+#include "tgfx/core/Bitmap.h"
+#include "tgfx/core/Pixmap.h"
+#include "tgfx/core/Surface.h"
+#include "tgfx/layers/DisplayList.h"
+#include "tgfx/layers/Layer.h"
+#include "utils/PAGXTestUtils.h"
+
+namespace pag {
+
+static std::shared_ptr<pagx::PAGXDocument> MakeGlassDocument(bool withGlass) {
+  auto document = pagx::PAGXDocument::Make(300, 300);
+
+  auto backgroundLayer = document->makeNode<pagx::Layer>();
+  auto backgroundRect = document->makeNode<pagx::Rectangle>();
+  backgroundRect->size = {300.0f, 300.0f};
+  backgroundRect->position = {150.0f, 150.0f};
+  auto backgroundFill = document->makeNode<pagx::Fill>();
+  auto backgroundColor = document->makeNode<pagx::SolidColor>();
+  backgroundColor->color = {1.0f, 0.0f, 0.0f, 1.0f};
+  backgroundFill->color = backgroundColor;
+  backgroundLayer->contents = {backgroundRect, backgroundFill};
+  document->layers.push_back(backgroundLayer);
+
+  auto detailLayer = document->makeNode<pagx::Layer>();
+  auto detailRect = document->makeNode<pagx::Rectangle>();
+  detailRect->size = {100.0f, 60.0f};
+  detailRect->position = {130.0f, 150.0f};
+  auto detailFill = document->makeNode<pagx::Fill>();
+  auto detailColor = document->makeNode<pagx::SolidColor>();
+  detailColor->color = {0.0f, 0.0f, 1.0f, 1.0f};
+  detailFill->color = detailColor;
+  detailLayer->contents = {detailRect, detailFill};
+  document->layers.push_back(detailLayer);
+
+  auto glassLayer = document->makeNode<pagx::Layer>();
+  auto glassRect = document->makeNode<pagx::Rectangle>();
+  glassRect->size = {200.0f, 200.0f};
+  glassRect->position = {150.0f, 150.0f};
+  auto glassFill = document->makeNode<pagx::Fill>();
+  auto glassColor = document->makeNode<pagx::SolidColor>();
+  glassColor->color = {0.9f, 0.9f, 0.9f, 0.8f};
+  glassFill->color = glassColor;
+  glassLayer->contents = {glassRect, glassFill};
+  if (withGlass) {
+    auto glass = document->makeNode<pagx::GlassStyle>();
+    glass->refraction = 80.0f;
+    glass->depth = 20.0f;
+    glass->frost = 40.0f;
+    glass->dispersion = 50.0f;
+    glass->splay = 0.0f;
+    glass->lightAngle = 45.0f;
+    glass->lightIntensity = 80.0f;
+    glassLayer->styles.push_back(glass);
+  }
+  document->layers.push_back(glassLayer);
+
+  return document;
+}
+
+static tgfx::Bitmap RenderViaDisplayList(pagx::PAGXDocument* document, tgfx::Context* context) {
+  document->applyLayout();
+  auto layer = pagx::LayerBuilder::Build(document);
+  EXPECT_NE(layer, nullptr);
+  if (layer == nullptr) {
+    return {};
+  }
+  auto surface = tgfx::Surface::Make(context, 300, 300);
+  EXPECT_NE(surface, nullptr);
+  if (surface == nullptr) {
+    return {};
+  }
+  tgfx::DisplayList displayList;
+  displayList.root()->addChild(layer);
+  displayList.render(surface.get(), false);
+
+  tgfx::Bitmap bitmap(surface->width(), surface->height(), false, false, nullptr);
+  tgfx::Pixmap pixmap(bitmap);
+  return surface->readPixels(pixmap.info(), pixmap.writablePixels()) ? bitmap : tgfx::Bitmap{};
+}
+
+static tgfx::Bitmap RenderViaOrphanDirectDraw(pagx::PAGXDocument* document, tgfx::Context* context) {
+  document->applyLayout();
+  auto layer = pagx::LayerBuilder::Build(document);
+  EXPECT_NE(layer, nullptr);
+  if (layer == nullptr) {
+    return {};
+  }
+  auto surface = tgfx::Surface::Make(context, 300, 300, tgfx::ColorType::RGBA_8888, 1, 0, 0, nullptr);
+  EXPECT_NE(surface, nullptr);
+  if (surface == nullptr) {
+    return {};
+  }
+  layer->draw(surface->getCanvas(), layer->alpha());
+
+  tgfx::Bitmap bitmap(surface->width(), surface->height(), false, false, nullptr);
+  tgfx::Pixmap pixmap(bitmap);
+  return surface->readPixels(pixmap.info(), pixmap.writablePixels()) ? bitmap : tgfx::Bitmap{};
+}
+
+static int CountDifferentPixels(const tgfx::Bitmap& first, const tgfx::Bitmap& second) {
+  if (first.isEmpty() || second.isEmpty() || first.width() != second.width() ||
+      first.height() != second.height()) {
+    return -1;
+  }
+  tgfx::Pixmap firstPixmap(first);
+  tgfx::Pixmap secondPixmap(second);
+  const auto* firstPixels = static_cast<const uint8_t*>(firstPixmap.pixels());
+  const auto* secondPixels = static_cast<const uint8_t*>(secondPixmap.pixels());
+  int differentPixels = 0;
+  const size_t pixelCount = static_cast<size_t>(first.width()) * first.height();
+  for (size_t pixel = 0; pixel < pixelCount; pixel++) {
+    for (size_t channel = 0; channel < 4; channel++) {
+      const auto offset = pixel * 4 + channel;
+      if (std::abs(firstPixels[offset] - secondPixels[offset]) > 8) {
+        differentPixels++;
+        break;
+      }
+    }
+  }
+  return differentPixels;
+}
+
+PAGX_TEST(PAGXGlassRenderTest, GlassStyleOrphanDirectDrawMatchesDisplayList) {
+  auto displayListGlassDocument = MakeGlassDocument(true);
+  auto orphanGlassDocument = MakeGlassDocument(true);
+  auto displayListControlDocument = MakeGlassDocument(false);
+  auto orphanControlDocument = MakeGlassDocument(false);
+
+  auto displayListGlass = RenderViaDisplayList(displayListGlassDocument.get(), context);
+  auto orphanGlass = RenderViaOrphanDirectDraw(orphanGlassDocument.get(), context);
+  auto displayListControl = RenderViaDisplayList(displayListControlDocument.get(), context);
+  auto orphanControl = RenderViaOrphanDirectDraw(orphanControlDocument.get(), context);
+
+  ASSERT_FALSE(displayListGlass.isEmpty());
+  ASSERT_FALSE(orphanGlass.isEmpty());
+  ASSERT_FALSE(displayListControl.isEmpty());
+  ASSERT_FALSE(orphanControl.isEmpty());
+
+  EXPECT_LE(CountDifferentPixels(displayListControl, orphanControl), 16);
+  EXPECT_GT(CountDifferentPixels(displayListGlass, displayListControl), 500);
+  EXPECT_GT(CountDifferentPixels(orphanGlass, orphanControl), 500);
+  EXPECT_LE(CountDifferentPixels(displayListGlass, orphanGlass), 16);
+}
+
+}  // namespace pag

--- a/test/src/PAGXGlassRenderTest.cpp
+++ b/test/src/PAGXGlassRenderTest.cpp
@@ -17,7 +17,6 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include <cmath>
-
 #include "base/PAGTest.h"
 #include "pagx/PAGXDocument.h"
 #include "pagx/nodes/Fill.h"
@@ -106,14 +105,16 @@ static tgfx::Bitmap RenderViaDisplayList(pagx::PAGXDocument* document, tgfx::Con
   return surface->readPixels(pixmap.info(), pixmap.writablePixels()) ? bitmap : tgfx::Bitmap{};
 }
 
-static tgfx::Bitmap RenderViaOrphanDirectDraw(pagx::PAGXDocument* document, tgfx::Context* context) {
+static tgfx::Bitmap RenderViaOrphanDirectDraw(pagx::PAGXDocument* document,
+                                              tgfx::Context* context) {
   document->applyLayout();
   auto layer = pagx::LayerBuilder::Build(document);
   EXPECT_NE(layer, nullptr);
   if (layer == nullptr) {
     return {};
   }
-  auto surface = tgfx::Surface::Make(context, 300, 300, tgfx::ColorType::RGBA_8888, 1, 0, 0, nullptr);
+  auto surface =
+      tgfx::Surface::Make(context, 300, 300, tgfx::ColorType::RGBA_8888, 1, 0, 0, nullptr);
   EXPECT_NE(surface, nullptr);
   if (surface == nullptr) {
     return {};

--- a/test/src/PAGXHtmlTest.cpp
+++ b/test/src/PAGXHtmlTest.cpp
@@ -278,6 +278,26 @@ CLI_TEST(PAGXHtmlTest, LayerGroupOpacity) {
   EXPECT_NE(html.find("opacity: 0.5"), std::string::npos);
 }
 
+CLI_TEST(PAGXHtmlTest, GlassStylePreservesBaseContent) {
+  pagx::HTMLExportOptions options;
+  options.extractStyleSheet = false;
+  auto html = LoadXMLAndConvert(R"(
+<pagx width="120" height="120">
+  <Layer id="glass-layer" left="0" right="0" top="0" bottom="0">
+    <Rectangle position="60,60" size="80,60" roundness="12"/>
+    <Fill color="#336699"/>
+    <GlassStyle refraction="70" frost="8"/>
+  </Layer>
+</pagx>)",
+                                options);
+  ASSERT_FALSE(html.empty());
+  EXPECT_NE(html.find("id=\"glass-layer\""), std::string::npos);
+  EXPECT_TRUE(html.find("width:80px") != std::string::npos ||
+              html.find("width: 80px") != std::string::npos);
+  EXPECT_EQ(html.find("backdrop-filter"), std::string::npos);
+  EXPECT_EQ(html.find("GlassStyle"), std::string::npos);
+}
+
 CLI_TEST(PAGXHtmlTest, MultipleDropShadowStylesUseOneFilterSource) {
   pagx::HTMLExportOptions options;
   options.extractStyleSheet = false;

--- a/test/src/PAGXPPTTest.cpp
+++ b/test/src/PAGXPPTTest.cpp
@@ -42,6 +42,7 @@
 #include "pagx/nodes/Ellipse.h"
 #include "pagx/nodes/Fill.h"
 #include "pagx/nodes/Font.h"
+#include "pagx/nodes/GlassStyle.h"
 #include "pagx/nodes/GlyphRun.h"
 #include "pagx/nodes/Group.h"
 #include "pagx/nodes/Image.h"
@@ -66,6 +67,7 @@
 #include "pagx/nodes/TextPath.h"
 #include "pagx/nodes/TrimPath.h"
 #include "pagx/ppt/PPTBoilerplate.h"
+#include "pagx/ppt/PPTFeatureProbe.h"
 #include "pagx/ppt/PPTWriter.h"
 #include "pagx/ppt/PPTWriterContext.h"
 #include "pagx/utils/TextUtils.h"
@@ -4751,6 +4753,42 @@ PAGX_TEST(PAGXPPTTest, BackgroundBlurStyleEmitted) {
 
   doc->layers.push_back(layer);
   ASSERT_TRUE(ExportAndVerify(*doc, "bg_blur_style"));
+}
+
+PAGX_TEST(PAGXPPTTest, GlassStyleUsesBackdropRasterization) {
+  auto doc = pagx::PAGXDocument::Make(400, 300);
+  auto* background = doc->makeNode<pagx::Layer>();
+  auto* backgroundRect = doc->makeNode<pagx::Rectangle>();
+  backgroundRect->position = {200, 150};
+  backgroundRect->size = {400, 300};
+  background->contents.push_back(backgroundRect);
+  background->contents.push_back(MakeSolidFill(doc.get(), {0.2f, 0.4f, 0.8f, 1.0f}));
+  doc->layers.push_back(background);
+
+  auto* glassLayer = doc->makeNode<pagx::Layer>();
+  auto* glassRect = doc->makeNode<pagx::Rectangle>();
+  glassRect->position = {200, 150};
+  glassRect->size = {180, 120};
+  glassRect->roundness = 24;
+  glassLayer->contents.push_back(glassRect);
+  glassLayer->contents.push_back(MakeSolidFill(doc.get(), {1.0f, 1.0f, 1.0f, 0.35f}));
+  glassLayer->styles.push_back(doc->makeNode<pagx::GlassStyle>());
+  doc->layers.push_back(glassLayer);
+
+  auto features = pagx::ProbeLayerFeatures(glassLayer);
+  EXPECT_TRUE(features.hasGlassStyle);
+  EXPECT_TRUE(features.needsRasterization(true));
+  EXPECT_TRUE(features.requiresBackdrop(true));
+  EXPECT_FALSE(features.needsRasterization(false));
+  EXPECT_FALSE(features.requiresBackdrop(false));
+
+  pagx::PPTExportOptions options;
+  options.bakeUnsupported = true;
+  auto data = pagx::PPTExporter::ToData({doc.get()}, options);
+  ASSERT_NE(data, nullptr);
+  std::string bytes(reinterpret_cast<const char*>(data->bytes()), data->size());
+  EXPECT_NE(bytes.find("ppt/media/image1.png"), std::string::npos);
+  ASSERT_TRUE(ExportAndVerify(*doc, "glass_style_with_backdrop", options));
 }
 
 PAGX_TEST(PAGXPPTTest, MultipleShadowStylesAndFilters) {

--- a/test/src/PAGXPPTTest.cpp
+++ b/test/src/PAGXPPTTest.cpp
@@ -4776,7 +4776,7 @@ PAGX_TEST(PAGXPPTTest, GlassStyleUsesBackdropRasterization) {
   doc->layers.push_back(glassLayer);
 
   auto features = pagx::ProbeLayerFeatures(glassLayer);
-  EXPECT_TRUE(features.hasGlassStyle);
+  EXPECT_TRUE(features.hasBackdropStyle);
   EXPECT_TRUE(features.needsRasterization(true));
   EXPECT_TRUE(features.requiresBackdrop(true));
   EXPECT_FALSE(features.needsRasterization(false));

--- a/test/src/PAGXSVGTest.cpp
+++ b/test/src/PAGXSVGTest.cpp
@@ -41,6 +41,7 @@
 #include "pagx/nodes/Ellipse.h"
 #include "pagx/nodes/Fill.h"
 #include "pagx/nodes/Font.h"
+#include "pagx/nodes/GlassStyle.h"
 #include "pagx/nodes/GlyphRun.h"
 #include "pagx/nodes/Group.h"
 #include "pagx/nodes/Image.h"
@@ -1236,6 +1237,31 @@ PAGX_TEST(PAGXSVGTest, SVGExport_DropShadowStyle) {
   EXPECT_NE(svg.find("<feOffset"), std::string::npos);
   EXPECT_NE(svg.find("<feMerge"), std::string::npos);
   SaveFile(svg, "PAGXSVGTest/svg_export_dropshadow_style.svg");
+}
+
+/**
+ * GlassStyle has no faithful SVG representation. The base vector content remains visible and no
+ * empty filter is emitted.
+ */
+PAGX_TEST(PAGXSVGTest, SVGExport_GlassStylePreservesBaseContent) {
+  auto doc = pagx::PAGXDocument::Make(200, 200);
+  auto layer = doc->makeNode<pagx::Layer>();
+  auto rect = doc->makeNode<pagx::Rectangle>();
+  rect->position = {100, 100};
+  rect->size = {120, 80};
+  auto fill = doc->makeNode<pagx::Fill>();
+  auto solid = doc->makeNode<pagx::SolidColor>();
+  solid->color = {0.2f, 0.4f, 0.8f, 1.0f};
+  fill->color = solid;
+  layer->contents.push_back(rect);
+  layer->contents.push_back(fill);
+  layer->styles.push_back(doc->makeNode<pagx::GlassStyle>());
+  doc->layers.push_back(layer);
+
+  auto svg = pagx::SVGExporter::ToSVG(*doc);
+  EXPECT_NE(svg.find("<rect"), std::string::npos);
+  EXPECT_EQ(svg.find("<filter"), std::string::npos);
+  EXPECT_EQ(svg.find("GlassStyle"), std::string::npos);
 }
 
 /**

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -60,6 +60,7 @@
 #include "pagx/nodes/Ellipse.h"
 #include "pagx/nodes/Fill.h"
 #include "pagx/nodes/Font.h"
+#include "pagx/nodes/GlassStyle.h"
 #include "pagx/nodes/GlyphRun.h"
 #include "pagx/nodes/Group.h"
 #include "pagx/nodes/Image.h"
@@ -131,6 +132,7 @@
 #include "tgfx/layers/filters/DropShadowFilter.h"
 #include "tgfx/layers/filters/NoiseFilter.h"
 #include "tgfx/layers/layerstyles/DropShadowStyle.h"
+#include "tgfx/layers/layerstyles/GlassStyle.h"
 #include "tgfx/layers/layerstyles/NoiseStyle.h"
 #include "tgfx/layers/vectors/FillStyle.h"
 #include "tgfx/layers/vectors/Gradient.h"
@@ -479,6 +481,97 @@ PAGX_TEST(PAGXTest, PAGXDocumentRoundTrip) {
   EXPECT_FLOAT_EQ(doc2->width, 200.0f);
   EXPECT_FLOAT_EQ(doc2->height, 150.0f);
   EXPECT_GE(doc2->layers.size(), 1u);
+}
+
+/**
+ * Test case: GlassStyle survives PAGX round-trip and maps all animatable fields to TGFX.
+ */
+PAGX_TEST(PAGXTest, GlassStyleRoundTripAndRuntime) {
+  auto doc = pagx::PAGXDocument::Make(200, 150);
+  auto layer = doc->makeNode<pagx::Layer>();
+  layer->width = 200;
+  layer->height = 150;
+
+  auto rect = doc->makeNode<pagx::Rectangle>();
+  rect->position = {100, 75};
+  rect->size = {120, 80};
+  auto fill = doc->makeNode<pagx::Fill>();
+  auto color = doc->makeNode<pagx::SolidColor>();
+  color->color = {1, 1, 1, 0.5f};
+  fill->color = color;
+  layer->contents.push_back(rect);
+  layer->contents.push_back(fill);
+
+  auto glass = doc->makeNode<pagx::GlassStyle>("glass");
+  glass->refraction = 12;
+  glass->depth = 24;
+  glass->frost = 6;
+  glass->dispersion = 36;
+  glass->splay = 48;
+  glass->lightAngle = -30;
+  glass->lightIntensity = 72;
+  glass->excludeChildEffects = true;
+  glass->blendMode = pagx::BlendMode::Screen;
+  layer->styles.push_back(glass);
+  doc->layers.push_back(layer);
+
+  auto animation = doc->makeNode<pagx::Animation>("glass-animation");
+  animation->duration = 60;
+  animation->frameRate = 60;
+  doc->animations.push_back(animation);
+  auto object = doc->makeNode<pagx::AnimationObject>();
+  object->target = "glass";
+  animation->objects.push_back(object);
+  auto refraction = doc->makeNode<pagx::TypedChannel<float>>();
+  refraction->name = "refraction";
+  refraction->keyframes.push_back({0, 30.0f, pagx::KeyframeInterpolationType::Hold, {}, {}});
+  object->channels.push_back(refraction);
+
+  auto xml = pagx::PAGXExporter::ToXML(*doc);
+  EXPECT_NE(xml.find("<GlassStyle"), std::string::npos);
+  EXPECT_NE(xml.find("refraction=\"12\""), std::string::npos);
+  EXPECT_NE(xml.find("lightIntensity=\"72\""), std::string::npos);
+  EXPECT_EQ(xml.find("backgroundRef"), std::string::npos);
+
+  auto reloaded = pagx::PAGXImporter::FromXML(xml);
+  ASSERT_TRUE(reloaded != nullptr);
+  ASSERT_TRUE(reloaded->errors.empty());
+  auto reloadedGlass = reloaded->findNode<pagx::GlassStyle>("glass");
+  ASSERT_TRUE(reloadedGlass != nullptr);
+  EXPECT_FLOAT_EQ(reloadedGlass->refraction, 12);
+  EXPECT_FLOAT_EQ(reloadedGlass->depth, 24);
+  EXPECT_FLOAT_EQ(reloadedGlass->frost, 6);
+  EXPECT_FLOAT_EQ(reloadedGlass->dispersion, 36);
+  EXPECT_FLOAT_EQ(reloadedGlass->splay, 48);
+  EXPECT_FLOAT_EQ(reloadedGlass->lightAngle, -30);
+  EXPECT_FLOAT_EQ(reloadedGlass->lightIntensity, 72);
+  EXPECT_TRUE(reloadedGlass->excludeChildEffects);
+  EXPECT_EQ(reloadedGlass->blendMode, pagx::BlendMode::Screen);
+
+  const char* channels[] = {"refraction", "depth",      "frost",         "dispersion",
+                            "splay",      "lightAngle", "lightIntensity"};
+  for (const auto* channel : channels) {
+    EXPECT_TRUE(pagx::IsAnimatableChannel(pagx::NodeType::GlassStyle, channel));
+  }
+
+  reloaded->applyLayout();
+  auto scene = pagx::PAGScene::Make(reloaded);
+  ASSERT_TRUE(scene != nullptr);
+  auto binding = scene->mutableBinding();
+  ASSERT_TRUE(binding != nullptr);
+  auto runtimeGlass = binding->get<tgfx::GlassStyle>(reloadedGlass);
+  ASSERT_TRUE(runtimeGlass != nullptr);
+  EXPECT_FLOAT_EQ(runtimeGlass->depth(), 24);
+  EXPECT_FLOAT_EQ(runtimeGlass->frost(), 6);
+  EXPECT_FLOAT_EQ(runtimeGlass->dispersion(), 36);
+  EXPECT_FLOAT_EQ(runtimeGlass->splay(), 48);
+  EXPECT_FLOAT_EQ(runtimeGlass->lightAngle(), -30);
+  EXPECT_FLOAT_EQ(runtimeGlass->lightIntensity(), 72);
+
+  auto timeline = std::static_pointer_cast<pagx::PAGAnimation>(scene->getDefaultTimeline());
+  ASSERT_TRUE(timeline != nullptr);
+  timeline->apply(1.0f);
+  EXPECT_FLOAT_EQ(runtimeGlass->refraction(), 30);
 }
 
 /**
@@ -10021,6 +10114,8 @@ PAGX_TEST(PAGXTest, AnimatableChannelsHaveWriters) {
   layer->styles.push_back(innerStyle);
   auto backgroundBlurStyle = doc->makeNode<pagx::BackgroundBlurStyle>();
   layer->styles.push_back(backgroundBlurStyle);
+  auto glassStyle = doc->makeNode<pagx::GlassStyle>();
+  layer->styles.push_back(glassStyle);
   auto blurFilter = doc->makeNode<pagx::BlurFilter>();
   layer->filters.push_back(blurFilter);
   auto dropFilter = doc->makeNode<pagx::DropShadowFilter>();
@@ -10044,19 +10139,20 @@ PAGX_TEST(PAGXTest, AnimatableChannelsHaveWriters) {
   ASSERT_TRUE(binding != nullptr);
 
   // For each built node, every Animatable channel in the registry must have a runtime writer.
-  pagx::Node* nodes[] = {layer,       rect,
-                         ellipse,     polystar,
-                         trim,        roundCorner,
-                         repeater,    fill,
-                         stroke,      solid,
-                         group,       linear,
-                         linearStop,  radial,
-                         conic,       diamond,
-                         modifier,    selector,
-                         text,        dropStyle,
-                         innerStyle,  backgroundBlurStyle,
-                         blurFilter,  dropFilter,
-                         innerFilter, blendFilter};
+  pagx::Node* nodes[] = {layer,      rect,
+                         ellipse,    polystar,
+                         trim,       roundCorner,
+                         repeater,   fill,
+                         stroke,     solid,
+                         group,      linear,
+                         linearStop, radial,
+                         conic,      diamond,
+                         modifier,   selector,
+                         text,       dropStyle,
+                         innerStyle, backgroundBlurStyle,
+                         glassStyle, blurFilter,
+                         dropFilter, innerFilter,
+                         blendFilter};
   for (auto* node : nodes) {
     for (const auto& channel : pagx::ChannelsFor(node->nodeType())) {
       if (!pagx::HasFlag(channel.flags, pagx::ChannelFlags::Animatable)) {

--- a/viewer/src/profiling/PAGNodeStatsModel.cpp
+++ b/viewer/src/profiling/PAGNodeStatsModel.cpp
@@ -78,6 +78,7 @@ static QString GetNodeCategory(pagx::NodeType type) {
     case pagx::NodeType::DropShadowStyle:
     case pagx::NodeType::InnerShadowStyle:
     case pagx::NodeType::BackgroundBlurStyle:
+    case pagx::NodeType::GlassStyle:
     case pagx::NodeType::BlurFilter:
     case pagx::NodeType::DropShadowFilter:
     case pagx::NodeType::InnerShadowFilter:

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -91,6 +91,15 @@ export interface PAG extends EmscriptenModule {
   TGFXPathFillType: TGFXPathFillType;
   TGFXLineCap: TGFXLineCap;
   TGFXLineJoin: TGFXLineJoin;
+  /**
+   * Sets the maximum number of worker threads that can be created for running tasks. Pass zero to
+   * restore the default, which is based on the number of CPU cores and capped at 32.
+   */
+  setTaskMaxThreadCounts: (maxThreadCounts: number) => void;
+  /**
+   * Returns the current maximum number of worker threads that can be created for running tasks.
+   */
+  taskMaxThreadCounts: () => number;
   globalCanvas: GlobalCanvas;
   module: PAG;
   PAGPlayer: typeof PAGPlayer;


### PR DESCRIPTION
## Summary

Adds a `GlassStyle` layer style to the PAGX format: refraction, chromatic dispersion, frosted blur, and specular highlights. The background is sampled implicitly from the layer tree below the layer — no `backgroundRef` attribute.

tgfx is pinned to `main` (`818d3748`), which contains the merged glass rendering work (tgfx#1572) and the PDF vector-mask fix (tgfx#1574) — public commits only.

## Format Contract

New `GlassStyle` node with seven animatable float fields matching `tgfx::GlassStyle`: `refraction` (80), `depth` (20), `frost` (5), `dispersion` (50), `splay` (0), `lightAngle` (45), `lightIntensity` (80). Registered in the XSD, bilingual format spec (§5.3.5), `NodeType` enum, and `LayerStyle` doc.

## Changes

- **Export/Import**: writes/parses `<GlassStyle>` with default-value omission; round-trip tested
- **Runtime**: seven `Anim` channels + `tgfx::GlassStyle::Make()` bridge with full animation readback; `PAG_DISABLE_GLASS_STYLE` guard mirrors the existing per-effect switches
- **PPT**: `hasBackdropStyle` flag triggers backdrop-aware rasterization
- **HTML / SVG**: explicitly skipped (no faithful primitive); SVG `hasEffectiveStyle` guard prevents an empty `<filter>`
- **CLI verify**: GlassStyle recognized as a high-cost style for near-transparent layers
- **WeChat risk**: GlassStyle counted alongside BackgroundBlurStyle; `frost` converted to logical sigma `max(0.5, frost * 0.5)` (omitted → default 5); regression test wired into CI (`build.yml` web job)
- **Web bindings**: `PAG` interface tracks the tgfx `main` API (`setTaskMaxThreadCounts` / `taskMaxThreadCounts`)

All three review rounds are addressed: probe/docs wording, the `hasBackdropStyle` merge, CLI high-cost detection, frost calibration, PPT comment sync, and CI wiring. See the review threads for details.

## Compatibility

- Files without `GlassStyle` are unaffected — zero regression
- New nodes require upgraded libpag; old parsers silently ignore the unknown element

## Test Results

- `PAGFullTest`: **2414/2414 passed** (against tgfx `818d3748`)
- Glass coverage: round-trip + runtime channels, DisplayList vs orphan draw pixel parity, PPT rasterization flag, HTML/SVG content preservation, CLI color semantics + low-opacity case, WeChat frost-calibration Node test (in CI)