### PR TITLE
Prevent OHOS PAGView updates from blocking the UI thread.

### DIFF
--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -908,42 +908,31 @@ void JPAGView::onAnimationUpdate(PAGAnimator* animator) {
 }
 
 void JPAGView::onSurfaceCreated(NativeWindow* window) {
-  std::shared_ptr<PAGPlayer> currentPlayer = nullptr;
-  {
-    std::lock_guard lock_guard(locker);
-    if (player == nullptr || animator == nullptr) {
-      return;
-    }
-    currentPlayer = player;
+  std::lock_guard lock_guard(locker);
+  if (player == nullptr || animator == nullptr) {
+    return;
   }
   auto drawable = pag::GPUDrawable::FromWindow(window, EGL_NO_CONTEXT, false);
-  currentPlayer->setSurface(pag::PAGSurface::MakeFrom(drawable));
+  player->setSurface(pag::PAGSurface::MakeFrom(drawable));
 }
 
 void JPAGView::onSurfaceSizeChanged() {
-  std::shared_ptr<PAGPlayer> currentPlayer = nullptr;
-  {
-    std::lock_guard lock_guard(locker);
-    currentPlayer = player;
-  }
-  if (currentPlayer == nullptr) {
+  std::lock_guard lock_guard(locker);
+  if (player == nullptr) {
     return;
   }
-  auto surface = currentPlayer->getSurface();
+  auto surface = player->getSurface();
   if (surface) {
     surface->updateSize();
   }
 }
 
 void JPAGView::onSurfaceDestroyed() {
-  std::shared_ptr<PAGPlayer> currentPlayer = nullptr;
-  {
-    std::lock_guard lock_guard(locker);
-    currentPlayer = player;
+  std::lock_guard lock_guard(locker);
+  if (player == nullptr) {
+    return;
   }
-  if (currentPlayer != nullptr) {
-    currentPlayer->setSurface(nullptr);
-  }
+  player->setSurface(nullptr);
 }
 
 void JPAGView::release() {

--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -29,6 +29,10 @@ namespace pag {
 
 static std::unordered_map<std::string, std::shared_ptr<JPAGView>> ViewMap = {};
 
+static void UpdateAnimator(const std::shared_ptr<PAGAnimator>& animator) {
+  animator->updateAsync();
+}
+
 static napi_value Flush(napi_env env, napi_callback_info info) {
   napi_value jsView = nullptr;
   size_t argc = 0;
@@ -61,7 +65,7 @@ static napi_value Update(napi_env env, napi_callback_info info) {
   if (view != nullptr) {
     auto animator = view->getAnimator();
     if (animator != nullptr) {
-      animator->update();
+      UpdateAnimator(animator);
     }
   }
   return nullptr;
@@ -85,7 +89,7 @@ static napi_value SetProgress(napi_env env, napi_callback_info info) {
     if (player != nullptr && animator != nullptr) {
       player->setProgress(progress);
       animator->setProgress(progress);
-      animator->update();
+      UpdateAnimator(animator);
     }
   }
   return nullptr;
@@ -881,72 +885,97 @@ void JPAGView::onAnimationRepeat(PAGAnimator*) {
 }
 
 void JPAGView::onAnimationUpdate(PAGAnimator* animator) {
-  std::lock_guard lock_guard(locker);
-  if (progressCallback) {
-    napi_call_threadsafe_function(progressCallback, nullptr,
+  napi_threadsafe_function callback = nullptr;
+  std::shared_ptr<PAGPlayer> currentPlayer = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    if (player == nullptr) {
+      return;
+    }
+    currentPlayer = player;
+    if (progressCallback != nullptr &&
+        napi_acquire_threadsafe_function(progressCallback) == napi_ok) {
+      callback = progressCallback;
+    }
+  }
+  if (callback != nullptr) {
+    napi_call_threadsafe_function(callback, nullptr,
                                   napi_threadsafe_function_call_mode::napi_tsfn_nonblocking);
+    napi_release_threadsafe_function(callback, napi_tsfn_release);
   }
-
-  if (player) {
-    player->setProgress(animator->progress());
-    player->flush();
-  }
+  currentPlayer->setProgress(animator->progress());
+  currentPlayer->flush();
 }
 
 void JPAGView::onSurfaceCreated(NativeWindow* window) {
-  std::lock_guard lock_guard(locker);
-  auto drawable = pag::GPUDrawable::FromWindow(window, EGL_NO_CONTEXT, false);
-  if (player == nullptr || animator == nullptr) {
-    return;
+  std::shared_ptr<PAGPlayer> currentPlayer = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    if (player == nullptr || animator == nullptr) {
+      return;
+    }
+    currentPlayer = player;
   }
-  player->setSurface(pag::PAGSurface::MakeFrom(drawable));
+  auto drawable = pag::GPUDrawable::FromWindow(window, EGL_NO_CONTEXT, false);
+  currentPlayer->setSurface(pag::PAGSurface::MakeFrom(drawable));
 }
 
 void JPAGView::onSurfaceSizeChanged() {
-  std::lock_guard lock_guard(locker);
-  if (player == nullptr) {
+  std::shared_ptr<PAGPlayer> currentPlayer = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    currentPlayer = player;
+  }
+  if (currentPlayer == nullptr) {
     return;
   }
-  auto surface = player->getSurface();
+  auto surface = currentPlayer->getSurface();
   if (surface) {
     surface->updateSize();
   }
 }
 
 void JPAGView::onSurfaceDestroyed() {
-  std::lock_guard lock_guard(locker);
-  if (player == nullptr) {
-    return;
+  std::shared_ptr<PAGPlayer> currentPlayer = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    currentPlayer = player;
   }
-  player->setSurface(nullptr);
+  if (currentPlayer != nullptr) {
+    currentPlayer->setSurface(nullptr);
+  }
 }
 
 void JPAGView::release() {
   XComponentHandler::RemoveListener(id);
+  std::shared_ptr<PAGAnimator> currentAnimator = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    currentAnimator = animator;
+  }
   // A memory leak may occur if the timer is not cancelled upon release.
-  if (animator) {
-    animator->cancel();
+  if (currentAnimator != nullptr) {
+    currentAnimator->cancel();
   }
 
-  std::lock_guard lock_guard(locker);
-  if (progressCallback != nullptr) {
-    napi_release_threadsafe_function(progressCallback, napi_tsfn_abort);
-    progressCallback = nullptr;
+  std::shared_ptr<PAGAnimator> releasedAnimator = nullptr;
+  std::shared_ptr<PAGPlayer> releasedPlayer = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    if (progressCallback != nullptr) {
+      napi_release_threadsafe_function(progressCallback, napi_tsfn_abort);
+      progressCallback = nullptr;
+    }
+    if (playingStateCallback != nullptr) {
+      napi_release_threadsafe_function(playingStateCallback, napi_tsfn_abort);
+      playingStateCallback = nullptr;
+    }
+    releasedAnimator = std::move(animator);
+    releasedPlayer = std::move(player);
+    isVisible = false;
   }
-  if (playingStateCallback != nullptr) {
-    napi_release_threadsafe_function(playingStateCallback, napi_tsfn_abort);
-    playingStateCallback = nullptr;
-  }
-
-  if (animator) {
-    animator = nullptr;
-  }
-
-  if (player) {
-    player->setSurface(nullptr);
-    player = nullptr;
-  }
-  isVisible = false;
+  // An in-flight update keeps its player and surface alive through its local reference until it
+  // completes. Detaching the surface here could wait indefinitely for the same blocked flush task.
 }
 
 std::shared_ptr<PAGAnimator> JPAGView::getAnimator() {
@@ -977,7 +1006,7 @@ void JPAGView::setComposition(std::shared_ptr<PAGComposition> composition) {
   int64_t duration = (composition != nullptr && visible) ? composition->duration() : 0;
   animator->setDuration(duration);
   if (visible) {
-    animator->update();
+    UpdateAnimator(animator);
   }
 }
 
@@ -998,7 +1027,7 @@ void JPAGView::setVisible(bool visible) {
   }
   animator->setDuration(visible && player != nullptr ? player->duration() : 0);
   if (visible) {
-    animator->update();
+    UpdateAnimator(animator);
   }
 }
 

--- a/src/platform/ohos/JPAGView.cpp
+++ b/src/platform/ohos/JPAGView.cpp
@@ -908,31 +908,42 @@ void JPAGView::onAnimationUpdate(PAGAnimator* animator) {
 }
 
 void JPAGView::onSurfaceCreated(NativeWindow* window) {
-  std::lock_guard lock_guard(locker);
-  if (player == nullptr || animator == nullptr) {
-    return;
+  std::shared_ptr<PAGPlayer> currentPlayer = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    if (player == nullptr || animator == nullptr) {
+      return;
+    }
+    currentPlayer = player;
   }
   auto drawable = pag::GPUDrawable::FromWindow(window, EGL_NO_CONTEXT, false);
-  player->setSurface(pag::PAGSurface::MakeFrom(drawable));
+  currentPlayer->setSurface(pag::PAGSurface::MakeFrom(drawable));
 }
 
 void JPAGView::onSurfaceSizeChanged() {
-  std::lock_guard lock_guard(locker);
-  if (player == nullptr) {
+  std::shared_ptr<PAGPlayer> currentPlayer = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    currentPlayer = player;
+  }
+  if (currentPlayer == nullptr) {
     return;
   }
-  auto surface = player->getSurface();
+  auto surface = currentPlayer->getSurface();
   if (surface) {
     surface->updateSize();
   }
 }
 
 void JPAGView::onSurfaceDestroyed() {
-  std::lock_guard lock_guard(locker);
-  if (player == nullptr) {
-    return;
+  std::shared_ptr<PAGPlayer> currentPlayer = nullptr;
+  {
+    std::lock_guard lock_guard(locker);
+    currentPlayer = player;
   }
-  player->setSurface(nullptr);
+  if (currentPlayer != nullptr) {
+    currentPlayer->setSurface(nullptr);
+  }
 }
 
 void JPAGView::release() {

--- a/src/rendering/PAGAnimator.cpp
+++ b/src/rendering/PAGAnimator.cpp
@@ -29,6 +29,23 @@ static constexpr int AnimationTypeEnd = 1;
 static constexpr int AnimationTypeRepeat = 2;
 static constexpr int AnimationTypeUpdate = 3;
 
+class AnimatorUpdateTask : public tgfx::Task {
+ public:
+  explicit AnimatorUpdateTask(std::weak_ptr<PAGAnimator> animator) : animator(std::move(animator)) {
+  }
+
+ protected:
+  void onExecute() override {
+    auto strongAnimator = animator.lock();
+    if (strongAnimator) {
+      strongAnimator->onAsyncFlush(this);
+    }
+  }
+
+ private:
+  std::weak_ptr<PAGAnimator> animator = {};
+};
+
 class AnimationTicker {
  public:
   static AnimationTicker* GetInstance() {
@@ -194,6 +211,12 @@ void PAGAnimator::start() {
 void PAGAnimator::cancel() {
   std::unique_lock<std::mutex> lock(locker);
   if (!_isRunning) {
+    if (isEnding) {
+      asyncUpdateRequested = false;
+    }
+    if (task != nullptr) {
+      extractAndWaitTask(lock);
+    }
     return;
   }
   _isRunning = false;
@@ -209,6 +232,35 @@ void PAGAnimator::update() {
   doUpdate(false);
 }
 
+void PAGAnimator::updateAsync() {
+  auto newTask = std::make_shared<AnimatorUpdateTask>(weakThis);
+  bool useDefaultUpdate = false;
+  {
+    std::lock_guard<std::mutex> autoLock(locker);
+    if (isEnding) {
+      asyncUpdateRequested = true;
+      return;
+    }
+    if (_isSync) {
+      useDefaultUpdate = true;
+    } else if (isTaskRunning()) {
+      if (taskCanCancel) {
+        asyncUpdateRequested = true;
+      }
+      return;
+    } else {
+      task = newTask;
+      taskCanCancel = true;
+      asyncUpdateRequested = false;
+    }
+  }
+  if (useDefaultUpdate) {
+    update();
+    return;
+  }
+  tgfx::Task::Run(std::move(newTask));
+}
+
 bool PAGAnimator::isTaskRunning() const {
   if (task == nullptr) {
     return false;
@@ -219,9 +271,25 @@ bool PAGAnimator::isTaskRunning() const {
 
 void PAGAnimator::extractAndWaitTask(std::unique_lock<std::mutex>& lock) {
   auto pendingTask = std::move(task);
+  auto canCancel = taskCanCancel;
+  auto isExecutingTaskThread = canCancel && asyncTaskThread == std::this_thread::get_id();
   task = nullptr;
+  asyncTaskThread = {};
+  taskCanCancel = false;
+  asyncUpdateRequested = false;
   lock.unlock();
   if (pendingTask == nullptr) {
+    return;
+  }
+  if (canCancel) {
+    pendingTask->cancel();
+    if (pendingTask->status() == tgfx::TaskStatus::Canceled) {
+      return;
+    }
+  }
+  // A listener may re-enter cancel() or setSync() from the explicit asynchronous update task.
+  // Waiting for that same executing task would block the callback until the timeout expires.
+  if (isExecutingTaskThread) {
     return;
   }
   // Wait with a timeout to avoid blocking the caller thread indefinitely when the async flush task
@@ -241,6 +309,8 @@ void PAGAnimator::flushAsync(bool setStartTime) {
   if (!_isRunning) {
     return;
   }
+  taskCanCancel = false;
+  asyncUpdateRequested = false;
   task = tgfx::Task::Run([weakThis = weakThis, setStartTime]() {
     auto animator = weakThis.lock();
     if (animator) {
@@ -253,13 +323,27 @@ void PAGAnimator::advance() {
   auto events = doAdvance();
   auto listener = weakListener.lock();
   if (listener == nullptr) {
+    std::lock_guard<std::mutex> autoLock(locker);
+    isEnding = false;
+    asyncUpdateRequested = false;
     return;
   }
   for (auto& type : events) {
     switch (type) {
-      case AnimationTypeEnd:
+      case AnimationTypeEnd: {
         listener->onAnimationEnd(this);
+        bool updateAfterEnd = false;
+        {
+          std::lock_guard<std::mutex> autoLock(locker);
+          isEnding = false;
+          updateAfterEnd = asyncUpdateRequested;
+          asyncUpdateRequested = false;
+        }
+        if (updateAfterEnd) {
+          updateAsync();
+        }
         break;
+      }
       case AnimationTypeRepeat:
         listener->onAnimationRepeat(this);
         break;
@@ -301,6 +385,7 @@ std::vector<int> PAGAnimator::doAdvance() {
   }
   // Set the playedCount to 0 to allow the animation to be played again.
   playedCount = 0;
+  isEnding = true;
   isEnded = true;
   _isRunning = false;
   cancelAnimation();
@@ -328,6 +413,35 @@ void PAGAnimator::doUpdate(bool setStartTime) {
     return;
   }
   flushAsync(setStartTime);
+}
+
+void PAGAnimator::onAsyncFlush(AnimatorUpdateTask* currentTask) {
+  {
+    std::lock_guard<std::mutex> autoLock(locker);
+    if (task.get() != currentTask) {
+      return;
+    }
+    asyncTaskThread = std::this_thread::get_id();
+  }
+  while (true) {
+    auto listener = weakListener.lock();
+    if (listener) {
+      listener->onAnimationWillUpdate(this);
+    }
+    onFlush(false);
+    std::lock_guard<std::mutex> autoLock(locker);
+    if (task.get() != currentTask) {
+      return;
+    }
+    if (asyncUpdateRequested) {
+      asyncUpdateRequested = false;
+      continue;
+    }
+    task = nullptr;
+    asyncTaskThread = {};
+    taskCanCancel = false;
+    return;
+  }
 }
 
 void PAGAnimator::onFlush(bool setStartTime) {

--- a/src/rendering/PAGAnimator.h
+++ b/src/rendering/PAGAnimator.h
@@ -18,10 +18,13 @@
 
 #pragma once
 
+#include <thread>
 #include "pag/pag.h"
 #include "tgfx/core/Task.h"
 
 namespace pag {
+class AnimatorUpdateTask;
+
 /**
  * PAGAnimator provides a simple timing engine for running animations.
  */
@@ -63,8 +66,9 @@ class PAGAnimator {
     }
 
     /**
-     * Notifies another frame of the animation will occur. This will only be called from the UI
-     * thread. Note: onAnimationWillUpdate and onAnimationUpdate will always appear in pairs.
+     * Notifies another frame of the animation will occur. This is called from the UI thread for
+     * playback updates and from a worker thread for updateAsync(). Note: onAnimationWillUpdate and
+     * onAnimationUpdate will always appear in pairs.
      */
     virtual void onAnimationWillUpdate(PAGAnimator*) {
     }
@@ -151,11 +155,20 @@ class PAGAnimator {
    */
   void update();
 
+  /**
+   * Updates an asynchronous animation on a background thread. Synchronous animations retain the
+   * behavior of update().
+   */
+  void updateAsync();
+
  private:
   std::mutex locker = {};
   std::weak_ptr<PAGAnimator> weakThis;
   std::weak_ptr<Listener> weakListener;
   std::shared_ptr<tgfx::Task> task = nullptr;
+  std::thread::id asyncTaskThread = {};
+  bool taskCanCancel = false;
+  bool asyncUpdateRequested = false;
   int64_t _startTime = INT64_MIN;
   int64_t _duration = 0;
   int _repeatCount = 1;
@@ -163,6 +176,7 @@ class PAGAnimator {
   bool _isSync = false;
   bool _isRunning = false;
   bool isAnimating = false;
+  bool isEnding = false;
   bool isEnded = false;
   int playedCount = 0;
 
@@ -173,11 +187,13 @@ class PAGAnimator {
   void advance();
   std::vector<int> doAdvance();
   void doUpdate(bool setStartTime);
+  void onAsyncFlush(AnimatorUpdateTask* currentTask);
   void onFlush(bool setStartTime);
   void startAnimation();
   void cancelAnimation();
   void resetStartTime();
 
   friend class AnimationTicker;
+  friend class AnimatorUpdateTask;
 };
 }  // namespace pag

--- a/test/src/PAGAnimatorTest.cpp
+++ b/test/src/PAGAnimatorTest.cpp
@@ -20,6 +20,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+#include <vector>
 #include "base/PAGTest.h"
 #include "rendering/PAGAnimator.h"
 
@@ -120,6 +121,64 @@ class CancelOnUpdateListener : public PAGAnimator::Listener {
   std::condition_variable condition = {};
   bool updateStarted = false;
   bool cancelReturned = false;
+};
+
+enum class AnimationEvent { Update, End };
+
+class EndUpdateListener : public PAGAnimator::Listener {
+ public:
+  explicit EndUpdateListener(bool cancelDeferredUpdate)
+      : cancelDeferredUpdate(cancelDeferredUpdate) {
+  }
+
+  bool waitForEventCount(size_t count, uint64_t timeout) {
+    std::unique_lock<std::mutex> lock(locker);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
+    while (events.size() < count) {
+      if (condition.wait_until(lock, deadline) == std::cv_status::timeout) {
+        return events.size() >= count;
+      }
+    }
+    return true;
+  }
+
+  std::vector<AnimationEvent> getEvents() {
+    std::lock_guard<std::mutex> autoLock(locker);
+    return events;
+  }
+
+ protected:
+  void onAnimationUpdate(PAGAnimator* animator) override {
+    bool requestUpdate = false;
+    {
+      std::lock_guard<std::mutex> autoLock(locker);
+      events.push_back(AnimationEvent::Update);
+      if (!deferredUpdateRequested) {
+        deferredUpdateRequested = true;
+        requestUpdate = true;
+      }
+      condition.notify_all();
+    }
+    if (requestUpdate) {
+      animator->updateAsync();
+      if (cancelDeferredUpdate) {
+        animator->cancel();
+      }
+    }
+  }
+
+  void onAnimationEnd(PAGAnimator*) override {
+    std::lock_guard<std::mutex> autoLock(locker);
+    events.push_back(AnimationEvent::End);
+    condition.notify_all();
+  }
+
+ private:
+  std::mutex locker = {};
+  std::condition_variable condition = {};
+  std::vector<AnimationEvent> events = {};
+  bool cancelDeferredUpdate = false;
+  bool deferredUpdateRequested = false;
 };
 
 class AnimatorCall {
@@ -263,6 +322,47 @@ PAG_TEST(PAGAnimatorTest, AsyncUpdateAllowsReentrantCancel) {
   }
   EXPECT_TRUE(cancelReturned);
   animator->cancel();
+  EXPECT_EQ(animator->task, nullptr);
+}
+
+PAG_TEST(PAGAnimatorTest, FinalUpdatePrecedesDeferredUpdate) {
+  auto listener = std::make_shared<EndUpdateListener>(false);
+  auto animator = MakeAnimator(listener);
+  animator->_duration = 1;
+  animator->_progress = 1.0;
+  animator->_isRunning = true;
+
+  animator->advance();
+
+  auto deferredUpdateCompleted = listener->waitForEventCount(3, 1000);
+  if (!deferredUpdateCompleted) {
+    animator->cancel();
+  }
+  ASSERT_TRUE(deferredUpdateCompleted);
+  animator->cancel();
+  auto events = listener->getEvents();
+  ASSERT_EQ(events.size(), 3u);
+  EXPECT_EQ(events[0], AnimationEvent::Update);
+  EXPECT_EQ(events[1], AnimationEvent::End);
+  EXPECT_EQ(events[2], AnimationEvent::Update);
+  EXPECT_FALSE(animator->isEnding);
+}
+
+PAG_TEST(PAGAnimatorTest, CancelDropsUpdateDeferredDuringEnd) {
+  auto listener = std::make_shared<EndUpdateListener>(true);
+  auto animator = MakeAnimator(listener);
+  animator->_duration = 1;
+  animator->_progress = 1.0;
+  animator->_isRunning = true;
+
+  animator->advance();
+
+  auto events = listener->getEvents();
+  ASSERT_EQ(events.size(), 2u);
+  EXPECT_EQ(events[0], AnimationEvent::Update);
+  EXPECT_EQ(events[1], AnimationEvent::End);
+  EXPECT_FALSE(animator->isEnding);
+  EXPECT_FALSE(animator->asyncUpdateRequested);
   EXPECT_EQ(animator->task, nullptr);
 }
 

--- a/test/src/PAGAnimatorTest.cpp
+++ b/test/src/PAGAnimatorTest.cpp
@@ -78,6 +78,50 @@ class AnimatorListener : public PAGAnimator::Listener {
   bool updateReleased = false;
 };
 
+class CancelOnUpdateListener : public PAGAnimator::Listener {
+ public:
+  bool waitForUpdateStart(uint64_t timeout) {
+    std::unique_lock<std::mutex> lock(locker);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
+    while (!updateStarted) {
+      if (condition.wait_until(lock, deadline) == std::cv_status::timeout) {
+        return updateStarted;
+      }
+    }
+    return true;
+  }
+
+  bool waitForCancelReturn(uint64_t timeout) {
+    std::unique_lock<std::mutex> lock(locker);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
+    while (!cancelReturned) {
+      if (condition.wait_until(lock, deadline) == std::cv_status::timeout) {
+        return cancelReturned;
+      }
+    }
+    return true;
+  }
+
+ protected:
+  void onAnimationUpdate(PAGAnimator* animator) override {
+    {
+      std::lock_guard<std::mutex> autoLock(locker);
+      updateStarted = true;
+      condition.notify_all();
+    }
+    animator->cancel();
+    std::lock_guard<std::mutex> autoLock(locker);
+    cancelReturned = true;
+    condition.notify_all();
+  }
+
+ private:
+  std::mutex locker = {};
+  std::condition_variable condition = {};
+  bool updateStarted = false;
+  bool cancelReturned = false;
+};
+
 class AnimatorCall {
  public:
   AnimatorCall(std::shared_ptr<PAGAnimator> animator, bool update)
@@ -143,7 +187,7 @@ static void RunAnimatorCall(AnimatorCall* call) {
 }
 
 static std::shared_ptr<PAGAnimator> MakeAnimator(
-    const std::shared_ptr<AnimatorListener>& listener) {
+    const std::shared_ptr<PAGAnimator::Listener>& listener) {
   auto animator = std::shared_ptr<PAGAnimator>(new PAGAnimator(listener));
   animator->weakThis = animator;
   return animator;
@@ -199,6 +243,25 @@ PAG_TEST(PAGAnimatorTest, StoppedAsyncUpdateProcessesLatestRequest) {
   animator->updateAsync();
   listener->releaseUpdate();
   EXPECT_TRUE(listener->waitForUpdateCount(2, 1000));
+  animator->cancel();
+  EXPECT_EQ(animator->task, nullptr);
+}
+
+PAG_TEST(PAGAnimatorTest, AsyncUpdateAllowsReentrantCancel) {
+  auto listener = std::make_shared<CancelOnUpdateListener>();
+  auto animator = MakeAnimator(listener);
+
+  animator->updateAsync();
+  auto updateStarted = listener->waitForUpdateStart(1000);
+  if (!updateStarted) {
+    animator->cancel();
+  }
+  ASSERT_TRUE(updateStarted);
+  auto cancelReturned = listener->waitForCancelReturn(100);
+  if (!cancelReturned) {
+    EXPECT_TRUE(listener->waitForCancelReturn(1000));
+  }
+  EXPECT_TRUE(cancelReturned);
   animator->cancel();
   EXPECT_EQ(animator->task, nullptr);
 }

--- a/test/src/PAGAnimatorTest.cpp
+++ b/test/src/PAGAnimatorTest.cpp
@@ -1,0 +1,206 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making libpag available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include "base/PAGTest.h"
+#include "rendering/PAGAnimator.h"
+
+namespace pag {
+class AnimatorListener : public PAGAnimator::Listener {
+ public:
+  bool waitForUpdateCount(size_t count, uint64_t timeout) {
+    std::unique_lock<std::mutex> lock(locker);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
+    while (updateCount < count) {
+      if (condition.wait_until(lock, deadline) == std::cv_status::timeout) {
+        return updateCount >= count;
+      }
+    }
+    return true;
+  }
+
+  void releaseUpdate() {
+    std::lock_guard<std::mutex> autoLock(locker);
+    updateReleased = true;
+    condition.notify_all();
+  }
+
+  std::thread::id willUpdateThread() {
+    std::lock_guard<std::mutex> autoLock(locker);
+    return willThread;
+  }
+
+  std::thread::id updateThread() {
+    std::lock_guard<std::mutex> autoLock(locker);
+    return currentUpdateThread;
+  }
+
+ protected:
+  void onAnimationWillUpdate(PAGAnimator*) override {
+    std::lock_guard<std::mutex> autoLock(locker);
+    willThread = std::this_thread::get_id();
+  }
+
+  void onAnimationUpdate(PAGAnimator*) override {
+    std::unique_lock<std::mutex> lock(locker);
+    currentUpdateThread = std::this_thread::get_id();
+    updateCount++;
+    condition.notify_all();
+    while (!updateReleased) {
+      condition.wait(lock);
+    }
+  }
+
+ private:
+  std::mutex locker = {};
+  std::condition_variable condition = {};
+  std::thread::id willThread = {};
+  std::thread::id currentUpdateThread = {};
+  size_t updateCount = 0;
+  bool updateReleased = false;
+};
+
+class AnimatorCall {
+ public:
+  AnimatorCall(std::shared_ptr<PAGAnimator> animator, bool update)
+      : animator(std::move(animator)), update(update) {
+  }
+
+  void run() {
+    {
+      std::lock_guard<std::mutex> autoLock(locker);
+      threadID = std::this_thread::get_id();
+      callStarted = true;
+      condition.notify_all();
+    }
+    if (update) {
+      animator->updateAsync();
+    } else {
+      animator->cancel();
+    }
+    std::lock_guard<std::mutex> autoLock(locker);
+    returned = true;
+    condition.notify_all();
+  }
+
+  bool waitForCallStart(uint64_t timeout) {
+    std::unique_lock<std::mutex> lock(locker);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
+    while (!callStarted) {
+      if (condition.wait_until(lock, deadline) == std::cv_status::timeout) {
+        return callStarted;
+      }
+    }
+    return true;
+  }
+
+  bool waitForReturn(uint64_t timeout) {
+    std::unique_lock<std::mutex> lock(locker);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
+    while (!returned) {
+      if (condition.wait_until(lock, deadline) == std::cv_status::timeout) {
+        return returned;
+      }
+    }
+    return true;
+  }
+
+  std::thread::id getThreadID() {
+    std::lock_guard<std::mutex> autoLock(locker);
+    return threadID;
+  }
+
+ private:
+  std::shared_ptr<PAGAnimator> animator = nullptr;
+  std::mutex locker = {};
+  std::condition_variable condition = {};
+  std::thread::id threadID = {};
+  bool update = false;
+  bool callStarted = false;
+  bool returned = false;
+};
+
+static void RunAnimatorCall(AnimatorCall* call) {
+  call->run();
+}
+
+static std::shared_ptr<PAGAnimator> MakeAnimator(
+    const std::shared_ptr<AnimatorListener>& listener) {
+  auto animator = std::shared_ptr<PAGAnimator>(new PAGAnimator(listener));
+  animator->weakThis = animator;
+  return animator;
+}
+
+PAG_TEST(PAGAnimatorTest, StoppedAsyncUpdateIsTrackedUntilCanceled) {
+  auto listener = std::make_shared<AnimatorListener>();
+  auto animator = MakeAnimator(listener);
+  AnimatorCall updateCall(animator, true);
+  std::thread updateThread(RunAnimatorCall, &updateCall);
+
+  auto updateReturned = updateCall.waitForReturn(1000);
+  if (!updateReturned) {
+    listener->releaseUpdate();
+  }
+  updateThread.join();
+  ASSERT_TRUE(updateReturned);
+  auto updateStarted = listener->waitForUpdateCount(1, 1000);
+  if (!updateStarted) {
+    listener->releaseUpdate();
+    animator->cancel();
+  }
+  ASSERT_TRUE(updateStarted);
+  EXPECT_NE(listener->updateThread(), updateCall.getThreadID());
+  EXPECT_EQ(listener->willUpdateThread(), listener->updateThread());
+
+  AnimatorCall cancelCall(animator, false);
+  std::thread cancelThread(RunAnimatorCall, &cancelCall);
+  auto cancelStarted = cancelCall.waitForCallStart(1000);
+  if (!cancelStarted) {
+    listener->releaseUpdate();
+    cancelThread.join();
+  }
+  ASSERT_TRUE(cancelStarted);
+  EXPECT_FALSE(cancelCall.waitForReturn(20));
+  listener->releaseUpdate();
+  EXPECT_TRUE(cancelCall.waitForReturn(1000));
+  cancelThread.join();
+  EXPECT_EQ(animator->task, nullptr);
+}
+
+PAG_TEST(PAGAnimatorTest, StoppedAsyncUpdateProcessesLatestRequest) {
+  auto listener = std::make_shared<AnimatorListener>();
+  auto animator = MakeAnimator(listener);
+
+  animator->updateAsync();
+  auto updateStarted = listener->waitForUpdateCount(1, 1000);
+  if (!updateStarted) {
+    listener->releaseUpdate();
+    animator->cancel();
+  }
+  ASSERT_TRUE(updateStarted);
+  animator->updateAsync();
+  listener->releaseUpdate();
+  EXPECT_TRUE(listener->waitForUpdateCount(2, 1000));
+  animator->cancel();
+  EXPECT_EQ(animator->task, nullptr);
+}
+
+}  // namespace pag


### PR DESCRIPTION
修复 HarmonyOS PAGView 在停止或暂停状态下调用 update 时同步执行 flush 并阻塞 ArkTS UI 线程的问题。

新增由 PAGAnimator 跟踪的异步更新机制，对重复请求进行合并，并正确处理取消重入、任务释放和动画自然结束期间的更新顺序。

调整 JPAGView 的回调和资源锁范围，使执行中的渲染通过局部 shared_ptr 保持资源生命周期，避免 flush 卡住后 release 继续无限等待视图锁。

新增停止态异步更新、重复请求、回调内取消、自然结束延后更新及结束阶段取消测试。PAGUnitTest 2408 项全部通过，HarmonyOS 原生模块编译通过。