### PR TITLE
Fix OHOS video decoder SIGSEGV crash during input buffer handling

### DIFF
--- a/src/platform/ohos/OHOSVideoDecoder.cpp
+++ b/src/platform/ohos/OHOSVideoDecoder.cpp
@@ -216,6 +216,10 @@ DecodingResult OHOSVideoDecoder::onSendBytes(void* bytes, size_t length, int64_t
   lock.unlock();
 
   if (codecBufferInfo.buffer == nullptr) {
+    // The buffer was already popped above but cannot be returned to the codec, so mark the codec
+    // as errored to stop further onSendBytes calls from draining and leaking the remaining input
+    // buffers or blocking forever once the queue empties. onFlush resets this to recover.
+    codecUserData->codecError = true;
     return DecodingResult::Error;
   }
 
@@ -228,6 +232,7 @@ DecodingResult OHOSVideoDecoder::onSendBytes(void* bytes, size_t length, int64_t
     if (bufferAddr == nullptr || capacity < 0 || static_cast<size_t>(capacity) < length) {
       LOGE("onSendBytes: invalid input buffer, addr=%p, capacity=%d, length=%zu", bufferAddr,
            capacity, length);
+      codecUserData->codecError = true;
       return DecodingResult::Error;
     }
     memcpy(bufferAddr, bytes, length);
@@ -247,6 +252,9 @@ DecodingResult OHOSVideoDecoder::onSendBytes(void* bytes, size_t length, int64_t
   }
 
   if (ret != AV_ERR_OK) {
+    // The buffer was popped but not accepted by the codec; treat the codec as errored so later
+    // calls fail fast instead of leaking the remaining input buffers or blocking forever.
+    codecUserData->codecError = true;
     return DecodingResult::Error;
   }
   if (length > 0 && time >= 0) {

--- a/src/platform/ohos/OHOSVideoDecoder.cpp
+++ b/src/platform/ohos/OHOSVideoDecoder.cpp
@@ -53,14 +53,21 @@ struct NV12FrameBuffer {
 };
 }  // namespace
 
-void OH_AVCodecOnError(OH_AVCodec*, int32_t index, void* userData) {
+void OH_AVCodecOnError(OH_AVCodec*, int32_t errorCode, void* userData) {
   if (userData == nullptr) {
     return;
   }
-  LOGE("video decoder error, index:%d \n", index);
+  LOGE("video decoder error, errorCode:%d \n", errorCode);
   CodecUserData* codecUserData = static_cast<CodecUserData*>(userData);
+  codecUserData->codecError = true;
+  // Wake the input waiter as well. The input queue is untouched here, so without an explicit
+  // error flag onSendBytes would keep waiting forever on a codec that will never deliver another
+  // input buffer. Take the lock before notifying so the flag cannot be missed by a waiter that is
+  // about to evaluate its predicate.
+  { std::unique_lock<std::mutex> lock(codecUserData->inputMutex); }
+  codecUserData->inputCondition.notify_all();
   std::unique_lock<std::mutex> lock(codecUserData->outputMutex);
-  codecUserData->outputBufferInfoQueue.emplace(index, nullptr);
+  codecUserData->outputBufferInfoQueue.emplace(0, nullptr);
   codecUserData->outputCondition.notify_all();
 }
 
@@ -196,20 +203,41 @@ bool OHOSVideoDecoder::initDecoder(const OH_AVCodecCategory avCodecCategory) {
 
 DecodingResult OHOSVideoDecoder::onSendBytes(void* bytes, size_t length, int64_t time) {
   std::unique_lock<std::mutex> lock(codecUserData->inputMutex);
-  codecUserData->inputCondition.wait(
-      lock, [this]() { return codecUserData->inputBufferInfoQueue.size() > 0; });
+  codecUserData->inputCondition.wait(lock, [this]() {
+    return codecUserData->inputBufferInfoQueue.size() > 0 || codecUserData->codecError;
+  });
+  if (codecUserData->codecError) {
+    return DecodingResult::Error;
+  }
   CodecBufferInfo codecBufferInfo = codecUserData->inputBufferInfoQueue.front();
+  // Pop before use so a buffer that fails validation below is never left in the queue for the
+  // next call to pick up again.
+  codecUserData->inputBufferInfoQueue.pop();
   lock.unlock();
+
+  if (codecBufferInfo.buffer == nullptr) {
+    return DecodingResult::Error;
+  }
+
+  if (bytes != nullptr && length > 0) {
+    uint8_t* bufferAddr = OH_AVBuffer_GetAddr(codecBufferInfo.buffer);
+    int32_t capacity = OH_AVBuffer_GetCapacity(codecBufferInfo.buffer);
+    // Guard the memcpy destination. On some HarmonyOS builds GetAddr can return null or report a
+    // capacity smaller than the data when the codec is already in a bad state, which previously
+    // crashed here with a SIGSEGV while writing the SPS/PPS headers during initialization.
+    if (bufferAddr == nullptr || capacity < 0 || static_cast<size_t>(capacity) < length) {
+      LOGE("onSendBytes: invalid input buffer, addr=%p, capacity=%d, length=%zu", bufferAddr,
+           capacity, length);
+      return DecodingResult::Error;
+    }
+    memcpy(bufferAddr, bytes, length);
+  }
 
   OH_AVCodecBufferAttr bufferAttr;
   bufferAttr.size = length;
   bufferAttr.offset = 0;
   bufferAttr.pts = time >= 0 ? time : 0;
   bufferAttr.flags = length == 0 ? AVCODEC_BUFFER_FLAGS_EOS : AVCODEC_BUFFER_FLAGS_NONE;
-
-  if (bytes != nullptr && length > 0) {
-    memcpy(OH_AVBuffer_GetAddr(codecBufferInfo.buffer), bytes, length);
-  }
   int ret = OH_AVBuffer_SetBufferAttr(codecBufferInfo.buffer, &bufferAttr);
   if (ret == AV_ERR_OK) {
     ret = OH_VideoDecoder_PushInputBuffer(videoCodec, codecBufferInfo.bufferIndex);
@@ -217,9 +245,6 @@ DecodingResult OHOSVideoDecoder::onSendBytes(void* bytes, size_t length, int64_t
       LOGE("OH_VideoDecoder_PushInputBuffer failed, ret:%d", ret);
     }
   }
-  lock.lock();
-  codecUserData->inputBufferInfoQueue.pop();
-  lock.unlock();
 
   if (ret != AV_ERR_OK) {
     return DecodingResult::Error;
@@ -265,6 +290,7 @@ void OHOSVideoDecoder::onFlush() {
     return;
   }
   codecUserData->clearQueue();
+  codecUserData->codecError = false;
   pendingFrames.clear();
   codecBufferInfo = {0, nullptr};
   start();
@@ -277,7 +303,11 @@ bool OHOSVideoDecoder::start() {
     return false;
   }
   for (auto& header : videoFormat.headers) {
-    onSendBytes(const_cast<void*>(header->data()), header->size(), -1);
+    if (onSendBytes(const_cast<void*>(header->data()), header->size(), -1) !=
+        DecodingResult::Success) {
+      LOGE("video decoder send header failed!");
+      return false;
+    }
   }
   return true;
 }

--- a/src/platform/ohos/OHOSVideoDecoder.cpp
+++ b/src/platform/ohos/OHOSVideoDecoder.cpp
@@ -301,7 +301,13 @@ void OHOSVideoDecoder::onFlush() {
   codecUserData->codecError = false;
   pendingFrames.clear();
   codecBufferInfo = {0, nullptr};
-  start();
+  if (!start()) {
+    // start() failed on this recovery path. When OH_VideoDecoder_Start itself fails the codec is
+    // not running, so OH_AVCodecOnNeedInputBuffer never fires and the next onSendBytes would block
+    // forever on an empty input queue with codecError cleared above. Surface the failure as an
+    // error instead so onSendBytes fast-fails and VideoReader can fall back to software decoding.
+    codecUserData->codecError = true;
+  }
 }
 
 bool OHOSVideoDecoder::start() {

--- a/src/platform/ohos/OHOSVideoDecoder.h
+++ b/src/platform/ohos/OHOSVideoDecoder.h
@@ -36,7 +36,12 @@ struct CodecBufferInfo {
 
   CodecBufferInfo(uint32_t argBufferIndex, OH_AVBuffer* argBuffer)
       : bufferIndex(argBufferIndex), buffer(argBuffer) {
-    OH_AVBuffer_GetBufferAttr(argBuffer, &attr);
+    // Guard against a null buffer (e.g. the (0, nullptr) sentinel pushed by the error callback):
+    // OH_AVBuffer_GetBufferAttr is not documented to tolerate a null buffer on every HarmonyOS
+    // build, and attr already holds a valid zero-initialized default here.
+    if (argBuffer != nullptr) {
+      OH_AVBuffer_GetBufferAttr(argBuffer, &attr);
+    }
   };
 };
 
@@ -50,10 +55,12 @@ class CodecUserData {
   std::condition_variable outputCondition;
   std::queue<CodecBufferInfo> outputBufferInfoQueue;
 
-  // Set by the error callback when the codec enters an unrecoverable error state. The input waiter
-  // checks it directly so it can bail out of onSendBytes instead of blocking forever; the output
-  // waiter is not gated on this flag but is instead woken by a sentinel (0, nullptr) entry the
-  // error callback pushes into outputBufferInfoQueue.
+  // Set when the codec enters an unrecoverable error state, either by the error callback or by
+  // onSendBytes after it dequeues an unusable input buffer (null/undersized) or fails to submit
+  // one. The input waiter checks it directly so it can bail out of onSendBytes instead of blocking
+  // forever on a codec that will never redeliver the dequeued input buffers; the output waiter is
+  // not gated on this flag but is instead woken by a sentinel (0, nullptr) entry the error callback
+  // pushes into outputBufferInfoQueue. onFlush clears it to allow recovery.
   std::atomic<bool> codecError = {false};
 
   void clearQueue() {

--- a/src/platform/ohos/OHOSVideoDecoder.h
+++ b/src/platform/ohos/OHOSVideoDecoder.h
@@ -20,6 +20,7 @@
 
 #include <multimedia/player_framework/native_avcapability.h>
 #include <multimedia/player_framework/native_avcodec_videodecoder.h>
+#include <atomic>
 #include <cstdint>
 #include <list>
 #include <queue>
@@ -48,6 +49,11 @@ class CodecUserData {
   std::mutex outputMutex;
   std::condition_variable outputCondition;
   std::queue<CodecBufferInfo> outputBufferInfoQueue;
+
+  // Set by the error callback when the codec enters an unrecoverable error state. The input and
+  // output waiters check it so they can bail out instead of blocking forever or using buffers
+  // that the codec service may have already released.
+  std::atomic<bool> codecError = {false};
 
   void clearQueue() {
     {

--- a/src/platform/ohos/OHOSVideoDecoder.h
+++ b/src/platform/ohos/OHOSVideoDecoder.h
@@ -55,7 +55,8 @@ class CodecUserData {
   std::condition_variable outputCondition;
   std::queue<CodecBufferInfo> outputBufferInfoQueue;
 
-  // Set when the codec enters an unrecoverable error state, either by the error callback or by
+  // Set when the codec enters an error state it cannot recover from on its own, either by the
+  // error callback or by
   // onSendBytes after it dequeues an unusable input buffer (null/undersized) or fails to submit
   // one. The input waiter checks it directly so it can bail out of onSendBytes instead of blocking
   // forever on a codec that will never redeliver the dequeued input buffers; the output waiter is

--- a/src/platform/ohos/OHOSVideoDecoder.h
+++ b/src/platform/ohos/OHOSVideoDecoder.h
@@ -50,9 +50,10 @@ class CodecUserData {
   std::condition_variable outputCondition;
   std::queue<CodecBufferInfo> outputBufferInfoQueue;
 
-  // Set by the error callback when the codec enters an unrecoverable error state. The input and
-  // output waiters check it so they can bail out instead of blocking forever or using buffers
-  // that the codec service may have already released.
+  // Set by the error callback when the codec enters an unrecoverable error state. The input waiter
+  // checks it directly so it can bail out of onSendBytes instead of blocking forever; the output
+  // waiter is not gated on this flag but is instead woken by a sentinel (0, nullptr) entry the
+  // error callback pushes into outputBufferInfoQueue.
   std::atomic<bool> codecError = {false};
 
   void clearQueue() {

--- a/src/platform/ohos/OHOSVideoDecoder.h
+++ b/src/platform/ohos/OHOSVideoDecoder.h
@@ -55,13 +55,12 @@ class CodecUserData {
   std::condition_variable outputCondition;
   std::queue<CodecBufferInfo> outputBufferInfoQueue;
 
-  // Set when the codec enters an error state it cannot recover from on its own, either by the
-  // error callback or by
-  // onSendBytes after it dequeues an unusable input buffer (null/undersized) or fails to submit
-  // one. The input waiter checks it directly so it can bail out of onSendBytes instead of blocking
-  // forever on a codec that will never redeliver the dequeued input buffers; the output waiter is
-  // not gated on this flag but is instead woken by a sentinel (0, nullptr) entry the error callback
-  // pushes into outputBufferInfoQueue. onFlush clears it to allow recovery.
+  // Set when the codec enters an error state it cannot recover from on its own, either by the error
+  // callback or by onSendBytes after it dequeues an unusable input buffer (null/undersized) or fails
+  // to submit one. The input waiter checks it directly so it can bail out of onSendBytes instead of
+  // blocking forever on a codec that will never redeliver the dequeued input buffers; the output
+  // waiter is not gated on this flag but is instead woken by a sentinel (0, nullptr) entry the error
+  // callback pushes into outputBufferInfoQueue. onFlush clears it to allow recovery.
   std::atomic<bool> codecError = {false};
 
   void clearQueue() {


### PR DESCRIPTION
## 问题背景

OHOS（HarmonyOS）硬件/软件视频解码器在初始化写入 SPS/PPS 头时，`onSendBytes` 中的 `memcpy` 会偶发 SIGSEGV 崩溃。根因是在某些 HarmonyOS 设备上，当编解码器已进入异常状态时，`OH_AVBuffer_GetAddr` 可能返回空指针，或 `OH_AVBuffer_GetCapacity` 报告的容量小于待写入数据长度，导致向非法地址拷贝而崩溃。此外，编解码器进入不可恢复错误后，输入等待方会永久阻塞在条件变量上。

## 主要改动

### 崩溃与阻塞修复
- **输入缓冲区写入前校验**：`memcpy` 前检查目标地址非空、容量非负且不小于数据长度，非法时记录日志并返回 `Error`，从源头消除越界写入。
- **新增 `codecError` 原子标志**：错误回调置位后，输入等待方谓词会检查该标志并及时退出，不再无限等待；错误回调同时向输出队列压入哨兵 `(0, nullptr)` 唤醒输出等待方。
- **修正错误回调入队值**：错误回调改为压入 `0` 而非被误当作 bufferIndex 的错误码，消除下游潜在误用。
- **传播头部发送失败**：`start()` 在头部重发失败时返回 `false`，使初始化失败能被正确感知。
- **调整输入缓冲区出队时机**：改为取用前 `pop`，避免校验失败的缓冲区滞留在队列中被下次调用重复取用。
- **`onFlush` 重置 `codecError`**，保证 flush 后可正常恢复解码。

### 边界加固（代码评审补充）
- **`CodecBufferInfo` 构造函数判空**：对 `nullptr`（如错误回调压入的哨兵）跳过 `OH_AVBuffer_GetBufferAttr`，避免个别 HarmonyOS 版本对空指针不容错导致的 UB/崩溃。
- **`onSendBytes` 失败路径统一置位 `codecError`**：缓冲区为空、地址/容量校验失败、`SetBufferAttr`/`PushInputBuffer` 失败三条早退路径均置位 `codecError`，使后续调用快速失败，避免持续消耗并泄漏已出队的输入缓冲区，或在队列耗尽后永久阻塞。
- **`onFlush` 处理解码器重启失败**：捕获 `start()` 返回值，`OH_VideoDecoder_Start` 失败时置位 `codecError`，使下次 `onSendBytes` 快速返回 `Error` 并触发上层软解回退，避免 codec 未启动导致输入等待方永久阻塞。

## 影响范围

仅涉及 `src/platform/ohos/` 下的 OHOS 平台解码器实现，不影响其他平台。

## 测试说明

OHOS 平台代码无法在非 HarmonyOS 主机上编译，改动已通过多轮代码评审（含并发安全、边界条件、丢失唤醒、缓冲区账目、恢复路径等专项核验，reviewer + 对抗式 verifier 双方确认）。建议在 HarmonyOS 设备上验证解码初始化与异常恢复路径。
