### PR TITLE
Fix NoiseStyle and NoiseFilter being silently dropped on PAGX export

### DIFF
--- a/spec/pagx.xsd
+++ b/spec/pagx.xsd
@@ -175,6 +175,14 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="NoiseModeType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="mono"/>
+      <xs:enumeration value="duo"/>
+      <xs:enumeration value="multi"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:simpleType name="FilterModeType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="nearest"/>
@@ -775,6 +783,21 @@
     <xs:attribute name="excludeChildEffects" type="BoolType" default="false"/>
   </xs:complexType>
 
+  <!-- NoiseStyle -->
+  <xs:complexType name="NoiseStyleType">
+    <xs:attributeGroup ref="CommonAttributes"/>
+    <xs:attribute name="blendMode" type="BlendModeType" default="normal"/>
+    <xs:attribute name="excludeChildEffects" type="BoolType" default="false"/>
+    <xs:attribute name="mode" type="NoiseModeType" default="mono"/>
+    <xs:attribute name="size" type="xs:decimal" default="4"/>
+    <xs:attribute name="density" type="xs:decimal" default="0.5"/>
+    <xs:attribute name="seed" type="xs:decimal" default="0"/>
+    <xs:attribute name="color" type="ColorType" default="#000000"/>
+    <xs:attribute name="firstColor" type="ColorType" default="#000000"/>
+    <xs:attribute name="secondColor" type="ColorType" default="#FFFFFF"/>
+    <xs:attribute name="opacity" type="xs:decimal" default="0.15"/>
+  </xs:complexType>
+
   <!-- ========================= Layer Filters ========================= -->
 
   <!-- BlurFilter -->
@@ -818,6 +841,20 @@
   <xs:complexType name="ColorMatrixFilterType">
     <xs:attributeGroup ref="CommonAttributes"/>
     <xs:attribute name="matrix" type="ColorMatrixType"/>
+  </xs:complexType>
+
+  <!-- NoiseFilter -->
+  <xs:complexType name="NoiseFilterType">
+    <xs:attributeGroup ref="CommonAttributes"/>
+    <xs:attribute name="mode" type="NoiseModeType" default="mono"/>
+    <xs:attribute name="size" type="xs:decimal" default="4"/>
+    <xs:attribute name="density" type="xs:decimal" default="0.5"/>
+    <xs:attribute name="seed" type="xs:decimal" default="0"/>
+    <xs:attribute name="blendMode" type="BlendModeType" default="normal"/>
+    <xs:attribute name="color" type="ColorType" default="#000000"/>
+    <xs:attribute name="firstColor" type="ColorType" default="#000000"/>
+    <xs:attribute name="secondColor" type="ColorType" default="#FFFFFF"/>
+    <xs:attribute name="opacity" type="xs:decimal" default="0.15"/>
   </xs:complexType>
 
   <!-- ========================= VectorElement Group ========================= -->
@@ -887,12 +924,14 @@
       <xs:element name="DropShadowStyle" type="DropShadowStyleType"/>
       <xs:element name="InnerShadowStyle" type="InnerShadowStyleType"/>
       <xs:element name="BackgroundBlurStyle" type="BackgroundBlurStyleType"/>
+      <xs:element name="NoiseStyle" type="NoiseStyleType"/>
       <!-- Layer Filters -->
       <xs:element name="BlurFilter" type="BlurFilterType"/>
       <xs:element name="DropShadowFilter" type="DropShadowFilterType"/>
       <xs:element name="InnerShadowFilter" type="InnerShadowFilterType"/>
       <xs:element name="BlendFilter" type="BlendFilterType"/>
       <xs:element name="ColorMatrixFilter" type="ColorMatrixFilterType"/>
+      <xs:element name="NoiseFilter" type="NoiseFilterType"/>
       <!-- Timeline drivers -->
       <xs:element name="Timelines" type="TimelinesType"/>
       <!-- Child Layers -->

--- a/src/cli/FormatUtils.cpp
+++ b/src/cli/FormatUtils.cpp
@@ -383,6 +383,14 @@ const char* NodeTypeName(NodeType type) {
       return "Image";
     case NodeType::BlurFilter:
       return "BlurFilter";
+    case NodeType::DropShadowFilter:
+      return "DropShadowFilter";
+    case NodeType::InnerShadowFilter:
+      return "InnerShadowFilter";
+    case NodeType::BlendFilter:
+      return "BlendFilter";
+    case NodeType::ColorMatrixFilter:
+      return "ColorMatrixFilter";
     case NodeType::DropShadowStyle:
       return "DropShadowStyle";
     case NodeType::InnerShadowStyle:

--- a/src/cli/FormatUtils.cpp
+++ b/src/cli/FormatUtils.cpp
@@ -389,6 +389,10 @@ const char* NodeTypeName(NodeType type) {
       return "InnerShadowStyle";
     case NodeType::BackgroundBlurStyle:
       return "BackgroundBlurStyle";
+    case NodeType::NoiseStyle:
+      return "NoiseStyle";
+    case NodeType::NoiseFilter:
+      return "NoiseFilter";
     default:
       return "Node";
   }

--- a/src/pagx/PAGXExporter.cpp
+++ b/src/pagx/PAGXExporter.cpp
@@ -48,6 +48,8 @@
 #include "pagx/nodes/InnerShadowStyle.h"
 #include "pagx/nodes/LinearGradient.h"
 #include "pagx/nodes/MergePath.h"
+#include "pagx/nodes/NoiseFilter.h"
+#include "pagx/nodes/NoiseStyle.h"
 #include "pagx/nodes/Path.h"
 #include "pagx/nodes/Polystar.h"
 #include "pagx/nodes/RadialGradient.h"
@@ -1219,6 +1221,38 @@ static void WriteShadowAttributes(XMLBuilder& xml, float offsetX, float offsetY,
   xml.addAttribute("color", ColorToHexString(color, color.alpha < 1.0f));
 }
 
+// NoiseStyle and NoiseFilter share the same noise parameters, so these two helpers serve both.
+// They are split because the two nodes place blendMode differently: NoiseStyle writes it up front
+// with the other LayerStyle attributes, while NoiseFilter writes it between the grain and color
+// parameters. Both orders mirror the importer and the XSD attribute declarations.
+template <typename T>
+static void WriteNoiseGrainAttributes(XMLBuilder& xml, const T* node) {
+  if (node->mode != Default<T>().mode) {
+    xml.addAttribute("mode", NoiseModeToString(node->mode));
+  }
+  xml.addAttribute("size", node->size, Default<T>().size);
+  xml.addAttribute("density", node->density, Default<T>().density);
+  xml.addAttribute("seed", node->seed, Default<T>().seed);
+}
+
+// Writes every non-default color and the opacity regardless of the active mode: the inactive
+// mode's fields must survive a round-trip so that changing mode later does not surface lost data.
+template <typename T>
+static void WriteNoiseColorAttributes(XMLBuilder& xml, const T* node) {
+  if (node->color != Default<T>().color) {
+    xml.addAttribute("color", ColorToHexString(node->color, node->color.alpha < 1.0f));
+  }
+  if (node->firstColor != Default<T>().firstColor) {
+    xml.addAttribute("firstColor",
+                     ColorToHexString(node->firstColor, node->firstColor.alpha < 1.0f));
+  }
+  if (node->secondColor != Default<T>().secondColor) {
+    xml.addAttribute("secondColor",
+                     ColorToHexString(node->secondColor, node->secondColor.alpha < 1.0f));
+  }
+  xml.addAttribute("opacity", node->opacity, Default<T>().opacity);
+}
+
 static void WriteLayerStyle(XMLBuilder& xml, const LayerStyle* node) {
   switch (node->nodeType()) {
     case NodeType::DropShadowStyle: {
@@ -1267,6 +1301,21 @@ static void WriteLayerStyle(XMLBuilder& xml, const LayerStyle* node) {
       if (style->tileMode != Default<BackgroundBlurStyle>().tileMode) {
         xml.addAttribute("tileMode", TileModeToString(style->tileMode));
       }
+      WriteCustomData(xml, node);
+      xml.closeElementSelfClosing();
+      break;
+    }
+    case NodeType::NoiseStyle: {
+      auto style = static_cast<const NoiseStyle*>(node);
+      xml.openElement("NoiseStyle");
+      xml.addAttribute("id", style->id);
+      if (style->blendMode != Default<NoiseStyle>().blendMode) {
+        xml.addAttribute("blendMode", BlendModeToString(style->blendMode));
+      }
+      xml.addAttribute("excludeChildEffects", style->excludeChildEffects,
+                       Default<NoiseStyle>().excludeChildEffects);
+      WriteNoiseGrainAttributes(xml, style);
+      WriteNoiseColorAttributes(xml, style);
       WriteCustomData(xml, node);
       xml.closeElementSelfClosing();
       break;
@@ -1334,6 +1383,19 @@ static void WriteLayerFilter(XMLBuilder& xml, const LayerFilter* node) {
       xml.openElement("ColorMatrixFilter");
       xml.addAttribute("id", filter->id);
       xml.addAttribute("matrix", FloatListToString(filter->matrix.data(), filter->matrix.size()));
+      WriteCustomData(xml, node);
+      xml.closeElementSelfClosing();
+      break;
+    }
+    case NodeType::NoiseFilter: {
+      auto filter = static_cast<const NoiseFilter*>(node);
+      xml.openElement("NoiseFilter");
+      xml.addAttribute("id", filter->id);
+      WriteNoiseGrainAttributes(xml, filter);
+      if (filter->blendMode != Default<NoiseFilter>().blendMode) {
+        xml.addAttribute("blendMode", BlendModeToString(filter->blendMode));
+      }
+      WriteNoiseColorAttributes(xml, filter);
       WriteCustomData(xml, node);
       xml.closeElementSelfClosing();
       break;

--- a/src/pagx/PAGXNodeChannel.cpp
+++ b/src/pagx/PAGXNodeChannel.cpp
@@ -43,6 +43,8 @@
 #include "pagx/nodes/LayoutNode.h"
 #include "pagx/nodes/LinearGradient.h"
 #include "pagx/nodes/MergePath.h"
+#include "pagx/nodes/NoiseFilter.h"
+#include "pagx/nodes/NoiseStyle.h"
 #include "pagx/nodes/Path.h"
 #include "pagx/nodes/Polystar.h"
 #include "pagx/nodes/RadialGradient.h"
@@ -745,6 +747,24 @@ static std::vector<ChannelDef> BuildBackgroundBlurStyleFields() {
   };
 }
 
+// The animatable set mirrors LayerBuilder::bindNoiseStyleChannels: the grain parameters are always
+// bound, while the colors and opacity are bound per mode. This table is mode-independent because it
+// declares which fields can carry a channel; the renderer decides which ones resolve at runtime.
+static std::vector<ChannelDef> BuildNoiseStyleFields() {
+  return {
+      FIELD_ENUM(NoiseStyle, "blendMode", blendMode, NoFlags, BlendMode),
+      FIELD_BOOL(NoiseStyle, "excludeChildEffects", excludeChildEffects, NoFlags),
+      FIELD_ENUM(NoiseStyle, "mode", mode, NoFlags, NoiseMode),
+      FIELD_FLOAT(NoiseStyle, "size", size, Anim),
+      FIELD_FLOAT(NoiseStyle, "density", density, Anim),
+      FIELD_FLOAT(NoiseStyle, "seed", seed, Anim),
+      FIELD_COLOR(NoiseStyle, "color", color, Anim),
+      FIELD_COLOR(NoiseStyle, "firstColor", firstColor, Anim),
+      FIELD_COLOR(NoiseStyle, "secondColor", secondColor, Anim),
+      FIELD_FLOAT(NoiseStyle, "opacity", opacity, Anim),
+  };
+}
+
 static std::vector<ChannelDef> BuildBlurFilterFields() {
   return {
       FIELD_FLOAT(BlurFilter, "blurX", blurX, Anim),
@@ -779,6 +799,22 @@ static std::vector<ChannelDef> BuildBlendFilterFields() {
   return {
       FIELD_COLOR(BlendFilter, "color", color, Anim),
       FIELD_ENUM(BlendFilter, "blendMode", blendMode, NoFlags, BlendMode),
+  };
+}
+
+// NoiseFilter carries the same noise parameters as NoiseStyle but declares its own blendMode and has
+// no excludeChildEffects, so the two tables cannot be shared.
+static std::vector<ChannelDef> BuildNoiseFilterFields() {
+  return {
+      FIELD_ENUM(NoiseFilter, "mode", mode, NoFlags, NoiseMode),
+      FIELD_FLOAT(NoiseFilter, "size", size, Anim),
+      FIELD_FLOAT(NoiseFilter, "density", density, Anim),
+      FIELD_FLOAT(NoiseFilter, "seed", seed, Anim),
+      FIELD_ENUM(NoiseFilter, "blendMode", blendMode, NoFlags, BlendMode),
+      FIELD_COLOR(NoiseFilter, "color", color, Anim),
+      FIELD_COLOR(NoiseFilter, "firstColor", firstColor, Anim),
+      FIELD_COLOR(NoiseFilter, "secondColor", secondColor, Anim),
+      FIELD_FLOAT(NoiseFilter, "opacity", opacity, Anim),
   };
 }
 
@@ -895,6 +931,10 @@ const std::vector<ChannelDef>& ChannelsFor(NodeType type) {
       static const std::vector<ChannelDef> table = BuildBackgroundBlurStyleFields();
       return table;
     }
+    case NodeType::NoiseStyle: {
+      static const std::vector<ChannelDef> table = BuildNoiseStyleFields();
+      return table;
+    }
     case NodeType::BlurFilter: {
       static const std::vector<ChannelDef> table = BuildBlurFilterFields();
       return table;
@@ -909,6 +949,10 @@ const std::vector<ChannelDef>& ChannelsFor(NodeType type) {
     }
     case NodeType::BlendFilter: {
       static const std::vector<ChannelDef> table = BuildBlendFilterFields();
+      return table;
+    }
+    case NodeType::NoiseFilter: {
+      static const std::vector<ChannelDef> table = BuildNoiseFilterFields();
       return table;
     }
     default:

--- a/src/pagx/PAGXNodeChannel.cpp
+++ b/src/pagx/PAGXNodeChannel.cpp
@@ -764,7 +764,9 @@ static std::vector<ChannelDef> BuildGlassStyleFields() {
 
 // The animatable set mirrors LayerBuilder::bindNoiseStyleChannels: the grain parameters are always
 // bound, while the colors and opacity are bound per mode. This table is mode-independent because it
-// declares which fields can carry a channel; the renderer decides which ones resolve at runtime.
+// declares which fields can carry a channel; the renderer decides which ones resolve at runtime, so
+// a field belonging to another mode has no runtime writer. That exemption is asserted explicitly
+// (both halves) by PAGXTest.AnimatableChannelsHaveWriters.
 static std::vector<ChannelDef> BuildNoiseStyleFields() {
   return {
       FIELD_ENUM(NoiseStyle, "blendMode", blendMode, NoFlags, BlendMode),
@@ -818,7 +820,8 @@ static std::vector<ChannelDef> BuildBlendFilterFields() {
 }
 
 // NoiseFilter carries the same noise parameters as NoiseStyle but declares its own blendMode and has
-// no excludeChildEffects, so the two tables cannot be shared.
+// no excludeChildEffects, so the two tables cannot be shared. The mode-dependent binding of the
+// color and opacity channels matches NoiseStyle (see BuildNoiseStyleFields).
 static std::vector<ChannelDef> BuildNoiseFilterFields() {
   return {
       FIELD_ENUM(NoiseFilter, "mode", mode, NoFlags, NoiseMode),

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -586,13 +586,34 @@ PAGX_TEST(PAGXTest, NoiseRoundTrip) {
   // The default nodes must serialize as bare tags: the exporter omits every attribute that still
   // holds its default, so an exporter regression that writes all defaults is caught right here
   // instead of going unnoticed.
-  // The default nodes are the last layer in the document, so their tags are the last occurrences.
+  //
+  // This uses a separate document that holds only the default nodes, so each tag appears exactly
+  // once and can be located directly instead of depending on element order. Ids are not an option
+  // for locating them: an id turns the node into a resource, and `pagx verify` reports an
+  // unreferenced one, while these styles are inlined rather than referenced.
+  auto defaultDoc = pagx::PAGXDocument::Make(200, 150);
+  ASSERT_TRUE(defaultDoc != nullptr);
+  auto defaultOnlyLayer = defaultDoc->makeNode<pagx::Layer>();
+  auto defaultRect = defaultDoc->makeNode<pagx::Rectangle>();
+  defaultRect->size = {80, 60};
+  auto defaultFill = defaultDoc->makeNode<pagx::Fill>();
+  auto defaultSolidColor = defaultDoc->makeNode<pagx::SolidColor>();
+  defaultSolidColor->color = {0, 1, 0, 1};
+  defaultFill->color = defaultSolidColor;
+  defaultOnlyLayer->contents.push_back(defaultRect);
+  defaultOnlyLayer->contents.push_back(defaultFill);
+  defaultOnlyLayer->styles.push_back(defaultDoc->makeNode<pagx::NoiseStyle>());
+  defaultOnlyLayer->filters.push_back(defaultDoc->makeNode<pagx::NoiseFilter>());
+  defaultDoc->layers.push_back(defaultOnlyLayer);
+
+  auto defaultXml = pagx::PAGXExporter::ToXML(*defaultDoc);
+  ASSERT_FALSE(defaultXml.empty());
   auto expectBareTag = [&](const std::string& tag) {
-    auto open = xml.rfind("<" + tag);
+    auto open = defaultXml.find("<" + tag);
     ASSERT_NE(open, std::string::npos) << tag;
-    auto close = xml.find("/>", open);
+    auto close = defaultXml.find("/>", open);
     ASSERT_NE(close, std::string::npos) << tag;
-    auto element = xml.substr(open, close - open);
+    auto element = defaultXml.substr(open, close - open);
     for (const auto* attribute : {"mode", "size", "density", "seed", "blendMode", "color",
                                   "firstColor", "secondColor", "opacity", "excludeChildEffects"}) {
       EXPECT_EQ(element.find(attribute), std::string::npos)

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -583,6 +583,25 @@ PAGX_TEST(PAGXTest, NoiseRoundTrip) {
   EXPECT_NE(xml.find("<NoiseStyle"), std::string::npos);
   EXPECT_NE(xml.find("<NoiseFilter"), std::string::npos);
 
+  // The default nodes must serialize as bare tags: the exporter omits every attribute that still
+  // holds its default, so an exporter regression that writes all defaults is caught right here
+  // instead of going unnoticed.
+  // The default nodes are the last layer in the document, so their tags are the last occurrences.
+  auto expectBareTag = [&](const std::string& tag) {
+    auto open = xml.rfind("<" + tag);
+    ASSERT_NE(open, std::string::npos) << tag;
+    auto close = xml.find("/>", open);
+    ASSERT_NE(close, std::string::npos) << tag;
+    auto element = xml.substr(open, close - open);
+    for (const auto* attribute : {"mode", "size", "density", "seed", "blendMode", "color",
+                                  "firstColor", "secondColor", "opacity", "excludeChildEffects"}) {
+      EXPECT_EQ(element.find(attribute), std::string::npos)
+          << "the default <" << tag << "> should omit '" << attribute << "' but wrote: " << element;
+    }
+  };
+  expectBareTag("NoiseStyle");
+  expectBareTag("NoiseFilter");
+
   auto reloaded = pagx::PAGXImporter::FromXML(xml);
   ASSERT_TRUE(reloaded != nullptr);
   EXPECT_TRUE(reloaded->errors.empty());

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -558,7 +558,7 @@ PAGX_TEST(PAGXTest, NoiseRoundTrip) {
     auto filter = doc->makeNode<pagx::NoiseFilter>();
     filter->mode = mode;
     filter->size = 9;
-    filter->density = 0.5f;
+    filter->density = 0.75f;
     filter->seed = 5;
     filter->blendMode = pagx::BlendMode::Screen;
     filter->color = {0, 1, 1, 1};
@@ -10261,6 +10261,27 @@ PAGX_TEST(PAGXTest, AnimatableChannelsHaveWriters) {
   auto blendFilter = doc->makeNode<pagx::BlendFilter>();
   layer->filters.push_back(blendFilter);
 
+  // One noise style and one noise filter per mode: their color/opacity channels are bound per mode,
+  // so every mode has to be built to cover the writers that resolve for it.
+  auto monoStyle = doc->makeNode<pagx::NoiseStyle>();
+  monoStyle->mode = pagx::NoiseMode::Mono;
+  layer->styles.push_back(monoStyle);
+  auto duoStyle = doc->makeNode<pagx::NoiseStyle>();
+  duoStyle->mode = pagx::NoiseMode::Duo;
+  layer->styles.push_back(duoStyle);
+  auto multiStyle = doc->makeNode<pagx::NoiseStyle>();
+  multiStyle->mode = pagx::NoiseMode::Multi;
+  layer->styles.push_back(multiStyle);
+  auto monoFilter = doc->makeNode<pagx::NoiseFilter>();
+  monoFilter->mode = pagx::NoiseMode::Mono;
+  layer->filters.push_back(monoFilter);
+  auto duoFilter = doc->makeNode<pagx::NoiseFilter>();
+  duoFilter->mode = pagx::NoiseMode::Duo;
+  layer->filters.push_back(duoFilter);
+  auto multiFilter = doc->makeNode<pagx::NoiseFilter>();
+  multiFilter->mode = pagx::NoiseMode::Multi;
+  layer->filters.push_back(multiFilter);
+
   // Text needs a registered fallback font to shape; apply layout with one before the scene build
   // so the Text node's runtime target (and TextHolder) are created.
   pagx::FontConfig fontConfig;
@@ -10299,6 +10320,36 @@ PAGX_TEST(PAGXTest, AnimatableChannelsHaveWriters) {
           << "' is Animatable but has no runtime writer";
     }
   }
+
+  // Noise nodes bind the grain channels (size/density/seed) for every mode, but the color and
+  // opacity channels are bound per mode: Mono -> color, Duo -> firstColor/secondColor,
+  // Multi -> opacity. The channel registry is type-level and lists every field that can carry a
+  // channel, so a field belonging to another mode intentionally has no runtime writer. Assert both
+  // halves of that contract so the exemption stays explicit instead of implicit.
+  auto expectNoiseModeChannels = [&](pagx::Node* node, std::vector<std::string> activeChannels) {
+    for (const auto& channel : pagx::ChannelsFor(node->nodeType())) {
+      if (!pagx::HasFlag(channel.flags, pagx::ChannelFlags::Animatable)) {
+        continue;
+      }
+      bool isActiveModeChannel = std::find(activeChannels.begin(), activeChannels.end(),
+                                           channel.channel) != activeChannels.end();
+      if (isActiveModeChannel) {
+        EXPECT_TRUE(binding->hasWriter(node, channel.channel))
+            << "channel '" << channel.channel
+            << "' is Animatable and active for this noise mode but has no runtime writer";
+      } else {
+        EXPECT_FALSE(binding->hasWriter(node, channel.channel))
+            << "channel '" << channel.channel
+            << "' belongs to another noise mode and is expected to stay unbound";
+      }
+    }
+  };
+  expectNoiseModeChannels(monoStyle, {"size", "density", "seed", "color"});
+  expectNoiseModeChannels(duoStyle, {"size", "density", "seed", "firstColor", "secondColor"});
+  expectNoiseModeChannels(multiStyle, {"size", "density", "seed", "opacity"});
+  expectNoiseModeChannels(monoFilter, {"size", "density", "seed", "color"});
+  expectNoiseModeChannels(duoFilter, {"size", "density", "seed", "firstColor", "secondColor"});
+  expectNoiseModeChannels(multiFilter, {"size", "density", "seed", "opacity"});
 }
 
 /**

--- a/test/src/PAGXTest.cpp
+++ b/test/src/PAGXTest.cpp
@@ -481,6 +481,142 @@ PAGX_TEST(PAGXTest, PAGXDocumentRoundTrip) {
   EXPECT_GE(doc2->layers.size(), 1u);
 }
 
+// NoiseStyle and NoiseFilter declare the same noise parameters, so one template covers both. The
+// fields belonging to the inactive modes are compared too, because the exporter must keep them.
+template <typename T>
+static void ExpectNoiseFieldsEqual(const T* expected, const T* actual, const std::string& label) {
+  ASSERT_TRUE(actual != nullptr) << label;
+  EXPECT_EQ(actual->mode, expected->mode) << label;
+  EXPECT_FLOAT_EQ(actual->size, expected->size) << label;
+  EXPECT_FLOAT_EQ(actual->density, expected->density) << label;
+  EXPECT_FLOAT_EQ(actual->seed, expected->seed) << label;
+  EXPECT_EQ(actual->blendMode, expected->blendMode) << label;
+  EXPECT_TRUE(actual->color == expected->color) << label;
+  EXPECT_TRUE(actual->firstColor == expected->firstColor) << label;
+  EXPECT_TRUE(actual->secondColor == expected->secondColor) << label;
+  EXPECT_FLOAT_EQ(actual->opacity, expected->opacity) << label;
+}
+
+// Checks that the channel table for a noise node type lists exactly the expected animatable fields,
+// which is the set LayerBuilder binds at runtime.
+static void ExpectAnimatableChannels(pagx::NodeType type, std::vector<std::string> expected,
+                                     const std::string& label) {
+  std::vector<std::string> animatable = {};
+  for (const auto& channel : pagx::ChannelsFor(type)) {
+    if (pagx::HasFlag(channel.flags, pagx::ChannelFlags::Animatable)) {
+      animatable.push_back(channel.channel);
+    }
+  }
+  std::sort(animatable.begin(), animatable.end());
+  std::sort(expected.begin(), expected.end());
+  EXPECT_EQ(animatable, expected) << label;
+}
+
+/**
+ * Test case: NoiseStyle and NoiseFilter survive an export -> import round-trip without losing any
+ * field, for every noise mode and for both the all-defaults and the all-custom case. Also checks
+ * that the exported XML passes schema validation through `pagx verify`.
+ */
+PAGX_TEST(PAGXTest, NoiseRoundTrip) {
+  auto doc = pagx::PAGXDocument::Make(200, 150);
+  ASSERT_TRUE(doc != nullptr);
+
+  auto addContents = [&](pagx::Layer* layer) {
+    auto rect = doc->makeNode<pagx::Rectangle>();
+    rect->size = {80, 60};
+    auto fill = doc->makeNode<pagx::Fill>();
+    auto solidColor = doc->makeNode<pagx::SolidColor>();
+    solidColor->color = {0, 1, 0, 1};
+    fill->color = solidColor;
+    layer->contents.push_back(rect);
+    layer->contents.push_back(fill);
+  };
+
+  const pagx::NoiseMode modes[] = {pagx::NoiseMode::Mono, pagx::NoiseMode::Duo,
+                                   pagx::NoiseMode::Multi};
+  for (auto mode : modes) {
+    auto layer = doc->makeNode<pagx::Layer>();
+    addContents(layer);
+
+    // Every field is set to a non-default value, including the colors and opacity that the current
+    // mode ignores: dropping them on export would lose data as soon as the mode changes.
+    auto style = doc->makeNode<pagx::NoiseStyle>();
+    style->mode = mode;
+    style->size = 7;
+    style->density = 0.25f;
+    style->seed = 3;
+    style->blendMode = pagx::BlendMode::Multiply;
+    style->excludeChildEffects = true;
+    style->color = {1, 0, 0, 1};
+    style->firstColor = {0, 0, 1, 1};
+    style->secondColor = {0, 1, 0, 1};
+    style->opacity = 0.75f;
+    layer->styles.push_back(style);
+
+    auto filter = doc->makeNode<pagx::NoiseFilter>();
+    filter->mode = mode;
+    filter->size = 9;
+    filter->density = 0.5f;
+    filter->seed = 5;
+    filter->blendMode = pagx::BlendMode::Screen;
+    filter->color = {0, 1, 1, 1};
+    filter->firstColor = {1, 1, 0, 1};
+    filter->secondColor = {1, 0, 1, 1};
+    filter->opacity = 0.25f;
+    layer->filters.push_back(filter);
+
+    doc->layers.push_back(layer);
+  }
+
+  // Nodes that keep every default: the exporter omits all attributes and the importer must restore
+  // the same defaults.
+  auto defaultLayer = doc->makeNode<pagx::Layer>();
+  addContents(defaultLayer);
+  defaultLayer->styles.push_back(doc->makeNode<pagx::NoiseStyle>());
+  defaultLayer->filters.push_back(doc->makeNode<pagx::NoiseFilter>());
+  doc->layers.push_back(defaultLayer);
+
+  auto xml = pagx::PAGXExporter::ToXML(*doc);
+  ASSERT_FALSE(xml.empty());
+  EXPECT_NE(xml.find("<NoiseStyle"), std::string::npos);
+  EXPECT_NE(xml.find("<NoiseFilter"), std::string::npos);
+
+  auto reloaded = pagx::PAGXImporter::FromXML(xml);
+  ASSERT_TRUE(reloaded != nullptr);
+  EXPECT_TRUE(reloaded->errors.empty());
+  ASSERT_EQ(reloaded->layers.size(), doc->layers.size());
+
+  for (size_t i = 0; i < doc->layers.size(); i++) {
+    auto label = "layer " + std::to_string(i);
+    auto* sourceLayer = doc->layers[i];
+    auto* targetLayer = reloaded->layers[i];
+    ASSERT_EQ(targetLayer->styles.size(), 1u) << label;
+    ASSERT_EQ(targetLayer->filters.size(), 1u) << label;
+    ASSERT_EQ(targetLayer->styles[0]->nodeType(), pagx::NodeType::NoiseStyle) << label;
+    ASSERT_EQ(targetLayer->filters[0]->nodeType(), pagx::NodeType::NoiseFilter) << label;
+
+    auto* expectedStyle = static_cast<pagx::NoiseStyle*>(sourceLayer->styles[0]);
+    auto* actualStyle = static_cast<pagx::NoiseStyle*>(targetLayer->styles[0]);
+    ExpectNoiseFieldsEqual(expectedStyle, actualStyle, label);
+    EXPECT_EQ(actualStyle->excludeChildEffects, expectedStyle->excludeChildEffects) << label;
+
+    ExpectNoiseFieldsEqual(static_cast<pagx::NoiseFilter*>(sourceLayer->filters[0]),
+                           static_cast<pagx::NoiseFilter*>(targetLayer->filters[0]), label);
+  }
+
+  auto pagxPath = SavePAGXFile(xml, "PAGXTest/noise_roundtrip.pagx");
+  VerifyFile(pagxPath, "noise_roundtrip");
+
+  // The grain parameters carry channels in every mode; the colors and opacity do so per mode, so
+  // the table lists them all and the renderer decides which ones resolve at runtime.
+  ExpectAnimatableChannels(
+      pagx::NodeType::NoiseStyle,
+      {"size", "density", "seed", "color", "firstColor", "secondColor", "opacity"}, "NoiseStyle");
+  ExpectAnimatableChannels(
+      pagx::NodeType::NoiseFilter,
+      {"size", "density", "seed", "color", "firstColor", "secondColor", "opacity"}, "NoiseFilter");
+}
+
 /**
  * Test case: Font and Glyph node creation
  */

--- a/viewer/src/profiling/PAGNodeStatsModel.cpp
+++ b/viewer/src/profiling/PAGNodeStatsModel.cpp
@@ -78,11 +78,13 @@ static QString GetNodeCategory(pagx::NodeType type) {
     case pagx::NodeType::DropShadowStyle:
     case pagx::NodeType::InnerShadowStyle:
     case pagx::NodeType::BackgroundBlurStyle:
+    case pagx::NodeType::NoiseStyle:
     case pagx::NodeType::BlurFilter:
     case pagx::NodeType::DropShadowFilter:
     case pagx::NodeType::InnerShadowFilter:
     case pagx::NodeType::BlendFilter:
     case pagx::NodeType::ColorMatrixFilter:
+    case pagx::NodeType::NoiseFilter:
       return "Effects";
     default:
       return "Other";


### PR DESCRIPTION
## Problem

`NoiseStyle` and `NoiseFilter` could be imported and rendered, but the export chain had no support for them: the PAGX exporter silently dropped both nodes (round-trips lost data), the XSD schema rejected files containing them, and the CLI type names and viewer node stats fell back to `Node` / `Other`. The published spec (`pagx_spec.md` §5.3.4 / §5.4.6) already documents both nodes, so this closes the gap between the spec and the implementation.

## Fix

Wire both nodes into the full export chain, mirroring the attribute names and defaults already defined by the importer and the spec:

- **PAGXExporter**: write `<NoiseStyle>` / `<NoiseFilter>` with the same default-value omission rule as the other layer styles/filters.
- **pagx.xsd**: add `NoiseModeType`, `NoiseStyleType`, `NoiseFilterType`, registered in `LayerChildGroup`.
- **PAGXNodeChannel**: channel tables whose animatable set mirrors the renderer's runtime binding (`LayerBuilder::bindNoiseStyleChannels`).
- **CLI / viewer**: recognize both node types.

Every non-default field is exported regardless of the active noise mode, so switching modes later does not surface lost data. As a side effect, `GetNodeChannel` / `SetNodeChannel` now work on noise fields (previously "unhandled channel").

## Testing

- New `PAGXTest.NoiseRoundTrip`: field-level round-trip for both nodes × Mono/Duo/Multi × all-defaults/all-custom (including fields of inactive modes), plus schema validation of the exported XML via `pagx verify`.
- Full suite: 2408 tests pass, no screenshot baseline changes.
- Byte-identical check: all 50 existing `spec/samples` assets produce identical `pagx format` and SVG exports before and after this change.
