### PR TITLE
Fix expat DEPS sha to stop redundant resyncs on every depsync

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -37,7 +37,7 @@
       },
       {
         "url": "https://github.com/libexpat/libexpat.git",
-        "commit": "70a0d4b01f2b6af4ec3d851ad2b399752f531ff8",
+        "commit": "92810461043fce37e70079b37ab1f04490a8f039",
         "dir": "third_party/expat"
       },
       {


### PR DESCRIPTION
## 问题

每次执行 `depsync` 时，即使上一次刚同步完、工作区没有任何改动，`third_party/expat` 都会被重新 `git init` + `fetch` + `reset --hard` 一遍：

```
【depsync】checking out repository: expat@70a0d4b01f2b6af4ec3d851ad2b399752f531ff8
```

同一个 DEPS 里的其它依赖（tgfx、vendor_tools、harfbuzz 等）都能正常跳过，只有 expat 每次必拉。

## 原因

DEPS 中 expat 的 `commit` 填的是 annotated tag `R_2_8_3` 的**对象 sha**，而不是该 tag 指向的 **commit sha**：

```
$ git cat-file -t 70a0d4b01f2b6af4ec3d851ad2b399752f531ff8
tag
$ git cat-file -p 70a0d4b01f2b6af4ec3d851ad2b399752f531ff8
object 92810461043fce37e70079b37ab1f04490a8f039
type commit
tag R_2_8_3
```

depsync 的同步流程是 `git fetch --depth 1 origin <sha>` + `git reset --hard FETCH_HEAD`，git 会自动把 tag 解引用到 commit，所以 `.git/shallow` 里记录的是实际的 commit `92810461`；而增量判定（`DepsTask.js`）拿 DEPS 声明值与 `.git/shallow` 比较：

```js
let commit = Utils.readFile(shallowFile).substring(0, 40);
let repoDirty = commit !== item.commit;
```

`92810461 !== 70a0d4b0` 恒成立，于是 expat 每次都被判定为 dirty 并无条件重拉。与网络、镜像配置、本地状态都无关，稳定必现。

该值由 `9642fa56c`（Update bundled Expat to 2.8.3）引入，被替换掉的旧值 `88b3ed55` 是正常的 commit sha，所以是这次升级新引入的问题。

## 修改

将 DEPS 中 expat 的 commit 改为 tag 指向的 commit sha：

```diff
   "url": "https://github.com/libexpat/libexpat.git",
-  "commit": "70a0d4b01f2b6af4ec3d851ad2b399752f531ff8",
+  "commit": "92810461043fce37e70079b37ab1f04490a8f039",
   "dir": "third_party/expat"
```

## 影响

- 检出的代码内容完全等价（同一个 tree），仅修正 sha 类型，无需改动任何构建配置，也不会触发重新编译。
- 修复后 `depsync` 的增量判定可以命中缓存，省掉每次多出来的一次 depth-1 clone 以及对 github.com 的一次网络依赖（对走内网镜像的团队尤其明显，此前 expat 这一项无法被镜像/缓存命中）。
- 已核对全部 11 个依赖条目：修正前只有 expat 的对象类型是 `tag`，修正后全部为 `commit` 且与本地 `.git/shallow` 一致，mismatch 数为 0。
- `release/4.4` 与 `release/4.5` 的 DEPS 中没有 expat 条目（该依赖是 PAGX 引入主线的），其依赖的 tgfx 版本里 expat 写的也是正确的 `92810461`，因此这两个分支不受影响，无需回迁。

## 验证

```bash
python3 - <<'EOF'
import json, os
d = json.load(open('DEPS'))
for plat, items in (d.get('repos') or {}).items():
    for it in items:
        sh = os.path.join(it['dir'], '.git', 'shallow')
        if not os.path.exists(sh):
            continue
        cur = open(sh).read()[:40]
        if cur != it['commit']:
            print(f"MISMATCH [{plat}] {it['dir']}\n  DEPS={it['commit']}\n  local={cur}")
EOF
```

修正前该脚本会报出 `third_party/expat`，修正后无输出；连续两次 `depsync`，第二次不再打印 `checking out repository: expat@...`。
